### PR TITLE
feat(geo): support more layer options from config

### DIFF
--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -217,7 +217,9 @@
         function generateLayer(layerConfig) {
             const handlers = {};
             const commonConfig = {
-                id: layerConfig.id
+                id: layerConfig.id,
+                visible: layerConfig.visibility === 'on',
+                opacity: layerConfig.opacity || 1
             };
 
             handlers[layerTypes.esriDynamic] = config => {
@@ -226,6 +228,9 @@
                 return l;
             };
             handlers[layerTypes.esriFeature] = config => {
+                commonConfig.mode = config.snapshot ?
+                    service.gapi.layer.FeatureLayer.MODE_SNAPSHOT :
+                    service.gapi.layer.FeatureLayer.MODE_ONDEMAND;
                 const l = new service.gapi.layer.FeatureLayer(config.url, commonConfig);
                 identify.addFeatureLayer(l, config.name);
                 return l;

--- a/src/schema.json
+++ b/src/schema.json
@@ -196,6 +196,21 @@
                     ],
                     "description": "Visibility toggle in the layer selector and its current state."
                 },
+                "opacity": {
+                    "allOf": [
+                        { "$ref": "#/definitions/option" },
+                        {
+                            "properties": {
+                                "value": {
+                                    "type": "number",
+                                    "default": 1,
+                                    "description": "Specifies the opacity of the layer. Should be between 0 and 1 inclusively."
+                                }
+                            }
+                        }
+                    ],
+                    "description": "FIXME: Specifies the opacity of the layer."
+                },
                 "query": {
                     "allOf": [
                         { "$ref": "#/definitions/option" },

--- a/src/schema.json
+++ b/src/schema.json
@@ -209,7 +209,7 @@
                             }
                         }
                     ],
-                    "description": "FIXME: Specifies the opacity of the layer."
+                    "description": "Specifies the opacity of the layer."
                 },
                 "query": {
                     "allOf": [


### PR DESCRIPTION
Add layer opacity to schema
Support layer visibility, opacity, and snapshot/onDemand from config

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/343)
<!-- Reviewable:end -->
