### PR TITLE
fix(ui): stupidity

### DIFF
--- a/src/app/ui/common/toggle-slide.animation.js
+++ b/src/app/ui/common/toggle-slide.animation.js
@@ -44,7 +44,7 @@
          * @param  {callback} callback
          */
         function toggleOpen(element, callback) {
-            let targetHeight = open ? getTargetHeight(element) : 0;
+            let targetHeight = getTargetHeight(element);
 
             TweenLite.fromTo(element, RV_TOGGLE_SLIDE_DURATION, {
                 height: 0


### PR DESCRIPTION
"open" is a native browser function; this is why it was not picked up during linting.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/84)
<!-- Reviewable:end -->
