### PR TITLE
feat(ui): add close button to content panes

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,7 +18,6 @@
     "quotmark": "single",
     "undef": true,
     "unused": true,
-    "strict": true,
     "maxparams": 10,
     "maxdepth": 5,
     "maxstatements": 40,

--- a/src/app/layout/filters-panel-plug.controller.js
+++ b/src/app/layout/filters-panel-plug.controller.js
@@ -1,5 +1,4 @@
-(function () {
-    'use strict';
+(() => {
 
     /**
      * @ngdoc function
@@ -22,6 +21,10 @@
         self.active = true;
         self.mode = 'default';
 
+        self.closePanel = closePanel;
+
+        ////////
+
         // staggers the main panel's transition if the side panel is open
         // FIXME: should be moved to a filter service and made sane
         $rootScope.$on('$stateChangeStart',
@@ -29,8 +32,13 @@
                 const filtersReg = /filters/;
 
                 if (filtersReg.test(toState.name)) {
-                    self.mode = toState.name.split('.').pop();
+                    self.mode = toState.name.split('.')
+                        .pop();
                 }
             });
+
+        function closePanel() {
+            console.log('Closing panel');
+        }
     }
 })();

--- a/src/app/layout/filters-panel-plug.controller.js
+++ b/src/app/layout/filters-panel-plug.controller.js
@@ -15,8 +15,8 @@
         .module('app.layout')
         .controller('FiltersPanelPlugController', FiltersPanelPlugController);
 
-    /* @ngInject */
-    function FiltersPanelPlugController($rootScope) {
+    function FiltersPanelPlugController($rootScope, $state) {
+        'ngInject';
         const self = this;
         self.active = true;
         self.mode = 'default';
@@ -37,8 +37,16 @@
                 }
             });
 
+        /**
+         * Temporary function to close the filters panel.
+         * FIXME: this should be handled in the shatehelper
+         */
         function closePanel() {
-            console.log('Closing panel');
+            let toState = $state.current.name.replace(/.filters.*/, '');
+            console.log('Closing filters panel; going to', toState);
+            $state.go(toState, {}, {
+                location: false
+            });
         }
     }
 })();

