### PR TITLE
bug(ui): change setZoom calls to shiftZoom

### DIFF
--- a/src/app/ui/mapnav/mapnav.service.js
+++ b/src/app/ui/mapnav/mapnav.service.js
@@ -41,7 +41,7 @@
                 label: 'Zoom in',
                 icon: 'content:add',
                 tooltip: 'Zoom in',
-                action: () => geoService.setZoom('1')
+                action: () => geoService.shiftZoom(1)
             },
             slider: {
                 // TODO: add slider properties when we find a suitable slider lib
@@ -50,7 +50,7 @@
                 label: 'Zoom out',
                 icon: 'content:remove',
                 tooltip: 'Zoom out',
-                action: () => geoService.setZoom('-1')
+                action: () => geoService.shiftZoom(-1)
             },
             geoLocation: {
                 label: 'Your Location',


### PR DESCRIPTION
Forgot to change actual zoom calls. Is it muffins? If it is, who is responsible?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/215)
<!-- Reviewable:end -->
