### PR TITLE
docs: resolve markdown not rendered in configService

### DIFF
--- a/docs/config/templates/common.template.html
+++ b/docs/config/templates/common.template.html
@@ -4,7 +4,7 @@
 <md-content layout-padding flex>
 	<strong>({$ doc.docType $})</strong>
 
-	<p>{$ doc.description $}</p>
+	<p>{$ doc.description | marked $}</p>
 
 	{$ doc.parent | toInternalRoute(doc, 'Go Up') $}
 </md-content>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "canonical-path": "0.0.2",
     "del": "^1.2.0",
     "dgeni": "^0.4.1",
-    "dgeni-packages": "https://github.com/ec-dev/dgeni-packages#develop",
+    "dgeni-packages": "0.11.0",
     "glob": "^5.0.14",
     "gulp": "^3.9.0",
     "gulp-add-src": "^0.2.0",

--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -12,7 +12,7 @@
      * @requires configDefaults
      * @description
      *
-     * The `configService' is responsible for loading and parsing the supplied configuration.
+     * The `configService` is responsible for loading and parsing the supplied configuration.
      *
      * Config file is either specified inline, by a url or is referencing a global variable:
      * ```html


### PR DESCRIPTION
caused by template issue: common.template.html missing marked filter.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/67)
<!-- Reviewable:end -->
