### PR TITLE
feat(geo): better asynch for attribute load

### DIFF
--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -29,7 +29,6 @@
             epsgLookup,
             getFormattedAttributes,
             registerLayer,
-            registerAttributes,
             setZoom,
             shiftZoom,
             selectBasemap,
@@ -129,28 +128,6 @@
         }
 
         /**
-         * Adds an attribute dataset to the layers registry
-         * @param  {promise} attribData a promise resolving in an attribute dataset
-         */
-        function registerAttributes(attribData) {
-            // FIXME this function may be obsolete? if not, update doc and code to be $q compliant.
-            // TODO determine the proper docstrings for a non-service function that lives in a service
-
-            if (!attribData.layerId) {
-                // TODO replace with proper error handling mechanism
-                console.log('Error: attempt to register attribute dataset without layerId property');
-            }
-
-            if (!service.layers[attribData.layerId]) {
-                // TODO replace with proper error handling mechanism
-                console.log('Error: attempt to register layer attributes against unregistered layer.  id: ' +
-                    attribData.layerId);
-            }
-
-            service.layers[attribData.layerId].attribs = attribData;
-        }
-
-        /**
          * Returns nicely bundled attributes for the layer described by layerId.
          * The bundles are used in the datatable.
          *
@@ -184,25 +161,12 @@
                 // used to track order of columns
                 const columnOrder = [];
 
+                identify = identifyService(service.gapi, map, service.layers);
+
                 // get the attribute keys to use as column headers
                 Object.keys(first.attributes)
                     .forEach((key, index) => {
-                        let title = key;
-
-                        // search for aliases
-                        // TODO add IE polyfill for array.find and use it instead of array.every
-                        // TODO duplicate alias search code as found in indentify.service. refactor to be in magic angular shared location
-                        if (attr.fields) {
-                            attr.fields.every(function (field) {
-                                if (field.name === key) {
-                                    if (field.alias && field.alias.length > 0) {
-                                        title = field.alias;
-                                    }
-                                    return false; // break the loop
-                                }
-                                return true; // keep looping
-                            });
-                        }
+                        const title = identify.aliasedFieldName(key, attr.fields);
 
                         columns[index] = {
                             title

--- a/src/app/geo/geo.service.spec.js
+++ b/src/app/geo/geo.service.spec.js
@@ -1,4 +1,4 @@
-/* global bard, geoService, $httpBackend */
+/* global bard, geoService, $httpBackend, $q */
 
 describe('geo', () => {
 
@@ -7,7 +7,7 @@ describe('geo', () => {
         bard.appModule('app.geo', 'app.common.router');
 
         // inject services
-        bard.inject('geoService', '$httpBackend');
+        bard.inject('geoService', '$httpBackend', '$q');
         geoService.promise.then(() => done());
     });
 
@@ -46,8 +46,7 @@ describe('geo', () => {
                 .toBe('on');
         });
 
-        // FIXME re-enable and correct this test once getFormattedAttributes is migrated
-        xit('should bundle attributes correctly', () => {
+        it('should bundle attributes correctly', () => {
             let tempLayer = {
                 id: 'sausages',
                 setVisibility: () => {}
@@ -55,9 +54,7 @@ describe('geo', () => {
             let tempConfig = {
                 url: 'http://www.sausagelayer.com/'
             };
-            geoService.registerLayer(tempLayer, tempConfig);
-
-            let tempAttribs = {
+            let tempAttribPromise = $q.resolve({
                 layerId: 'sausages',
                 0: {
                     features: [{
@@ -66,14 +63,16 @@ describe('geo', () => {
                         }
                     }]
                 }
-            };
-            geoService.registerAttributes(tempAttribs);
+            });
 
-            let bundledAttributes = geoService.getFormattedAttributes(tempLayer.id, '0');
-            expect(bundledAttributes.data)
-                .toBeDefined();
-            expect(bundledAttributes.columns)
-                .toBeDefined();
+            geoService.registerLayer(tempLayer, tempConfig, tempAttribPromise);
+
+            geoService.getFormattedAttributes(tempLayer.id, '0').then(bundledAttributes => {
+                expect(bundledAttributes.data)
+                    .toBeDefined();
+                expect(bundledAttributes.columns)
+                    .toBeDefined();
+            });
         });
 
         it('should set zoom correctly', () => {

--- a/src/app/geo/geo.service.spec.js
+++ b/src/app/geo/geo.service.spec.js
@@ -46,32 +46,6 @@ describe('geo', () => {
                 .toBe('on');
         });
 
-        // TODO if we decide registerAttributes is obsolete, remove this test
-        /*
-        // check registering a attribute object
-        it('should register attributes', () => {
-            let tempLayer = {
-                id: 'sausages',
-                setVisibility: () => {}
-            };
-            let tempConfig = {
-                url: 'http://www.sausagelayer.com/'
-            };
-            geoService.registerLayer(tempLayer, tempConfig, {});
-
-            let tempAttribs = {
-                layerId: 'sausages'
-            };
-            geoService.registerAttributes(tempAttribs);
-
-            // attribute object is attached to correct layer
-            expect(geoService.layers.sausages.attribs)
-                .toBeDefined();
-            expect(geoService.layers.sausages.attribs.layerId)
-                .toBe('sausages');
-        });
-        */
-
         // FIXME re-enable and correct this test once getFormattedAttributes is migrated
         xit('should bundle attributes correctly', () => {
             let tempLayer = {

--- a/src/app/geo/geo.service.spec.js
+++ b/src/app/geo/geo.service.spec.js
@@ -22,7 +22,7 @@ describe('geo', () => {
             let tempConfig = {
                 url: 'http://www.sausagelayer.com/'
             };
-            geoService.registerLayer(tempLayer, tempConfig);
+            geoService.registerLayer(tempLayer, tempConfig, {});
 
             // layer is now in registry
             expect(geoService.layers.sausages)
@@ -32,6 +32,8 @@ describe('geo', () => {
             expect(geoService.layers.sausages.layer.id)
                 .toBe('sausages');
             expect(geoService.layers.sausages.state)
+                .toBeDefined();
+            expect(geoService.layers.sausages.attribs)
                 .toBeDefined();
             expect(geoService.layers.sausages.state.url)
                 .toBe('http://www.sausagelayer.com/');
@@ -44,6 +46,8 @@ describe('geo', () => {
                 .toBe('on');
         });
 
+        // TODO if we decide registerAttributes is obsolete, remove this test
+        /*
         // check registering a attribute object
         it('should register attributes', () => {
             let tempLayer = {
@@ -53,7 +57,7 @@ describe('geo', () => {
             let tempConfig = {
                 url: 'http://www.sausagelayer.com/'
             };
-            geoService.registerLayer(tempLayer, tempConfig);
+            geoService.registerLayer(tempLayer, tempConfig, {});
 
             let tempAttribs = {
                 layerId: 'sausages'
@@ -66,7 +70,10 @@ describe('geo', () => {
             expect(geoService.layers.sausages.attribs.layerId)
                 .toBe('sausages');
         });
+        */
 
+        /*
+        // FIXME re-enable and correct this test once getFormattedAttributes is migrated
         it('should bundle attributes correctly', () => {
             let tempLayer = {
                 id: 'sausages',
@@ -95,6 +102,7 @@ describe('geo', () => {
             expect(bundledAttributes.columns)
                 .toBeDefined();
         });
+        */
 
         it('should set zoom correctly', () => {
             // make a fake map object

--- a/src/app/geo/geo.service.spec.js
+++ b/src/app/geo/geo.service.spec.js
@@ -72,9 +72,8 @@ describe('geo', () => {
         });
         */
 
-        /*
         // FIXME re-enable and correct this test once getFormattedAttributes is migrated
-        it('should bundle attributes correctly', () => {
+        xit('should bundle attributes correctly', () => {
             let tempLayer = {
                 id: 'sausages',
                 setVisibility: () => {}
@@ -102,7 +101,6 @@ describe('geo', () => {
             expect(bundledAttributes.columns)
                 .toBeDefined();
         });
-        */
 
         it('should set zoom correctly', () => {
             // make a fake map object

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -224,7 +224,7 @@
                             const attribSet = attribsBundle[attribsBundle.indexes[0]];
 
                             // queryFeatures returns a dojo-style promise, so cannot use .catch
-                            layer.queryFeatures(qry).then(queryResult => {
+                            $q.resolve(layer.queryFeatures(qry)).then(queryResult => {
 
                                 // transform attributes of query results into {name,data} objects
                                 // one object per queried feature
@@ -248,7 +248,7 @@
                                 result.isLoading = false;
                                 resolve(true);
 
-                            }, err => {
+                            }).catch(err => {
                                 console.warn('Layer query failed');
                                 console.warn(err);
                                 result.data = JSON.stringify(err);

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -32,12 +32,38 @@
                  * @param {Object} layer an ESRI FeatureLayer object
                  * @param {String} name the display name of the layer
                  */
-                addFeatureLayer: (layer, name) => featureLayers.push({ layer, name })
+                addFeatureLayer: (layer, name) => featureLayers.push({ layer, name }),
+
+                aliasedFieldName
 
             };
         };
 
         /******/
+
+        /**
+         * Get the best user-friendly name of a field. Uses alias if alias is defined, else uses the system attribute name.
+         * @param {String} attribName the attribute name we want a nice name for
+         * @param {Object} fields array of field definitions. the attribute should belong to the provided set of fields
+         */
+        function aliasedFieldName(attribName, fields) {
+            let fName = attribName;
+
+            // search for aliases
+            // TODO add IE polyfill for array.find and use it instead of array.every
+            if (fields) {
+                fields.every(function (field) {
+                    if (field.name === attribName) {
+                        if (field.alias && field.alias.length > 0) {
+                            fName = field.alias;
+                        }
+                        return false; // break the loop
+                    }
+                    return true; // keep looping
+                });
+            }
+            return fName;
+        }
 
         // returns the number of visible layers that have been registered with the identify service
         function getVisibleLayers() {
@@ -53,21 +79,7 @@
             // simple array of text mapping for demonstration purposes. fancy grid formatting later?
 
             return Object.keys(attribs).map(key => {
-                let fieldName = key;
-
-                // search for aliases
-                // TODO add IE polyfill for array.find and use it instead of array.every
-                if (fields) {
-                    fields.every(function (field) {
-                        if (field.name === key) {
-                            if (field.alias && field.alias.length > 0) {
-                                fieldName = field.alias;
-                            }
-                            return false; // break the loop
-                        }
-                        return true; // keep looping
-                    });
-                }
+                let fieldName = aliasedFieldName(key, fields);
 
                 // FIXME change this output into a tabular format that is compatible with the detail pane (format yet to be decided)
                 return `${fieldName} - ${attribs[key]}`;

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -50,17 +50,13 @@
             let fName = attribName;
 
             // search for aliases
-            // TODO add IE polyfill for array.find and use it instead of array.every
             if (fields) {
-                fields.every(function (field) {
-                    if (field.name === attribName) {
-                        if (field.alias && field.alias.length > 0) {
-                            fName = field.alias;
-                        }
-                        return false; // break the loop
-                    }
-                    return true; // keep looping
+                const attribField = fields.find(field => {
+                    return field.name === attribName;
                 });
+                if (attribField && attribField.alias && attribField.alias.length > 0) {
+                    fName = attribField.alias;
+                }
             }
             return fName;
         }

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -978,6 +978,7 @@
 
             // temporary data loading
             // FIXME: remove default ecogeo data once filters is disabled for layers with no attribs
+            // TODO have getFormattedAttributes return a promise, remove timeout
             const newData = $timeout(() => {
                 const attrs = geoService.layers[layer.id] && geoService.layers[layer.id].attribs ?
                     geoService.getFormattedAttributes(layer.id, geoService.layers[layer.id].attribs.indexes[

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -977,7 +977,7 @@
             };
 
             // wait for attributes to be loaded, then process them into grid format
-            const newData = geoService.layers[layer.id].attribs.then(attribBundle => {
+            const dataPromise = geoService.layers[layer.id].attribs.then(attribBundle => {
                 let layerId = layer.id;
                 let layerIdx;
 
@@ -993,20 +993,20 @@
                     layerIdx = attribBundle.indexes[0];
                 }
 
-                return geoService.getFormattedAttributes(layerId, layerIdx).then(attrs => {
-                    return {
-                        data: {
-                            // TODO investigate .isNumber call.  layer.id is generally never a number
-                            columns: attrs.columns.slice(0, ((angular.isNumber(layer.id) ? layer.id : 0) + 1) *
-                                5),
-                            data: attrs.data.slice(0, ((angular.isNumber(layer.id) ? layer.id : 0) + 1) * 50),
+                return geoService.getFormattedAttributes(layerId, layerIdx);
+            }).then(attrs => {
+                return {
+                    data: {
+                        // TODO remove .isNumber stuff once proper table support is completed
+                        columns: attrs.columns.slice(0, ((angular.isNumber(layer.id) ? layer.id : 0) + 1) *
+                            5),
+                        data: attrs.data.slice(0, ((angular.isNumber(layer.id) ? layer.id : 0) + 1) * 50),
 
-                            // FIXME: this after dynamic layer index gets refactored to proper separate layers
-                            featureIndex: '0'
-                        },
-                        isLoaded: false
-                    };
-                });
+                        // FIXME: this after dynamic layer index gets refactored to proper separate layers
+                        featureIndex: '0'
+                    },
+                    isLoaded: false
+                };
             });
 
             stateManager.setActive({
@@ -1016,7 +1016,7 @@
                 .setActive({
                     side: false
                 })
-                .then(() => stateManager.toggleDisplayPanel('filtersFulldata', newData, requester, 0));
+                .then(() => stateManager.toggleDisplayPanel('filtersFulldata', dataPromise, requester, 0));
         }
 
         /**


### PR DESCRIPTION
This Pull Request (for now) is to get feedback on the changes to layer attributes.  If the team is OK with it, another commit will be done to align the grid load and any .spec tests with the changes.  Online docs will also be updated

Summary: the `.attribs` property of the entry in the layer registry is now a promise that resolves with the attribute bundle.  Previously the property would be undefined while loading, then set to the bundle outright.

It now makes it easier for code using the attributes to wait for them to load.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/364)
<!-- Reviewable:end -->
