### PR TITLE
perf(ui): do not remove layer groups from dom when toggled

### DIFF
--- a/src/app/ui/common/toggle-slide.animation.js
+++ b/src/app/ui/common/toggle-slide.animation.js
@@ -30,8 +30,8 @@
         const service = {
             enter: toggleOpen,
             leave: toggleClose,
-            addClass: ngShowHideBootstrap(1),
-            removeClass: ngShowHideBootstrap(0)
+            addClass: ngShowHideBootstrap(true),
+            removeClass: ngShowHideBootstrap(false)
         };
 
         return () => service;
@@ -74,26 +74,20 @@
         /**
          * When using `ng-show` or `ng-hide`, animation is triggered on `addClass`, `removeClass`, and `setClass`. See more here: https://docs.angularjs.org/api/ng/service/$animate#addClass
          *
-         * @param  {number} addClass a flag indicating whether the class was added or removed
+         * @param  {boolean} addClass a flag indicating whether the `ng-hide` class was added or removed
          * @return {function}        bootstrapped open or close function
          */
         function ngShowHideBootstrap(addClass) {
             return (element, cssClass, callback) => {
-                // either `ng-hide` or `ng-show` class is toggled, depending on the directive
-                const directive = {
-                    'ng-hide': 0,
-                    'ng-show': 1
-                };
-
+                // both `ng-hide` and `ng-show` use `ng-hide` css class
                 const action = {
-                    0: toggleOpen,
-                    1: toggleClose
+                    false: toggleOpen,
+                    true: toggleClose
                 };
 
                 // pick the action to perform;
-                // `1 - directive[cssClass]` chooses between opening and closing action based on the directive
-                // `addClass * ...` flips the action depending on whether the class is added or removed
-                action[addClass * (1 - directive[cssClass])](element, callback);
+                // `addClass` flips the action depending on whether the class is added or removed
+                action[addClass](element, callback);
             };
         }
 

--- a/src/app/ui/common/toggle-slide.animation.js
+++ b/src/app/ui/common/toggle-slide.animation.js
@@ -11,10 +11,13 @@
      * @module app.ui.common
      * @description
      *
-     * The `rvToggleSlide` is an animation. It animates enter and leave events on any node by `sliding` it up or down, animating its height, when its added or removed from the dom.
+     * The `rvToggleSlide` is an animation. It animates `enter` and `leave` events for `ng-if`; `addClass` and `removeClass`, for `ng-if` and `ng-show` directives on any node by `sliding` it up or down, animating its height, when its added or removed from the dom.
      *
      * ```html
-     * <div class="rv-toggle-slide"></div>
+     * <div class="rv-toggle-slide" ng-show="value"></div>
+     * <div class="rv-toggle-slide" ng-hide="value"></div>
+     *
+     * <div class="rv-toggle-slide" ng-if="value"></div>
      * ```
      */
     angular
@@ -26,7 +29,9 @@
     function toggleOpenBuilder() {
         const service = {
             enter: toggleOpen,
-            leave: toggleClose
+            leave: toggleClose,
+            addClass: ngShowHideBootstrap(1),
+            removeClass: ngShowHideBootstrap(0)
         };
 
         return () => service;
@@ -64,6 +69,32 @@
                 ease: RV_SWIFT_IN_OUT_EASE,
                 onComplete: () => callback()
             });
+        }
+
+        /**
+         * When using `ng-show` or `ng-hide`, animation is triggered on `addClass`, `removeClass`, and `setClass`. See more here: https://docs.angularjs.org/api/ng/service/$animate#addClass
+         *
+         * @param  {number} addClass a flag indicating whether the class was added or removed
+         * @return {function}        bootstrapped open or close function
+         */
+        function ngShowHideBootstrap(addClass) {
+            return (element, cssClass, callback) => {
+                // either `ng-hide` or `ng-show` class is toggled, depending on the directive
+                const directive = {
+                    'ng-hide': 0,
+                    'ng-show': 1
+                };
+
+                const action = {
+                    0: toggleOpen,
+                    1: toggleClose
+                };
+
+                // pick the action to perform;
+                // `1 - directive[cssClass]` chooses between opening and closing action based on the directive
+                // `addClass * ...` flips the action depending on whether the class is added or removed
+                action[addClass * (1 - directive[cssClass])](element, callback);
+            };
         }
 
         /**

--- a/src/app/ui/toc/layer-group-toggle.html
+++ b/src/app/ui/toc/layer-group-toggle.html
@@ -1,9 +1,9 @@
 <md-button ng-click="self.toggleGroup()">
     <div flex layout="row">
         <span class="md-toggle-icon" ng-class="{ 'rv-toggled' : self.group.expanded }">
-            <md-icon md-svg-src="hardware:keyboard_arrow_up"></md-icon>
+            <md-icon md-svg-src="hardware:keyboard_arrow_right"></md-icon>
         </span>
         {{ self.group.name }}
         <span flex></span>
-    </div>    
+    </div>
 </md-button>

--- a/src/app/ui/toc/toc.html
+++ b/src/app/ui/toc/toc.html
@@ -14,7 +14,7 @@
                     <md-divider ng-if="!$first"></md-divider>
                     <rv-layer-group-toggle group="item" ></rv-layer-group-toggle>
 
-                    <ul class="rv-layer-list rv-toggle-slide" dx-connect="item" ng-if="item.expanded"></ul>
+                    <ul class="rv-layer-list rv-toggle-slide" dx-connect="item" ng-show="item.expanded"></ul>
                     <md-divider ng-if="$last && $dxLevel === 0"></md-divider>
                 </div>
             </li>

--- a/src/content/styles/modules/_toc.scss
+++ b/src/content/styles/modules/_toc.scss
@@ -20,7 +20,7 @@
             transition: transform $swift-ease-in-duration $swift-ease-in-out-timing-function;
 
             &.rv-toggled {
-                transform: rotate(180deg);
+                transform: rotate(90deg);
             }
         }
 


### PR DESCRIPTION
I was using `ng-if` to toggle layer groups, but this removes and reinserts them into the dom every time which can get slow, especially with many layers. Changed to using `ng-show` and updated the animation to work with that as well.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/65)
<!-- Reviewable:end -->
