### PR TITLE
statemanager / displaymanager

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -172,6 +172,7 @@ function jsbuild() {
         .pipe($.insert.transform(injectVersion))
         .pipe(versionFilter.restore)
 
+        // TODO: fix this: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/293
         //.pipe($.sourcemaps.init())
         .pipe($.plumber({ errorHandler: injectError }))
         .pipe($.babel())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -171,7 +171,8 @@ function jsbuild() {
         .pipe(versionFilter)
         .pipe($.insert.transform(injectVersion))
         .pipe(versionFilter.restore)
-        .pipe($.sourcemaps.init())
+
+        //.pipe($.sourcemaps.init())
         .pipe($.plumber({ errorHandler: injectError }))
         .pipe($.babel())
         .pipe($.plumber.stop())
@@ -184,7 +185,7 @@ function jsbuild() {
         .pipe($.concat(config.jsSingleFile))
 
         // if prod, uglify; if not, write sourcemaps inline because it will be merged with other libraries and it's not possible to use external files in that case
-        .pipe($.if(args.prod, $.uglify(), $.sourcemaps.write()));
+        .pipe($.if(args.prod, $.uglify())); //, $.sourcemaps.write()));
 }
 
 gulp.task('assetcopy', 'Copy fixed assets to the build directory',

--- a/src/app/common/router/displaymanager.service.js
+++ b/src/app/common/router/displaymanager.service.js
@@ -90,6 +90,7 @@
                 }
 
                 if (!state.active) { // panel is not open; open it
+                    display.data = null; // clear data so the newly opened panel doesn't have any content
                     stateManager.setActive(panelName);
                 }
 
@@ -132,8 +133,8 @@
 
             // check if the layerId for displayed data still matches data being retrieved
             // this prevents old request which complete after the newer ones to update display with old data
-            // `state.active` check makes sure data is not set when the panel is closed
-            if (display.requestId === requestId && state.active === true) {
+            // data can be set on the closed panel, see fgpv-vpgf/fgpv-vpgf#308
+            if (display.requestId === requestId) {
                 display.data = data;
 
                 // in some cases you might not want to turn off the loading indicator from tocService toggle function
@@ -142,7 +143,7 @@
                 $q
                     .resolve(isLoaded)
                     .then(value => {
-                        if (display.requestId === requestId && state.active === true && value === true) {
+                        if (display.requestId === requestId && value === true) {
                             display.isLoading = false;
 
                             // cancel loading indicator timeout if any

--- a/src/app/common/router/displaymanager.service.js
+++ b/src/app/common/router/displaymanager.service.js
@@ -33,7 +33,7 @@
          * Toggles the specified panel with following logic:
          * The requested panel can be open or closed;
          *     open:
-         *         the content alredy in the panel can belong to a differen layer
+         *         the content alredy in the panel can belong to a different layer
          *             same layer:
          *                 -> close panel
          *             different layer:

--- a/src/app/common/router/displaymanager.service.js
+++ b/src/app/common/router/displaymanager.service.js
@@ -8,7 +8,7 @@
      * @requires dependencies
      * @description
      *
-     * The `displayManager` factory description.
+     * The `displayManager` factory handles the display of dynamically retrived or constructed data like layer metadata, attributes, details, or settings.
      *
      */
     angular
@@ -30,7 +30,7 @@
         ///////////
 
         /**
-         * Toggles panel specified with following logic:
+         * Toggles the specified panel with following logic:
          * The requested panel can be open or closed;
          *     open:
          *         the content alredy in the panel can belong to a differen layer
@@ -41,6 +41,8 @@
          *     closed:
          *         -> open panel
          *
+         * If the panel is not closing, a loading indicator will be triggered (immediately or after a delay).
+         *
          * @param  {String} panelName        panel to open
          * @param  {Object} requester        object requesting display change; must have `id` attribute
          * @param  {String} panelNameToClose name of the panel to close before opening the main one if needed
@@ -48,7 +50,6 @@
          * @return {Number} return a data requestId; if equals -1, the panel will be closed, no further actions needed; otherwise, the panel will be opened
          */
         function toggleDisplayPanel(panelName, requester, panelNameToClose, delay = 100) {
-            console.log(panelName, requester, panelNameToClose, delay);
             const displayName = stateManager.state[panelName].display;
             if (typeof displayName === 'undefined') {
                 return -1; // display for this panel is not defined, exit
@@ -94,7 +95,7 @@
         }
 
         /**
-         * Sets displayed data for a specific content like layer metadata in the metadata panel.
+         * Sets displayed data for a specific content like layer metadata in the metadata panel. It checks agains the provided requestId, if the id matches, the data is set and the loading indidcator is turned off.
          *
          * @param {String} panelName     name of the panel where to update displayed content
          * @param {Number} requestId     request id

--- a/src/app/common/router/displaymanager.service.js
+++ b/src/app/common/router/displaymanager.service.js
@@ -8,7 +8,7 @@
      * @requires dependencies
      * @description
      *
-     * The `displayManager` factory handles the display of dynamically retrived or constructed data like layer metadata, attributes, details, or settings.
+     * The `displayManager` factory handles the display of dynamically retrieved or constructed data like layer metadata, attributes, details, or settings.
      *
      */
     angular
@@ -27,8 +27,6 @@
         return sm => {
             stateManager = sm;
 
-            activate();
-
             return service;
         };
 
@@ -38,19 +36,19 @@
          * Toggles the specified panel with following logic:
          * The requested panel can be open or closed;
          *     open:
-         *         the content alredy in the panel can belong to a different layer
+         *         the content already in the panel can belong to a different layer
          *             same layer:
          *                 -> close panel
          *             different layer:
-         *                 -> dehighlight the the old layer; highlihgt the new one
+         *                 -> dehighlight the the old layer; highlight the new one
          *     closed:
          *         -> open panel
          *
          * If the panel is not closing, a loading indicator will be triggered (immediately or after a delay).
          *
-         * @param  {String} panelName        panel to open
+         * @param  {String} panelName        panel to open; `statemanager.constant.service` `initialState` for valid panel names; any panel with a `display` property is a valid target;
          * @param  {Object} dataPromise      data object or a promise returning a data object; both can be plain data object or containers `{data: data, isLoaded: <boolean|promise> }`, where isLoaded can be a promise;
-         * @param  {Object} requester        object requesting display change; must have `id` attribute if you want the panel to toggle off on the same requester
+         * @param  {Object} requester        object requesting display change; must have `id` attribute if you want the panel to toggle off on the same requester; requester object can be used to immediately pass content to the panel - for example passing layer name to the filters panel to be displayed in the panel header while the datatable is being constructed;
          * @param  {Number} delay            time to wait before setting loading indicator
          * @return {Number} return a data requestId; if equals -1, the panel will be closed, no further actions needed; otherwise, the panel will be opened
          */
@@ -115,7 +113,7 @@
         }
 
         /**
-         * Sets displayed data for a specific content like layer metadata in the metadata panel. It checks agains the provided requestId, if the id matches, the data is set and the loading indidcator is turned off.
+         * Sets displayed data for a specific content like layer metadata in the metadata panel. It checks against the provided requestId, if the id matches, the data is set and the loading indidcator is turned off.
          *
          * @param {String} panelName     name of the panel where to update displayed content
          * @param {Number} requestId     request id to check if it's the latest request
@@ -150,11 +148,13 @@
                             // cancel loading indicator timeout if any
                             $timeout.cancel(display.loadingTimeout);
                         } else {
+                            // TODO: add fancy es6 string substitution when adding a logger library
                             console.log(displayName + ' Data rejected for request id ' + requestId +
                                 '; loading in progress or panel is closed');
                         }
                     });
             } else {
+                // TODO: add fancy es6 string substitution when adding a logger library
                 console.log(displayName + ' Data rejected for request id ' + requestId +
                     '; loading in progress or panel is closed');
             }
@@ -169,6 +169,8 @@
             const state = stateManager.state[panelName];
             const displayName = state.display;
 
+            console.log('clear!!!', panelName);
+
             if (typeof displayName === 'undefined') {
                 return -1; // display for this panel is not defined, exit
             }
@@ -181,7 +183,5 @@
             display.isLoading = false;
             $timeout.cancel(display.loadingTimeout);
         }
-
-        function activate() {}
     }
 })();

--- a/src/app/common/router/displaymanager.service.js
+++ b/src/app/common/router/displaymanager.service.js
@@ -18,7 +18,7 @@
     function displayManager($timeout, $q, $rootScope) {
         const service = {
             toggleDisplayPanel,
-            setDisplayData
+            clearDisplay
         };
         let stateManager;
         let requestIdCounter = 1;
@@ -119,9 +119,10 @@
                         const data = typeof value.data !== 'undefined' ? value.data : value;
                         const isLoaded = typeof value.isLoaded !== 'undefined' ? value.isLoaded : true;
 
-                        setDisplayData(panelName, requestId, data, isLoaded);
+                        setDisplay(panelName, requestId, data, isLoaded);
                     })
                     .catch(value => {
+                        // TODO: handle rejections properly
                         console.log('error retrieving data apparently', value);
                     });
             }
@@ -133,9 +134,9 @@
          * @param {String} panelName     name of the panel where to update displayed content
          * @param {Number} requestId     request id
          * @param {Object} data          data to be displayed
-         * @param {Boolean} isLoaded     flag to remove loading indicator from the panel
+         * @param {Boolean|Promise} isLoaded     flag to remove loading indicator from the panel; if `false`, don't remove the flag; if a promise, remove the flag upon its resolution
          */
-        function setDisplayData(panelName, requestId, data, isLoaded) {
+        function setDisplay(panelName, requestId, data, isLoaded) {
             const state = stateManager.state[panelName];
             const displayName = state.display;
 
@@ -153,11 +154,11 @@
 
                 // in some cases you might not want to turn off the loading indicator from tocService toggle function
                 // with the filters panel for example: fetching data for the table takes time, but generating the actual table also takes time; so you want to turn off the loading indicator from filters panel
-                // when `isLoaded` promise resolves, the loading indicator is removed no matter the resolve value
+                // when `isLoaded` promise resolves, the loading indicator is removed if the resolved value is not false
                 $q
                     .resolve(isLoaded)
                     .then(value => {
-                        if (display.requestId === requestId && state.active === true) {
+                        if (display.requestId === requestId && state.active === true && value === true) {
                             display.isLoading = false;
 
                             // cancel loading indicator timeout if any

--- a/src/app/common/router/displaymanager.service.js
+++ b/src/app/common/router/displaymanager.service.js
@@ -1,0 +1,145 @@
+(() => {
+    'use strict';
+
+    /**
+     * @ngdoc service
+     * @name displayManager
+     * @module app.common.router
+     * @requires dependencies
+     * @description
+     *
+     * The `displayManager` factory description.
+     *
+     */
+    angular
+        .module('app.common.router')
+        .factory('displayManager', displayManager);
+
+    function displayManager($timeout, $rootScope, stateManager) {
+        const service = {
+            toggleDisplayPanel,
+            setDisplayData
+        };
+
+        let requestIdCounter = 1;
+
+        activate();
+
+        return service;
+
+        ///////////
+
+        /**
+         * Toggles panel specified with following logic:
+         * The requested panel can be open or closed;
+         *     open:
+         *         the content alredy in the panel can belong to a differen layer
+         *             same layer:
+         *                 -> close panel
+         *             different layer:
+         *                 -> dehighlight the the old layer; highlihgt the new one
+         *     closed:
+         *         -> open panel
+         *
+         * @param  {String} panelName        panel to open
+         * @param  {Object} requester        object requesting display change; must have `id` attribute
+         * @param  {String} panelNameToClose name of the panel to close before opening the main one if needed
+         * @param  {Number} delay            time to wait before setting loading indicator
+         * @return {Number} return a data requestId; if equals -1, the panel will be closed, no further actions needed; otherwise, the panel will be opened
+         */
+        function toggleDisplayPanel(panelName, requester, panelNameToClose, delay = 100) {
+            console.log(panelName, requester, panelNameToClose, delay);
+            const displayName = stateManager.state[panelName].display;
+            if (typeof displayName === 'undefined') {
+                return -1; // display for this panel is not defined, exit
+            }
+
+            // if specified panel is open and the requester matches
+            if (stateManager.state[panelName].active &&
+                stateManager.display[displayName].requester.id === requester.id) {
+                stateManager.setActive(panelName); // just close the panel
+
+                return -1;
+            } else {
+                // cancel previous data retrieval timeout so we don't display old data
+                $timeout.cancel(stateManager.display[displayName].loadingTimeout);
+
+                if (delay === 0) {
+                    stateManager.display[displayName].isLoading = true;
+                } else {
+                    // if it takes longer than 100 ms to get metadata, kick in the loading screen
+                    // this is fast enough for people to perceive it as instantaneous
+                    stateManager.display[displayName].loadingTimeout = $timeout(() => {
+                        stateManager.display[displayName].isLoading = true;
+                    }, delay);
+                }
+
+                if (!stateManager.state[panelName].active) { // panel is not open; open it; close other panels is specified
+                    // open panel closing anything else specified
+                    if (panelNameToClose) {
+                        let closePanel = {};
+                        closePanel[panelNameToClose] = false;
+                        stateManager.setActive(closePanel, panelName);
+                    } else {
+                        stateManager.setActive(panelName);
+                    }
+                }
+
+                // update requestId and the requester object
+                stateManager.display[displayName].requester = requester;
+                stateManager.display[displayName].requestId = ++requestIdCounter;
+
+                return requestIdCounter;
+            }
+        }
+
+        /**
+         * Sets displayed data for a specific content like layer metadata in the metadata panel.
+         *
+         * @param {String} panelName     name of the panel where to update displayed content
+         * @param {Number} requestId     request id
+         * @param {Object} data          data to be displayed
+         * @param {Boolean} isLoaded     flag to remove loading indicator from the panel
+         */
+        function setDisplayData(panelName, requestId, data, isLoaded) {
+            const displayName = stateManager.state[panelName].display;
+            if (typeof displayName === 'undefined') {
+                return -1; // display for this panel is not defined, exit
+            }
+
+            // check if the layerId for displayed data still matches data being retrieved
+            // this prevents old request which complete after the newer ones to update display with old data
+            if (stateManager.display[displayName].requestId === requestId) {
+                stateManager.display[displayName].data = data;
+
+                // in some cases you might not want to turn off the loading indicator from tocService toggle function
+                // with the filters panel for example: fetching data for the table takes time, but generating the actual table also takes time; so you want to turn off the loading indicator from filters panel
+                if (isLoaded === true) {
+                    stateManager.display[displayName].isLoading = false;
+
+                    // cancel loading indicator timeout if any
+                    $timeout.cancel(stateManager.display[displayName].loadingTimeout);
+                }
+            } else {
+                console.log(displayName + ' Data rejected for request id ' + requestId +
+                    '; loading in progress');
+            }
+        }
+
+        function activate() {
+            // listen to panels closing; set their corresponding displays to null when they close
+            $rootScope.$on('stateChangeComplete', (event, name, property, value) => {
+                const displayName = stateManager.state[name].display;
+
+                if (typeof displayName !== 'undefined' && value === false) {
+                    //console.log('displayName', displayName, stateManager.display[displayName]);
+
+                    // null data, and requester info on child panel close
+                    stateManager.display[displayName].data = null;
+                    stateManager.display[displayName].requester = null;
+                    stateManager.display[displayName].requestId = null;
+                }
+            });
+        }
+    }
+})();

--- a/src/app/common/router/displaymanager.service.js
+++ b/src/app/common/router/displaymanager.service.js
@@ -173,21 +173,28 @@
             }
         }
 
-        function activate() {
-            // listen to panels closing; set their corresponding displays to null when they close
-            $rootScope.$on('stateChangeComplete', (event, name, property, value) => {
-                const displayName = stateManager.state[name].display;
-                const display = stateManager.display[displayName];
+        /**
+         * Clears data from the specified display.
+         * @param  {String} panelName the name of the panel whose display should be cleared
+         */
+        function clearDisplay(panelName) {
+            // TODO: the following 4 statements could be moved to a helper function
+            const state = stateManager.state[panelName];
+            const displayName = state.display;
 
-                if (typeof displayName !== 'undefined' && value === false) {
-                    console.log('displayName', displayName, display);
+            if (typeof displayName === 'undefined') {
+                return -1; // display for this panel is not defined, exit
+            }
 
-                    // null data, and requester info on child panel close
-                    display.data = null;
-                    display.requester = null;
-                    display.requestId = null;
-                }
-            });
+            const display = stateManager.display[displayName];
+
+            display.data = null;
+            display.requester = null;
+            display.requestId = null;
+            display.isLoading = false;
+            $timeout.cancel(display.loadingTimeout);
         }
+
+        function activate() {}
     }
 })();

--- a/src/app/common/router/displaymanager.service.js
+++ b/src/app/common/router/displaymanager.service.js
@@ -15,17 +15,22 @@
         .module('app.common.router')
         .factory('displayManager', displayManager);
 
-    function displayManager($timeout, $rootScope, stateManager) {
+    function displayManager($timeout, $rootScope) {
         const service = {
             toggleDisplayPanel,
             setDisplayData
         };
-
+        let stateManager;
         let requestIdCounter = 1;
 
-        activate();
+        // to avoid circular references, stateManger instantiates displayManager by passing its own service to the init function
+        return sm => {
+            stateManager = sm;
 
-        return service;
+            activate();
+
+            return service;
+        };
 
         ///////////
 

--- a/src/app/common/router/displaymanager.service.js
+++ b/src/app/common/router/displaymanager.service.js
@@ -170,7 +170,7 @@
             const state = stateManager.state[panelName];
             const displayName = state.display;
 
-            console.log('clear!!!', panelName);
+            //console.log('Clearing ' + panelName);
 
             if (typeof displayName === 'undefined') {
                 return -1; // display for this panel is not defined, exit

--- a/src/app/common/router/statemanager.constant.service.js
+++ b/src/app/common/router/statemanager.constant.service.js
@@ -1,12 +1,13 @@
 (() => {
     'use strict';
 
-    const STATE_OBJECT_DEFAULTS = parentName => {
+    const STATE_OBJECT_DEFAULTS = (parentName, displayName) => {
         if (parentName) {
             return {
                 parent: parentName,
                 active: false,
-                activeSkip: false
+                activeSkip: false,
+                display: displayName
             };
         } else {
             return {
@@ -54,16 +55,17 @@
             // `morph` indicates the mode of the panel; filters panel has three different modes: 'full', 'default', and 'minimized'; filters panel's modes specify different height for the panel; its changes are also animated;
             // `morphSkip` is a boolean flag indicating whether the animation on changes to the `morph` should be skipped
             // `history` keeps track of pane names opened in a panel; limit of 10 items;
+            // 'displayName' links panel to a certain display object; several panels can target the same display object;
 
             main: STATE_OBJECT_DEFAULTS(),
             mainToc: STATE_OBJECT_DEFAULTS('main'),
             mainToolbox: STATE_OBJECT_DEFAULTS('main'),
-            mainDetails: STATE_OBJECT_DEFAULTS('main'),
+            mainDetails: STATE_OBJECT_DEFAULTS('main', 'details'),
             side: STATE_OBJECT_DEFAULTS(),
-            sideMetadata: STATE_OBJECT_DEFAULTS('side'),
-            sideSettings: STATE_OBJECT_DEFAULTS('side'),
+            sideMetadata: STATE_OBJECT_DEFAULTS('side', 'metadata'),
+            sideSettings: STATE_OBJECT_DEFAULTS('side', 'settings'),
             filters: STATE_OBJECT_DEFAULTS(),
-            filtersFulldata: STATE_OBJECT_DEFAULTS('filters'),
+            filtersFulldata: STATE_OBJECT_DEFAULTS('filters', 'filters'),
             filtersNamedata: STATE_OBJECT_DEFAULTS('filters'),
             other: STATE_OBJECT_DEFAULTS(),
             otherBasemap: STATE_OBJECT_DEFAULTS('other'),

--- a/src/app/common/router/statemanager.service.js
+++ b/src/app/common/router/statemanager.service.js
@@ -228,6 +228,11 @@
                     // emit event on the rootscope when change is complete
                     $rootScope.$broadcast('stateChangeComplete', itemName, property, value, skip);
 
+                    // record history of `active` changes only 
+                    if (property === 'morph') {
+                        return;
+                    }
+
                     let history;
 
                     if (item.parent && value) { // add to history only when a child opens or ...

--- a/src/app/common/router/statemanager.service.js
+++ b/src/app/common/router/statemanager.service.js
@@ -233,16 +233,6 @@
                         return;
                     }
 
-                    let displayName = item.display;
-                    if (typeof displayName !== 'undefined' && value === false) {
-                        console.log('displayName', displayName, service.display[displayName]);
-
-                        // null data, and requester info on child panel close
-                        service.display[displayName].data = null;
-                        service.display[displayName].requester = null;
-                        service.display[displayName].requestId = null;
-                    }
-
                     let history;
 
                     if (item.parent && value) { // add to history only when a child opens or ...

--- a/src/app/common/router/statemanager.service.js
+++ b/src/app/common/router/statemanager.service.js
@@ -19,7 +19,7 @@
      * - activated: it activates its parent and deactivates its active sibling if any;
      * - deactivated: it deactivates its parent as well;
      *
-     * Only `active` and `morph` state properties are animated (animation can be skip which is indicated by the `activeSkip` and `morphSkip` flags) and need to be set through `setActive` and `setMorph` functions accordingly; these properties can be bound and watched directly though. Everything else on the `state` object can be set, bound, and watched directly.
+     * Only `active` and `morph` state properties are animated (animation can be skipped which is indicated by the `activeSkip` and `morphSkip` flags) and need to be set through `setActive` and `setMorph` functions accordingly; these properties can be bound and watched directly though. Everything else on the `state` object can be set, bound, and watched directly.
      */
     angular
         .module('app.common.router')
@@ -27,7 +27,7 @@
 
     // https://github.com/johnpapa/angular-styleguide#factory-and-service-names
 
-    function stateManager($q, $rootScope, initialState, initialDisplay) {
+    function stateManager($q, $rootScope, displayManager, initialState, initialDisplay) {
         const service = {
             addState,
 
@@ -47,6 +47,9 @@
         };
 
         const fulfillStore = {}; // keeping references to promise fulfill functions
+
+        const displayService = displayManager(service); // init displayManager
+        angular.extend(service, displayService); // merge displayManager service function into stateManager
 
         return service;
 

--- a/src/app/common/router/statemanager.service.js
+++ b/src/app/common/router/statemanager.service.js
@@ -228,9 +228,19 @@
                     // emit event on the rootscope when change is complete
                     $rootScope.$broadcast('stateChangeComplete', itemName, property, value, skip);
 
-                    // record history of `active` changes only 
+                    // record history of `active` changes only
                     if (property === 'morph') {
                         return;
+                    }
+
+                    let displayName = item.display;
+                    if (typeof displayName !== 'undefined' && value === false) {
+                        console.log('displayName', displayName, service.display[displayName]);
+
+                        // null data, and requester info on child panel close
+                        service.display[displayName].data = null;
+                        service.display[displayName].requester = null;
+                        service.display[displayName].requestId = null;
                     }
 
                     let history;

--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -61,7 +61,7 @@
             }
 
             // store the promise and return it on all future calls; this way initialize can be called one time only
-            initializePromise = $q(function (fulfill, reject) {
+            initializePromise = $q((fulfill, reject) => {
                 const configAttr = $rootElement.attr('th-config');
                 let configJson;
 
@@ -129,11 +129,11 @@
          */
         function ready(nextPromises) {
             return initializePromise
-                .then(function () {
+                .then(() => {
                     console.log('Ready promise resolved.');
                     return $q.all(nextPromises);
                 })
-                .catch(function () {
+                .catch(() => {
                     console.log('"ready" function failed');
                 });
         }

--- a/src/app/ui/appbar/appbar.html
+++ b/src/app/ui/appbar/appbar.html
@@ -10,7 +10,7 @@
         <span flex></span>
         <md-button translate translate-attr-aria-label="appbar.aria.pointInfo" class="md-icon-button primary" rv-help="details-button"
             ng-class="{ selected: self.stateManager.state.mainDetails.active }" ng-click="self.toggleDetails()"
-            ng-show="self.stateManager.display.details.data">
+            ng-show="self.stateManager.display.details.requestId">
             <md-tooltip>{{'appbar.tooltip.pointInfo' | translate}}</md-tooltip>
             <md-icon md-svg-src="maps:place"></md-icon>
         </md-button>

--- a/src/app/ui/details/details.directive.js
+++ b/src/app/ui/details/details.directive.js
@@ -112,11 +112,19 @@
          * Closes details pane and switches to toc.
          */
         function closeDetails() {
+            const item = stateManager.state.main.history.slice(-2).shift(); // get second to last history item
+            const options = {};
+
+            // reopen previous selected pane if it's not null or 'mainDetails'
+            if (item !== null && item !== 'mainDetails') {
+                options[item] = true;
+            } else {
+                options.mainDetails = false;
+            }
+
             // close `mainDetails` panel
             stateManager
-                .setActive({
-                    side: false
-                }, 'mainDetails')
+                .setActive(options)
                 .then(() => stateManager.clearDisplayPanel('mainDetails')); // clear `details` display
         }
 

--- a/src/app/ui/details/details.directive.js
+++ b/src/app/ui/details/details.directive.js
@@ -90,10 +90,13 @@
 
         // TODO: adding stateManger to scope to set up watch
         $scope.$watch('self.display.data', newValue => {
-            console.log('self.display.data', newValue);
+            //console.log('self.display.data', newValue);
+            // if multiple points added to the details panel ...
             if (newValue && newValue.length > 0) {
                 // pick random point to be selected initially
                 self.selectedItem = newValue[Math.floor(Math.random() * newValue.length)];
+            } else {
+                self.selectedItem = null;
             }
         });
 

--- a/src/app/ui/details/details.directive.js
+++ b/src/app/ui/details/details.directive.js
@@ -113,10 +113,11 @@
          */
         function closeDetails() {
             // close `mainDetails` panel
-            stateManager.setActive({
-                side: false
-            }, 'mainDetails')
-            .then(() => stateManager.clearDisplayPanel('mainDetails')); // clear `details` display
+            stateManager
+                .setActive({
+                    side: false
+                }, 'mainDetails')
+                .then(() => stateManager.clearDisplayPanel('mainDetails')); // clear `details` display
         }
 
         /**

--- a/src/app/ui/details/details.directive.js
+++ b/src/app/ui/details/details.directive.js
@@ -79,7 +79,7 @@
     // COMMENT to self: brief flickering of fake content is caused by immediately setting data and isLoading flag;
     // in a real case, we wait for 100ms to get data, and then set isLoading which;
 
-    function Controller(stateManager, $scope, $timeout) {
+    function Controller(stateManager, $scope) {
         'ngInject';
         const self = this;
 
@@ -116,7 +116,7 @@
             stateManager.setActive({
                 side: false
             }, 'mainDetails')
-            .then(() => stateManager.clearDisplay('mainDetails')); // clear `details` display
+            .then(() => stateManager.clearDisplayPanel('mainDetails')); // clear `details` display
         }
 
         /**

--- a/src/app/ui/details/details.directive.js
+++ b/src/app/ui/details/details.directive.js
@@ -112,16 +112,11 @@
          * Closes details pane and switches to toc.
          */
         function closeDetails() {
+            // close `mainDetails` panel
             stateManager.setActive({
                 side: false
-            }, 'mainDetails');
-
-            // TODO: remove;
-            // null the data on panel close
-            $timeout(() => {
-                self.display.data = null;
-                self.selectedItem = null;
-            }, 400);
+            }, 'mainDetails')
+            .then(() => stateManager.clearDisplay('mainDetails')); // clear `details` display
         }
 
         /**

--- a/src/app/ui/details/details.html
+++ b/src/app/ui/details/details.html
@@ -4,12 +4,34 @@
     title-style="title"
     title-value="Point Information"
     is-loading="self.display.isLoading"
-    hide-when-loading="self.display.data.length === 1">
-    <div class="rv-details" ng-class="{ 'rv-multiple': self.display.data.length > 1 }">
+    hide-when-loading="self.display.data.length === 1 || !self.display.data">
+
+    <div class="rv-details" ng-if="self.display.data.length === 1">
+        <md-content class="rv-details-data rv-content">
+            <div
+                class="rv-subsection">
+                <div class="rv-subheader">
+                    <h4 class="md-subhead">{{ self.display.data[0].requester }}</h4>
+                </div>
+
+                <div class="rv-subcontent">
+                    <h5 class="rv-sub-subhead" ng-repeat-start="item in self.display.data[0].data">{{ item.name }}</h5>
+
+                    <p ng-repeat-end ng-repeat="paragraph in item.data">
+                        {{ paragraph }}
+                    </p>
+
+                </div>
+
+            </div>
+        </md-content>
+    </div>
+
+    <div class="rv-details rv-multiple" ng-if="self.display.data.length > 1">
         <md-content class="rv-details-data rv-content">
             <div
                 class="rv-subsection rv-hide-animate"
-                ng-class="{ 'rv-hide': self.display.data.length > 1 && self.selectedItem.isLoading }">
+                ng-class="{ 'rv-hide': (self.display.data.length > 1 && self.selectedItem.isLoading) || !self.display.data }">
                 <div class="rv-subheader">
                     <h4 class="md-subhead">{{ self.selectedItem.requester }}</h4>
                 </div>

--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -64,7 +64,7 @@
                     .on('init.dt', () => {
                         // turn off loading indicator after the table initialized or the forced delay whichever takes longer; cancel loading timeout as well
                         forcedDelay.then(() => {
-                            // TODO: these ought to be moved to a helper function in displayManager 
+                            // TODO: these ought to be moved to a helper function in displayManager
                             stateManager.display.filters.isLoading = false;
                             $timeout.cancel(stateManager.display.filters.loadingTimeout);
                         });

--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -64,6 +64,7 @@
                     .on('init.dt', () => {
                         // turn off loading indicator after the table initialized or the forced delay whichever takes longer; cancel loading timeout as well
                         forcedDelay.then(() => {
+                            // TODO: these ought to be moved to a helper function in displayManager 
                             stateManager.display.filters.isLoading = false;
                             $timeout.cancel(stateManager.display.filters.loadingTimeout);
                         });

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -919,31 +919,33 @@
          * @param  {Object} layer layer object whose data should be displayed.
          */
         function toggleLayerFiltersPanel(layer) {
-            // close basemap selector if open
-            stateManager.setActive({
-                other: false
-            });
-
             const requester = {
                 id: layer.id,
                 name: layer.name
             };
 
-            // we have to set the loading indicator immediately because the creating of the datatable block ui from updating and uless the indicator is already set, it will be visible until after the table is created
-            const requestId = stateManager.toggleDisplayPanel('filtersFulldata', requester, 'side', 0);
-
-            if (requestId === -1) {
-                return;
-            }
-
             // temporary data loading
-            // TODO: replace ecogeo with layerid
-            const newData = geoService.getFormattedAttributes('ecogeo', '0');
-            newData.columns = newData.columns.slice(0, (layer.id + 1) * 5);
-            newData.data = newData.data.slice(0, (layer.id + 1) * 50);
+            // TODO: replace ecogeo with layerid;
+            const newData = $timeout(() => {
+                const attrs = geoService.getFormattedAttributes('ecogeo', '0');
 
-            // need to use 0 timeout; otherwise the loading indicator will never be shown as ui gets blocked by datatable construction
-            $timeout(() => stateManager.setDisplayData('filtersFulldata', requestId, newData, false), 0);
+                return {
+                    data: {
+                        columns: attrs.columns.slice(0, (layer.id + 1) * 5),
+                        data: attrs.data.slice(0, (layer.id + 1) * 50)
+                    },
+                    isLoaded: false
+                };
+            }, 0);
+
+            stateManager.setActive({
+                other: false
+            });
+            stateManager
+                .setActive({
+                    side: false
+                })
+                .then(() => stateManager.toggleDisplayPanel('filtersFulldata', newData, requester, 0));
         }
 
         /**

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -991,6 +991,14 @@
          * @param  {String} displayName type of the display data (layer toggle name: 'settings', 'metadata', 'filters')
          */
         function watchPanelState(panelName, displayName) {
+            // clear display on metadata, settings, and filters panels when closed
+            $rootScope.$on('stateChangeComplete', (event, name, property, value) => {
+                //console.log(name, property, value);
+                if (property === 'active' && name === panelName && value === false) {
+                    stateManager.clearDisplayPanel(panelName);
+                }
+            });
+
             $rootScope.$watch(() => stateManager.display[displayName].requester, (newRequester, oldRequester) => {
                 if (newRequester !== null) {
                     // deselect layer from the old requester if layer ids don't match

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -18,7 +18,7 @@
         .module('app.ui.toc')
         .factory('tocService', tocService);
 
-    function tocService(stateManager, $timeout, $rootScope, $http, geoService) {
+    function tocService($timeout, $q, $rootScope, $http, stateManager, geoService) {
         // TODO: remove after switching to the real config
         // jscs:disable maximumLineLength
         const service = {
@@ -905,13 +905,13 @@
             const requester = {
                 id: layer.id
             };
-            const requestId = stateManager.toggleDisplayPanel('sideSettings', requester, 'filters');
-
-            if (requestId === -1) {
-                return;
-            }
-
-            stateManager.setDisplayData('sideSettings', requestId, {}, true);
+            const panelToClose = {
+                filters: false
+            };
+            
+            stateManager
+                .setActive(panelToClose)
+                .then(() => stateManager.toggleDisplayPanel('sideSettings', {}, requester));
         }
 
         /**

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -908,7 +908,7 @@
             const panelToClose = {
                 filters: false
             };
-            
+
             stateManager
                 .setActive(panelToClose)
                 .then(() => stateManager.toggleDisplayPanel('sideSettings', {}, requester));
@@ -952,30 +952,34 @@
          * @param  {Object} layer layer object whose data should be displayed.
          */
         function toggleMetadata(layer) {
-            // toggle panels as needed
             const requester = {
                 id: layer.id
             };
-            const requestId = stateManager.toggleDisplayPanel('sideMetadata', requester, 'filters');
+            const panelToClose = {
+                filters: false
+            };
 
-            if (requestId === -1) {
-                return;
-            }
+            // construct a temp promise which resolves when data is generated or retrieved;
+            const dataPromise = $q(fulfill => {
+                // check if metadata is cached
+                if (layer.cache.metadata) {
+                    fulfill(layer.cache.metadata);
+                } else {
+                    // TODO: generate some metadata to display functionality
+                    const mdata = HolderIpsum.paragraphs(2, true);
 
-            // check if metadata is cached
-            if (layer.cache.metadata) {
-                stateManager.setDisplayData('sideMetadata', requestId, layer.cache.metadata, true);
-            } else { // else, retrieve it;
-                // TODO: generate some metadata to display functionality
-                const mdata = HolderIpsum.paragraphs(2, true);
+                    // TODO: remove; simulating delay on retrieving metadata
+                    $timeout(() => {
+                        layer.cache.metadata = mdata;
 
-                // TODO: remove; simulating delay on retrieving metadata
-                $timeout(() => {
-                    layer.cache.metadata = mdata;
+                        fulfill(layer.cache.metadata);
+                    }, Math.random() * 3000 + 300); // random delay
+                }
+            });
 
-                    stateManager.setDisplayData('sideMetadata', requestId, layer.cache.metadata, true);
-                }, Math.random() * 3000 + 300); // random delay
-            }
+            stateManager
+                .setActive(panelToClose)
+                .then(() => stateManager.toggleDisplayPanel('sideMetadata', dataPromise, requester));
         }
 
         /**

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -18,7 +18,7 @@
         .module('app.ui.toc')
         .factory('tocService', tocService);
 
-    function tocService(stateManager, displayManager, $timeout, $rootScope, $http, geoService) {
+    function tocService(stateManager, $timeout, $rootScope, $http, geoService) {
         // TODO: remove after switching to the real config
         // jscs:disable maximumLineLength
         const service = {
@@ -905,13 +905,13 @@
             const requester = {
                 id: layer.id
             };
-            const requestId = displayManager.toggleDisplayPanel('sideSettings', requester, 'filters');
+            const requestId = stateManager.toggleDisplayPanel('sideSettings', requester, 'filters');
 
             if (requestId === -1) {
                 return;
             }
 
-            displayManager.setDisplayData('sideSettings', requestId, {}, true);
+            stateManager.setDisplayData('sideSettings', requestId, {}, true);
         }
 
         /**
@@ -930,7 +930,7 @@
             };
 
             // we have to set the loading indicator immediately because the creating of the datatable block ui from updating and uless the indicator is already set, it will be visible until after the table is created
-            const requestId = displayManager.toggleDisplayPanel('filtersFulldata', requester, 'side', 0);
+            const requestId = stateManager.toggleDisplayPanel('filtersFulldata', requester, 'side', 0);
 
             if (requestId === -1) {
                 return;
@@ -943,7 +943,7 @@
             newData.data = newData.data.slice(0, (layer.id + 1) * 50);
 
             // need to use 0 timeout; otherwise the loading indicator will never be shown as ui gets blocked by datatable construction
-            $timeout(() => displayManager.setDisplayData('filtersFulldata', requestId, newData, false), 0);
+            $timeout(() => stateManager.setDisplayData('filtersFulldata', requestId, newData, false), 0);
         }
 
         /**
@@ -956,7 +956,7 @@
             const requester = {
                 id: layer.id
             };
-            const requestId = displayManager.toggleDisplayPanel('sideMetadata', requester, 'filters');
+            const requestId = stateManager.toggleDisplayPanel('sideMetadata', requester, 'filters');
 
             if (requestId === -1) {
                 return;
@@ -964,7 +964,7 @@
 
             // check if metadata is cached
             if (layer.cache.metadata) {
-                displayManager.setDisplayData('sideMetadata', requestId, layer.cache.metadata, true);
+                stateManager.setDisplayData('sideMetadata', requestId, layer.cache.metadata, true);
             } else { // else, retrieve it;
                 // TODO: generate some metadata to display functionality
                 const mdata = HolderIpsum.paragraphs(2, true);
@@ -973,7 +973,7 @@
                 $timeout(() => {
                     layer.cache.metadata = mdata;
 
-                    displayManager.setDisplayData('sideMetadata', requestId, layer.cache.metadata, true);
+                    stateManager.setDisplayData('sideMetadata', requestId, layer.cache.metadata, true);
                 }, Math.random() * 3000 + 300); // random delay
             }
         }

--- a/src/app/ui/toc/toc.service.spec.js
+++ b/src/app/ui/toc/toc.service.spec.js
@@ -86,19 +86,21 @@ describe('tocService', () => {
             expect(display.data.length)
                 .toBeGreaterThan(0); // some metadata was generated
 
-            spyWatch('sideMetadata', newValue => {
-
+            rs.$watch(() => stateManager.display.metadata.requester, newRequester => {
                 // waiting for sideMetadata to close, it should clear metadata display object
-                if (!newValue) {
-
+                if (newRequester === null) {
                     expect(display.requestId)
                         .toEqual(null); // request id is reset
                     expect(layerOption.selected)
                         .toBe(false); // layer toggle no longer selected
 
+                    expect(sm.state.sideMetadata.active)
+                        .toBe(false);
+
                     done();
                 }
             });
+
             toggle.action(layer); // close metadata panel;
             rs.$digest();
 


### PR DESCRIPTION
A bit of reorganization of the statemanager: some code in toc handling data display (like metadata, filters) is abstracted and moved to a new service - `displayManager`.

`stateManager` handles layout - opening/closing panels, morphing between different views (filters panel).
`displayManager` handles the display of dynamically retrieved/generated data (layer metadata, attributes, details); it uses `stateManager` internally to open/close panels.

Suggestions are welcome.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/295)
<!-- Reviewable:end -->
