### PR TITLE
fix(ui): rename title attributes used in content pane

### DIFF
--- a/src/app/ui/filters/filters-default.html
+++ b/src/app/ui/filters/filters-default.html
@@ -1,4 +1,4 @@
-<rv-content-pane title-style="title" title="Selected Feature Layer Name">
+<rv-content-pane title-style="title" title-value="Selected Feature Layer Name">
     <div>
         <p>{{ self.message }}</p>
 

--- a/src/app/ui/metadata/metadata.html
+++ b/src/app/ui/metadata/metadata.html
@@ -1,4 +1,4 @@
-<rv-content-pane title-style="subhead" title="Metadata">
+<rv-content-pane title-style="subhead" title-value="Metadata">
     <div>
         <p>[ metadata content ]</p>
 

--- a/src/app/ui/panels/content-pane.directive.js
+++ b/src/app/ui/panels/content-pane.directive.js
@@ -24,7 +24,7 @@
             require: '^ngController', // require plug controller
             templateUrl: 'app/ui/panels/content-pane.html',
             scope: {
-                title: '@', // binds to the evaluated dom property
+                titleValue: '@', // binds to the evaluated dom property
                 titleStyle: '@'
             },
             transclude: true,

--- a/src/app/ui/panels/content-pane.html
+++ b/src/app/ui/panels/content-pane.html
@@ -2,9 +2,9 @@
 
     <div class="rv-header" ng-switch on="self.titleStyle">
         <!-- display an appropriate header based on `headline` value -->
-        <h2 class="md-headline" ng-switch-when="headline">{{ self.title }}</h2>
-        <h3 class="md-title" ng-switch-when="title">{{ self.title }}</h3>
-        <h4 class="md-subhead" ng-switch-when="subhead">{{ self.title }}</h4>
+        <h2 class="md-headline" ng-switch-when="headline">{{ self.titleValue }}</h2>
+        <h3 class="md-title" ng-switch-when="title">{{ self.titleValue }}</h3>
+        <h4 class="md-subhead" ng-switch-when="subhead">{{ self.titleValue }}</h4>
 
         <span flex></span>
 

--- a/src/app/ui/settings/settings.html
+++ b/src/app/ui/settings/settings.html
@@ -1,4 +1,4 @@
-<rv-content-pane title-style="subhead" title="Settings">
+<rv-content-pane title-style="subhead" title-value="Settings">
     <div>
         <p>[ settings content ]</p>
 

--- a/src/app/ui/toc/toc.html
+++ b/src/app/ui/toc/toc.html
@@ -1,4 +1,4 @@
-<rv-content-pane title-style="title" title="Layer Selector">
+<rv-content-pane title-style="title" title-value="Layer Selector">
     <div class="rv-toc" ng-controller="TocController as self">
         <md-button ng-click="self.toggleFilters()">Filters</md-button>
         <md-button ng-click="self.toggleFiltersFull()">Filters mode</md-button>

--- a/src/app/ui/toolbox/toolbox.html
+++ b/src/app/ui/toolbox/toolbox.html
@@ -1,4 +1,4 @@
-<rv-content-pane title-style="title" title="Mapping Tools">
+<rv-content-pane title-style="title" title-value="Mapping Tools">
     <div>
         <p>[ mapping tools content ]</p>
 


### PR DESCRIPTION
"title" is a proper html attribute; renamed to "title-value" to avoid collisions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/83)
<!-- Reviewable:end -->