--- a/src/app/layout/side-panel-plug.controller.js
+++ b/src/app/layout/side-panel-plug.controller.js
@@ -1,5 +1,4 @@
-(function () {
-    'use strict';
+(() => {
 
     /**
      * @ngdoc function
@@ -14,13 +13,20 @@
         .module('app.layout')
         .controller('SidePanelPlugController', SidePanelPlugController);
 
-    /* @ngInject */
     /**
      * SidePanel plug controller
      * `self.active` is bound to a CSS class that prevents the plug view from occupying space when its content is not visible.
      */
     function SidePanelPlugController() {
         const self = this;
+
         self.active = true;
+        self.closePanel = closePanel;
+
+        ////////
+
+        function closePanel() {
+            console.log('Closing panel');
+        }
     }
 })();

--- a/src/app/layout/side-panel-plug.controller.js
+++ b/src/app/layout/side-panel-plug.controller.js
@@ -7,17 +7,14 @@
      * @description
      *
      * The `SidePanelPlugController` controller handles the side panel plug view.
-     * `self.active` is triggering an `active` CSS class to be added to the side panel plug when it's active.
+     * `self.active` is triggering an `active` CSS class to be added to the side panel plug when it's active. It's bound to a CSS class that prevents the plug view from occupying space when its content is not visible.
      */
     angular
         .module('app.layout')
         .controller('SidePanelPlugController', SidePanelPlugController);
 
-    /**
-     * SidePanel plug controller
-     * `self.active` is bound to a CSS class that prevents the plug view from occupying space when its content is not visible.
-     */
-    function SidePanelPlugController() {
+    function SidePanelPlugController($state) {
+        'ngInject';
         const self = this;
 
         self.active = true;
@@ -25,8 +22,16 @@
 
         ////////
 
+        /**
+         * Temporary function to close the side panel.
+         * FIXME: this should be handled in the shatehelper
+         */
         function closePanel() {
-            console.log('Closing panel');
+            let toState = $state.current.name.replace(/.side.*/, '');
+            console.log('Closing side panel; going to', toState);
+            $state.go(toState, {}, {
+                location: false
+            });
         }
     }
 })();

--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -1,5 +1,4 @@
-(function () {
-    'use strict';
+(() => {
 
     /**
      * @ngdoc directive
@@ -14,7 +13,6 @@
         .module('app.ui.filters')
         .directive('rvFiltersDefault', rvFiltersDefault);
 
-    /* @ngInject */
     /**
      * `rvFiltersDefault` directive body.
      *
@@ -37,11 +35,9 @@
          * Skeleton link function.
          */
         function linkFunc() { //scope, el, attr, ctrl) {
-
         }
     }
 
-    /* @ngInject */
     /**
      * Skeleton controller function with test message.
      */

--- a/src/app/ui/filters/filters-default.html
+++ b/src/app/ui/filters/filters-default.html
@@ -1,6 +1,6 @@
 <rv-content-pane title-style="title" title="Selected Feature Layer Name">
     <div>
-        <p>{{self.message}}</p>
+        <p>{{ self.message }}</p>
 
         <p>[ filter default content ]</p>
 

--- a/src/app/ui/panels/content-pane.directive.js
+++ b/src/app/ui/panels/content-pane.directive.js
@@ -1,5 +1,4 @@
-(function () {
-    'use strict';
+(() => {
 
     /**
      * @ngdoc directive
@@ -14,7 +13,6 @@
         .module('app.ui.panels')
         .directive('rvContentPane', rvContentPane);
 
-    /* @ngInject */
     /**
      * `rvContentPane` directive body.
      *
@@ -23,13 +21,14 @@
     function rvContentPane() {
         const directive = {
             restrict: 'E',
+            require: '^ngController', // require plug controller
             templateUrl: 'app/ui/panels/content-pane.html',
             scope: {
                 title: '@', // binds to the evaluated dom property
                 titleStyle: '@'
             },
             transclude: true,
-            link: linkFunc,
+            link: link,
             controller: Controller,
             controllerAs: 'self',
             bindToController: true
@@ -38,20 +37,20 @@
         return directive;
 
         /**
-         * Skeleton link function.
+         * Binds the `closePanel` method from the panel plug controller.
          */
-        function linkFunc() { // scope, el, attr, ctrl ) {
-
+        function link(scope, el, attr, ctrl) {
+            const self = scope.self;
+            self.closePanel = ctrl.closePanel;
         }
     }
 
-    /* @ngInject */
     /**
      * Skeleton controller function.
      */
     function Controller() {
 
-        //var self = this;
+        //const self = this;
 
         activate();
 

--- a/src/app/ui/panels/content-pane.html
+++ b/src/app/ui/panels/content-pane.html
@@ -3,12 +3,14 @@
     <div class="rv-header" ng-switch on="self.titleStyle">
         <!-- display an appropriate header based on `headline` value -->
         <h2 class="md-headline" ng-switch-when="headline">{{ self.title }}</h2>
-        <h3 class="md-title" ng-switch-when="title">{{ self.title}}</h3>
+        <h3 class="md-title" ng-switch-when="title">{{ self.title }}</h3>
         <h4 class="md-subhead" ng-switch-when="subhead">{{ self.title }}</h4>
 
         <span flex></span>
-        <md-button aria-label="Sets" class="md-icon-button black rv-auto"
-            ng-class="{ selected: self.tocSelected }" ng-click="self.toggleToc()">
+
+        <!-- show close button if there is a closePanel function -->
+        <md-button aria-label="Close" class="md-icon-button black rv-auto" ng-click="self.closePanel()"
+            ng-if="self.closePanel">
             <md-tooltip>Close</md-tooltip>
             <md-icon md-svg-src="navigation:close"></md-icon>
         </md-button>

--- a/src/app/ui/panels/content-pane.html
+++ b/src/app/ui/panels/content-pane.html
@@ -1,8 +1,22 @@
-<md-content class="content-pane layout-padding" ng-switch on="self.titleStyle">
-    <!-- display an appropriate header based on `headline` value -->
-    <h2 class="md-headline" ng-switch-when="headline">{{self.title}}</h2>
-    <h3 class="md-title" ng-switch-when="title">{{self.title}}</h3>
-    <h4 class="md-subhead" ng-switch-when="subhead">{{self.title}}</h4>
+<div class="rv-content-pane layout-padding">
+
+    <div class="rv-header" ng-switch on="self.titleStyle">
+        <!-- display an appropriate header based on `headline` value -->
+        <h2 class="md-headline" ng-switch-when="headline">{{ self.title }}</h2>
+        <h3 class="md-title" ng-switch-when="title">{{ self.title}}</h3>
+        <h4 class="md-subhead" ng-switch-when="subhead">{{ self.title }}</h4>
+
+        <span flex></span>
+        <md-button aria-label="Sets" class="md-icon-button black rv-auto"
+            ng-class="{ selected: self.tocSelected }" ng-click="self.toggleToc()">
+            <md-tooltip>Close</md-tooltip>
+            <md-icon md-svg-src="navigation:close"></md-icon>
+        </md-button>
+    </div>
+
     <md-divider></md-divider>
-    <ng-transclude></ng-transclude>
-</md-content>
+
+    <md-content class="rv-content">
+        <ng-transclude></ng-transclude>
+    </md-content>
+</div>

--- a/src/app/ui/panels/filters-panel.directive.js
+++ b/src/app/ui/panels/filters-panel.directive.js
@@ -1,5 +1,4 @@
-(function () {
-    'use strict';
+(() => {
 
     /**
      * @ngdoc directive
@@ -13,7 +12,6 @@
         .module('app.ui.panels')
         .directive('rvFiltersPanel', rvFiltersPanel);
 
-    /* @ngInject */
     /**
      * `rvFiltersPanel` directive body.
      *
@@ -40,14 +38,15 @@
         }
     }
 
-    /* @ngInject */
     /**
      * Skeleton controller function.
      */
     function Controller() {
-        //var self = this;
+        //const self = this;
 
         activate();
+
+        //////////
 
         function activate() {
 

--- a/src/app/ui/panels/side-panel.directive.js
+++ b/src/app/ui/panels/side-panel.directive.js
@@ -1,5 +1,4 @@
-(function () {
-    'use strict';
+(() => {
 
     /**
      * @ngdoc directive
@@ -13,7 +12,6 @@
         .module('app.ui.panels')
         .directive('rvSidePanel', rvSidePanel);
 
-    /* @ngInject */
     /**
      * `rvSidePanel` directive body.
      * @return {object} directive body
@@ -39,14 +37,15 @@
         }
     }
 
-    /* @ngInject */
     /**
      * Skeleton controller function.
      */
     function Controller() {
-        //var vm = this;
+        const self = this;
 
         activate();
+
+        //////////
 
         function activate() {
 

--- a/src/app/ui/panels/side-panel.directive.js
+++ b/src/app/ui/panels/side-panel.directive.js
@@ -41,7 +41,7 @@
      * Skeleton controller function.
      */
     function Controller() {
-        const self = this;
+        //const self = this;
 
         activate();
 

--- a/src/app/ui/toc/toc.html
+++ b/src/app/ui/toc/toc.html
@@ -19,6 +19,22 @@
                 </div>
             </li>
         </ul>
+
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+        <p>[ place holder content ]</p>
+
     </div>
 
 </rv-main-panel-content>

--- a/src/content/styles/modules/_buttons.scss
+++ b/src/content/styles/modules/_buttons.scss
@@ -17,6 +17,24 @@
         &.primary {
             @include icon($primary-color);
         }
+
+        // adjust size of the button container to the its parent while keeping the normal-sized ripple
+        &.rv-auto {
+            height: auto;
+            line-height: normal;
+            min-height: auto;
+            width: auto;
+            min-width: auto;
+            overflow: visible;
+
+            > .md-ripple-container {
+                width: 48px;
+                height: 48px;
+                left: -12px;
+                top: -12px;
+                overflow: visible;
+            }
+        }
     }
 }
 

--- a/src/content/styles/modules/_content-pane.scss
+++ b/src/content/styles/modules/_content-pane.scss
@@ -1,16 +1,42 @@
 // Primary mixin
 @mixin content-pane {
-    .content-pane {
+    .rv-content-pane {
         top: 0;
         left: 0;
         bottom: 8px;
         right: 0;
         position: absolute;
 
-        .md-headline, .md-title, .md-subhead {
-            line-height: 24px;
-            margin-top: 5px;
-            margin-bottom: 11px;
+        .rv-header {
+            display: flex;
+            white-space: nowrap;
+            margin: {
+                top: 5px;
+                bottom: 11px;
+            }
+
+            > .md-headline,
+            > .md-title,
+            > .md-subhead {
+                line-height: 24px;
+                margin-top: 0;
+                margin-bottom: 0;
+                display: inline-block;
+                text-overflow: ellipsis;
+                overflow: hidden;
+            }
+        }
+
+        .rv-content {
+            top: 49px;
+            left: 0;
+            bottom: 0;
+            right: 0;
+            position: absolute;
+            padding: {
+                left: 8px;
+                right: 8px;
+            }
         }
     }
 }

--- a/src/content/styles/modules/_content-plug.scss
+++ b/src/content/styles/modules/_content-plug.scss
@@ -32,28 +32,28 @@
     &.ng-leave {
         transition: none $duration $swift-ease-in-out-timing-function;
 
-        .content-pane {
+        .rv-content-pane {
             transition: all $duration $swift-ease-in-out-timing-function;
         }
     }
 
-    &.ng-enter .content-pane {
+    &.ng-enter .rv-content-pane {
         transform: translate3d($xFrom, $yFrom, 0);
         transition-delay: $duration / 2; // enter delay lets leave pane disappear preventing overlap
         opacity: 0;
     }
 
-    &.ng-enter-active .content-pane {
+    &.ng-enter-active .rv-content-pane {
         transform: translate3d($xTo, $yTo, 0);
         opacity: 1;
     }
 
-    &.ng-leave .content-pane {
+    &.ng-leave .rv-content-pane {
         transform: translate3d($xTo, $yTo, 0);
         opacity: 1;
     }
 
-    &.ng-leave-active .content-pane {
+    &.ng-leave-active .rv-content-pane {
         transform: translate3d(-$xFrom, -$yFrom, 0);
         opacity: 0;
     }


### PR DESCRIPTION
The content pane directive now has a close button that executes a `closePanel` function found on its parent plug's `ngController`. The button is not shown if the function is undefined.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/56)
<!-- Reviewable:end -->
