### PR TITLE
Proposal: split geoService !important

### DIFF
--- a/gulp.config.js
+++ b/gulp.config.js
@@ -40,11 +40,11 @@ module.exports = function () {
             '!' + app + '**/*.spec.js'
         ],
         jsOrder: [
-            '**/app.module.js',
-            '**/*.module.js',
-            '**/!(app-seed).js',
-            '**/*.js',
-            '**/app-seed.js'
+            'lib.js',
+            'global-registry.js',
+            'app.js',
+            'templates.js',
+            'app-seed.js'
         ],
 
         // please rename if there are better shorter names
@@ -63,6 +63,9 @@ module.exports = function () {
 
         // angular template cache file to be injected
         templates: tmp + 'templates.js',
+
+        jsAppSeed: app + 'app-seed.js', // initializes viewer instances
+        jsGlobalRegistry: app + 'global-registry.js', // create global registry; loads gapi, etc.
 
         jsInjectorFile: app + 'injector.js',
         jsInjectorFilePath: build + 'injector.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -228,16 +228,12 @@ gulp.task('jsrollup', 'Roll up all js into one file',
         const jslib = libbuild();
         const jscache = templatecache();
         const jsapp = jsbuild();
-        const seed = gulp.src(`${config.app}app-seed.js`); // app-seed `must` be the last item
+        const registry = gulp.src(config.jsGlobalRegistry); // global registry goes after the lib package
+        const seed = gulp.src(config.jsAppSeed); // app-seed `must` be the last item
 
         // merge all js streams to avoid writing individual files to disk
-        return merge(jslib, jscache, jsapp, seed) // merge doesn't guarantee file order :(
-            .pipe($.order([
-                'lib.js',
-                'app.js',
-                'templates.js',
-                'app-seed.js'
-            ]))
+        return merge(jslib, registry, jscache, jsapp, seed) // merge doesn't guarantee file order :(
+            .pipe($.order(config.jsOrder))
             .pipe($.concat(config.jsCoreFile))
             .pipe(gulp.dest(config.build));
     });

--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -73,8 +73,8 @@
             data: { },
             getCurrent,
             applyBasicDefaults, // silence JSHint since we might want this later after all the hacks are removed
-            initialize: initialize,
-            ready: ready
+            initialize,
+            ready
         };
 
         const partials = {}; // partial config promises, one array per language entry

--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -250,8 +250,8 @@
         }
         /**
          * Checks if the service is ready to use.
-         * @param  {object} nextPromises optional promises to be resolved before returning
-         * @return {object}              promise to be resolved on config service initialization
+         * @param  {Promise|Array} nextPromises optional promises to be resolved before returning
+         * @return {Promise}              promise to be resolved on config service initialization
          */
         function ready(nextPromises) {
             return initializePromise

--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -217,7 +217,7 @@
 
         /**
          * Returns the currently used config. Language is determined by asking $translate.
-         * @return {object}     The config object tied to the current language
+         * @return {Promise}     The config promise object tied to the current language resolving with that config
          */
         function getCurrent() {
             const currentLang = ($translate.proposedLanguage() || $translate.use()).split('-')[0];

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -13,10 +13,12 @@
         .module('app.core')
         .run(runBlock);
 
-    function runBlock(configService, $rootScope, $translate, $q, events, gapiService) {
-        const promises = [];
-        promises.push(gapiService.ready());
-        promises.push(configService.initialize());
+    function runBlock($rootScope, $translate, $q, events, configService, gapiService, mapService, geoService) {
+        const promises = [
+            gapiService.ready(),
+            configService.initialize(),
+            mapService.isReady
+        ];
 
         // wait on the config and geoapi
         $q.all(promises)
@@ -24,6 +26,7 @@
                 // initialize other services, if any
                 console.log('Config initialized');
                 $rootScope.$broadcast(events.rvReady);
+                geoService.buildMap();
             })
             .catch(reason => {
                 console.error('Everything broke');

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -26,7 +26,7 @@
                 // initialize other services, if any
                 console.log('Config initialized');
                 $rootScope.$broadcast(events.rvReady);
-                geoService.buildMap();
+                geoService.assembleMap();
             })
             .catch(reason => {
                 console.error('Everything broke');

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -13,11 +13,10 @@
         .module('app.core')
         .run(runBlock);
 
-    function runBlock($rootScope, $translate, $q, events, configService, gapiService, geoService) {
+    function runBlock($rootScope, $translate, $q, events, configService, gapiService) {
         const promises = [
             configService.initialize(),
-            gapiService.isReady,
-            geoService.isReady
+            gapiService.isReady
         ];
 
         // wait on the config and geoapi
@@ -25,7 +24,6 @@
             .then(() => {
                 // initialize other services, if any
                 console.log('Config initialized');
-                geoService.assembleMap();
                 $rootScope.$broadcast(events.rvReady);
             })
             .catch(reason => {

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -13,9 +13,9 @@
         .module('app.core')
         .run(runBlock);
 
-    function runBlock(configService, $rootScope, $translate, $q, events, geoService) {
+    function runBlock(configService, $rootScope, $translate, $q, events, gapi) {
         const promises = [];
-        promises.push(geoService.promise);
+        promises.push(gapi.ready());
         promises.push(configService.initialize());
 
         // wait on the config and geoapi

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -13,11 +13,11 @@
         .module('app.core')
         .run(runBlock);
 
-    function runBlock($rootScope, $translate, $q, events, configService, gapiService, mapService, geoService) {
+    function runBlock($rootScope, $translate, $q, events, configService, gapiService, geoService) {
         const promises = [
             configService.initialize(),
             gapiService.isReady,
-            mapService.isReady
+            geoService.isReady
         ];
 
         // wait on the config and geoapi

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -13,9 +13,9 @@
         .module('app.core')
         .run(runBlock);
 
-    function runBlock(configService, $rootScope, $translate, $q, events, gapi) {
+    function runBlock(configService, $rootScope, $translate, $q, events, gapiService) {
         const promises = [];
-        promises.push(gapi.ready());
+        promises.push(gapiService.ready());
         promises.push(configService.initialize());
 
         // wait on the config and geoapi

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -15,8 +15,8 @@
 
     function runBlock($rootScope, $translate, $q, events, configService, gapiService, mapService, geoService) {
         const promises = [
-            gapiService.ready(),
             configService.initialize(),
+            gapiService.isReady,
             mapService.isReady
         ];
 

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -25,8 +25,8 @@
             .then(() => {
                 // initialize other services, if any
                 console.log('Config initialized');
-                $rootScope.$broadcast(events.rvReady);
                 geoService.assembleMap();
+                $rootScope.$broadcast(events.rvReady);
             })
             .catch(reason => {
                 console.error('Everything broke');

--- a/src/app/core/global-registry.service.js
+++ b/src/app/core/global-registry.service.js
@@ -1,0 +1,17 @@
+(() => {
+    'use strict';
+
+    /**
+     * @ngdoc service
+     * @name globalRegistry
+     * @module app.core
+     * @description
+     *
+     * The `globalRegistry` constant wraps around RV global registry for a single point of reference. Use this to access `RV` global.
+     * It's useful if we need to change the name of the global registry.
+     *
+     */
+    angular
+        .module('app.core')
+        .constant('globalRegistry', window.RV);
+})();

--- a/src/app/geo/gapi.service.js
+++ b/src/app/geo/gapi.service.js
@@ -1,4 +1,3 @@
-/* global RV */
 (() => {
     'use strict';
 
@@ -16,25 +15,24 @@
         .module('app.geo')
         .factory('gapiService', gapi);
 
-    function gapi($q) {
-        // wait for `gapiPromise` from the global registry to resolve
-        const initializePromise = RV.gapiPromise;
-
+    function gapi($q, globalRegistry) {
         const service = {
             gapi: null, // actual gapi interface; available after gapiPromise resovles
-            ready
+            isReady: null
         };
+
+        init();
 
         return service;
 
         /***/
 
         /**
-         * Checks if the service is ready to use.
-         * @return {Promise} promise to be resolved when gapi loads
+         * Sets `isReady` promise which is resolved when gapi loads
          */
-        function ready() {
-            return initializePromise
+        function init() {
+            // wait for `gapiPromise` from the global registry to resolve
+            service.isReady = globalRegistry.gapiPromise
                 .then(gapi => {
                     service.gapi = gapi;
                     console.info('gapi is ready');

--- a/src/app/geo/gapi.service.js
+++ b/src/app/geo/gapi.service.js
@@ -14,7 +14,7 @@
      */
     angular
         .module('app.geo')
-        .factory('gapi', gapi);
+        .factory('gapiService', gapi);
 
     function gapi($q) {
         // wait for `gapiPromise` from the global registry to resolve

--- a/src/app/geo/gapi.service.js
+++ b/src/app/geo/gapi.service.js
@@ -1,0 +1,48 @@
+/* global RV */
+(() => {
+    'use strict';
+
+    /**
+     * @ngdoc service
+     * @name gapi
+     * @module app.geo
+     * @requires $q
+     * @description
+     *
+     * The `gapi` factory exposes `geoApi` interface after it's loaded. Modules should not access `gapi` property before it's set. It's safe though since `core.run` block waits for `gapi` to be ready before kicking in the app into gear.
+     *
+     */
+    angular
+        .module('app.geo')
+        .factory('gapi', gapi);
+
+    function gapi($q) {
+        // wait for `gapiPromise` from the global registry to resolve
+        const initializePromise = RV.gapiPromise;
+
+        const service = {
+            gapi: null, // actual gapi interface; available after gapiPromise resovles
+            ready
+        };
+
+        return service;
+
+        /***/
+
+        /**
+         * Checks if the service is ready to use.
+         * @return {Promise} promise to be resolved when gapi loads
+         */
+        function ready() {
+            return initializePromise
+                .then(gapi => {
+                    service.gapi = gapi;
+                    console.info('gapi is ready');
+                    return $q.resolve(null);
+                })
+                .catch(() => {
+                    console.error('gapi is not ready :(');
+                });
+        }
+    }
+})();

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -165,7 +165,7 @@
                 // used to track order of columns
                 const columnOrder = [];
 
-                identify = identifyService(gapi.gapi, map, service.layers);
+                identify = identifyService(map, service.layers);
 
                 // get the attribute keys to use as column headers
                 Object.keys(first.attributes)
@@ -300,7 +300,7 @@
             if (config.services && config.services.proxyUrl) {
                 gapi.gapi.mapManager.setProxy(config.services.proxyUrl);
             }
-            identify = identifyService(gapi.gapi, map, service.layers);
+            identify = identifyService(map, service.layers);
 
             config.layers.forEach(layerConfig => {
                 const l = generateLayer(layerConfig);

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -103,7 +103,9 @@
          * TODO: break this function and move some of it (stuff related to actual map building) to `mapService.buildMapObject` function
          */
         function assembleMap() {
-            const state = {
+            // reuse the previous state or create the new one
+            // when reusing existing state, its map will be destroyed
+            const state = service.state || {
                 mapNode: ref.mapNode
             };
 

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -1,4 +1,4 @@
-/* global geoapi */
+/* global RV */
 (() => {
     'use strict';
 
@@ -46,7 +46,12 @@
         let fullExtent = null;
 
         // FIXME: need to find a way to have the dojo URL set by the config
-        service.promise = geoapi('http://js.arcgis.com/3.14/', window)
+        // service.promise = geoapi('http://js.arcgis.com/3.14/', window)
+        //    .then(initializedGeoApi => service.gapi = initializedGeoApi);
+
+        // console.log(RV);
+        // use RV registry to get gapiPromise
+        service.promise = RV.gapiPromise
             .then(initializedGeoApi => service.gapi = initializedGeoApi);
 
         return service;

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -22,13 +22,8 @@
         // Add a function to update the layer order. This function will raise a change event so other interested
         // pieces of code can react to the change in the order
 
-        const ref = {
-            mapNode: null
-        };
-
         const service = {
-            isReady: null,
-            registerMapNode: null,
+            isReady: false, // flag indicating that the map is ready
 
             epsgLookup,
             assembleMap,
@@ -36,31 +31,7 @@
             state: null
         };
 
-        init();
-
         return service;
-
-        /**
-         * Sets an `isReady` promise resolving when the map node is registered.
-         */
-        function init() {
-            service.isReady =
-                $q(resolve =>
-                    service.registerMapNode = (node => registerMapNode(resolve, node))
-                );
-        }
-
-        /**
-         * Stores a reference to the map node.
-         * @param  {Function} resolve function to resolve ready promise
-         * @param  {Object} node    dom node to build the map on
-         */
-        function registerMapNode(resolve, node) {
-            if (ref.mapNode === null) {
-                ref.mapNode = node;
-                resolve();
-            }
-        }
 
         /**
          * Lookup a proj4 style projection definition for a given ESPG code.
@@ -99,15 +70,18 @@
 
         /**
          * Constructs a map on the given DOM node given the current config object.
+         * @param  {Object} mapNode    dom node to build the map on; need to be specified only the first time the map is created;
          * @return {Promise} resolving when all the map building is done
          * TODO: break this function and move some of it (stuff related to actual map building) to `mapService.buildMapObject` function
          */
-        function assembleMap() {
+        function assembleMap(mapNode) {
             // reuse the previous state or create the new one
             // when reusing existing state, its map will be destroyed
             const state = service.state || {
-                mapNode: ref.mapNode
+                mapNode: mapNode
             };
+
+            service.isReady = false;
 
             // assemble geo state object
             return mapService(state)
@@ -127,8 +101,8 @@
                     // expose idenitifyService on geoService
                     angular.extend(service, id);
 
-                    // store geo state
-                    service.state = state;
+                    service.state = state; // store geo state
+                    service.isReady = true;
 
                     return service;
                 })

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -23,7 +23,7 @@
         // pieces of code can react to the change in the order
 
         const service = {
-            isReady: false, // flag indicating that the map is ready
+            isMapReady: false, // flag indicating that the map is ready
 
             epsgLookup,
             assembleMap,
@@ -70,9 +70,15 @@
 
         /**
          * Constructs a map on the given DOM node given the current config object.
+         * When switching languages, switch language using `$translate` and call `assembleMap` without parameters. This will rebuild the map using the exising map node.
+         *
+         * ```js
+         * $translate.use(lang);
+         * geoService.assembleMap();
+         * ```
+         *
          * @param  {Object} mapNode    dom node to build the map on; need to be specified only the first time the map is created;
          * @return {Promise} resolving when all the map building is done
-         * TODO: break this function and move some of it (stuff related to actual map building) to `mapService.buildMapObject` function
          */
         function assembleMap(mapNode) {
             // reuse the previous state or create the new one
@@ -80,8 +86,6 @@
             const state = service.state || {
                 mapNode: mapNode
             };
-
-            service.isReady = false;
 
             // assemble geo state object
             return mapService(state)
@@ -102,7 +106,7 @@
                     angular.extend(service, id);
 
                     service.state = state; // store geo state
-                    service.isReady = true;
+                    service.isMapReady = true;
 
                     return service;
                 })

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -76,10 +76,8 @@
          * TODO: refactor this behemoth
          */
         function buildMap() {
-            console.log('BBBBBBBBBBBBBB');
             return configService.getCurrent()
                 .then(config => {
-                    console.log('AAAAAAAAAA', config);
 
                     // reset before rebuilding the map
                     if (mapService.map !== null) {
@@ -88,7 +86,7 @@
                         mapService.map.mapManager.OverviewMapControl.destroy();
                         mapService.map.mapManager.ScalebarControl.destroy();
                         mapService.map = null;
-                        layerRegistry.layers = {};
+                        layerRegistry.reset();
                     }
 
                     // FIXME remove the hardcoded settings when we have code which does this properly
@@ -203,6 +201,10 @@
                     window.FGPV = {
                         layers: service.layers
                     };
+                })
+                .catch(error => {
+                    console.error('Failed to build the map');
+                    console.error(error);
                 });
         }
 

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -5,6 +5,7 @@
      * @ngdoc service
      * @name geoService
      * @module app.geo
+     * @requires $http, $q, gapiService, mapService, layerRegistry, configService, identifyService
      *
      * @description
      * `geoService` wraps all calls to geoapi and also tracks the state of anything map related
@@ -23,7 +24,7 @@
 
         const service = {
             epsgLookup,
-            buildMap,
+            assembleMap,
             setZoom,
             shiftZoom,
             selectBasemap,
@@ -70,12 +71,11 @@
         }
 
         /**
-         * Constructs a map on the given DOM node.
-         * @param {object} config the map configuration based on the configuration schema
+         * Constructs a map on the given DOM node given the current config object.
          * @return {Promise} resolving when all the map building is done
-         * TODO: refactor this behemoth
+         * TODO: break this function and move some of it (stuff related to actual map building) to `mapService.buildMapObject` function
          */
-        function buildMap() {
+        function assembleMap() {
             return configService.getCurrent()
                 .then(config => {
 
@@ -118,7 +118,8 @@
                                     // FIXME if layer type is not an attribute-having type (WMS, Tile, Image, Raster, more?), resolve an empty attribute set instead
 
                                     // get the attributes for the layer
-                                    const a = gapiService.gapi.attribs.loadLayerAttribs(l);
+                                    const a = gapiService.gapi.attribs.loadLayerAttribs(
+                                        l);
 
                                     a
                                         .then(data => {

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -72,7 +72,7 @@
                 // get the attribute keys to use as column headers
                 Object.keys(first.attributes)
                     .forEach((key, index) => {
-                        const title = identifyService(layerRegistry.layers).aliasedFieldName(key, attr.fields);
+                        const title = identifyService.aliasedFieldName(key, attr.fields);
 
                         columns[index] = {
                             title
@@ -162,9 +162,12 @@
                         gapiService.gapi.mapManager.setProxy(config.services.proxyUrl);
                     }
 
+                    // init idenitfy service when a new map is created
+                    identifyService.init();
+
                     config.layers.forEach(layerConfig => {
                         // TODO: decouple identifyservice from everything
-                        const l = layerRegistry.generateLayer(layerConfig, map);
+                        const l = layerRegistry.generateLayer(layerConfig);
                         const pAttrib = $q((resolve, reject) => { // handles the asynch loading of attributes
 
                             // TODO investigate potential issue -- load event finishes prior to this event registration, thus attributes are never loaded

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -23,7 +23,6 @@
 
         const service = {
             epsgLookup,
-            getFormattedAttributes,
             buildMap,
             setZoom,
             shiftZoom,
@@ -34,66 +33,6 @@
         };
 
         return service;
-
-        /**
-         * Returns nicely bundled attributes for the layer described by layerId.
-         * The bundles are used in the datatable.
-         *
-         * @param   {String} layerId        The id for the layer
-         * @param   {String} featureIndex   The index for the feature (attribute set) within the layer
-         * @return  {Promise}               Resolves with the column headers and data to show in the datatable
-         */
-        function getFormattedAttributes(layerId, featureIndex) {
-            // FIXME change to new promise format of attributes.  return a promise from this function.
-
-            if (!layerRegistry.layers[layerId]) {
-                throw new Error('Cannot get attributes for unregistered layer');
-            }
-
-            // waits for attributes to be loaded, then resolves with formatted data
-            return layerRegistry.layers[layerId].attribs.then(attribBundle => {
-                if (!attribBundle[featureIndex] || attribBundle[featureIndex].features.length === 0) {
-                    throw new Error('Cannot get attributes for feature set that does not exist');
-                }
-
-                // get the attributes and single out the first one
-                const attr = attribBundle[featureIndex];
-                const first = attr.features[0];
-
-                // columns for the data table
-                const columns = [];
-
-                // data for the data table
-                const data = [];
-
-                // used to track order of columns
-                const columnOrder = [];
-
-                // get the attribute keys to use as column headers
-                Object.keys(first.attributes)
-                    .forEach((key, index) => {
-                        const title = identifyService.aliasedFieldName(key, attr.fields);
-
-                        columns[index] = {
-                            title
-                        };
-                        columnOrder[index] = key;
-                    });
-
-                // get the attribute data from every feature
-                attr.features.forEach((feat, index) => {
-                    data[index] = [];
-                    angular.forEach(feat.attributes, (value, key) => {
-                        data[index][columnOrder.indexOf(key)] = value;
-                    });
-                });
-
-                return {
-                    columns,
-                    data
-                };
-            });
-        }
 
         /**
          * Lookup a proj4 style projection definition for a given ESPG code.
@@ -133,11 +72,15 @@
         /**
          * Constructs a map on the given DOM node.
          * @param {object} config the map configuration based on the configuration schema
+         * @return {Promise} resolving when all the map building is done
          * TODO: refactor this behemoth
          */
         function buildMap() {
-            configService.getCurrent()
+            console.log('BBBBBBBBBBBBBB');
+            return configService.getCurrent()
                 .then(config => {
+                    console.log('AAAAAAAAAA', config);
+
                     // reset before rebuilding the map
                     if (mapService.map !== null) {
                         // NOTE: Possible to have dom listeners stick around after the node is destroyed

--- a/src/app/geo/geo.service.spec.js
+++ b/src/app/geo/geo.service.spec.js
@@ -54,7 +54,6 @@ describe('geo', () => {
             // set a spy on it
             spyOn(map, 'setZoom');
 
-            geoService.registerMapNode({});
             configService.setCurrent({
                 layers: [],
                 map: {
@@ -73,7 +72,7 @@ describe('geo', () => {
             });
 
             // create a fake map
-            geoService.assembleMap()
+            geoService.assembleMap({})
                 .then(() => {
                     // call setZoom with different arguments
 
@@ -132,9 +131,8 @@ describe('geo', () => {
                 spyOn(m, 'Map')
                     .and.callThrough();
 
-                geoService.registerMapNode(el[0]);
                 configService.setCurrent(emptyConfig);
-                geoService.assembleMap()
+                geoService.assembleMap(el[0])
                     .then(() => {
                         console.log('map is done');
                         expect(m.Map)

--- a/src/app/geo/geo.service.spec.js
+++ b/src/app/geo/geo.service.spec.js
@@ -73,7 +73,7 @@ describe('geo', () => {
             });
 
             // create a fake map
-            geoService.buildMap()
+            geoService.assembleMap()
                 .then(() => {
                     // call setZoom with different arguments
 
@@ -134,7 +134,7 @@ describe('geo', () => {
 
                 mapService.registerMapNode(el[0]);
                 configService.setCurrent(emptyConfig);
-                geoService.buildMap()
+                geoService.assembleMap()
                     .then(() => {
                         console.log('map is done');
                         expect(m.Map)
@@ -151,7 +151,7 @@ describe('geo', () => {
                 spyOn(l, 'FeatureLayer');
                 spyOn(l, 'WmsLayer');
                 spyOn(l, 'ArcGISDynamicMapServiceLayer');
-                geoService.buildMap(el[0], layerConfig);
+                geoService.assembleMap(el[0], layerConfig);
                 expect(l.FeatureLayer)
                     .toHaveBeenCalled();
                 expect(l.WmsLayer)

--- a/src/app/geo/geo.service.spec.js
+++ b/src/app/geo/geo.service.spec.js
@@ -1,4 +1,4 @@
-/* global bard, geoService, gapiService, $rootScope, configService, mapService, $httpBackend */
+/* global bard, geoService, gapiService, $rootScope, configService, $httpBackend */
 
 describe('geo', () => {
 
@@ -44,7 +44,7 @@ describe('geo', () => {
         bard.appModule('app.geo', 'app.common.router', mockGapiService, mockConfigService);
 
         // inject services
-        bard.inject('geoService', 'gapiService', '$rootScope', 'mapService', 'configService',
+        bard.inject('geoService', 'gapiService', '$rootScope', 'configService',
             '$httpBackend');
     });
 
@@ -54,7 +54,7 @@ describe('geo', () => {
             // set a spy on it
             spyOn(map, 'setZoom');
 
-            mapService.registerMapNode({});
+            geoService.registerMapNode({});
             configService.setCurrent({
                 layers: [],
                 map: {
@@ -132,7 +132,7 @@ describe('geo', () => {
                 spyOn(m, 'Map')
                     .and.callThrough();
 
-                mapService.registerMapNode(el[0]);
+                geoService.registerMapNode(el[0]);
                 configService.setCurrent(emptyConfig);
                 geoService.assembleMap()
                     .then(() => {

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -11,13 +11,13 @@
         .module('app.geo')
         .factory('identifyService', identifyService);
 
-    function identifyService(stateManager, $q) {
+    function identifyService($q, gapi, stateManager) {
 
         const dynamicLayers = [];
         const featureLayers = [];
 
-        return (geoApi, map, layerRegistry) => {
-            geoApi.events.wrapEvents(map, { click: clickHandlerBuilder(geoApi, map, layerRegistry) });
+        return (map, layerRegistry) => {
+            gapi.gapi.events.wrapEvents(map, { click: clickHandlerBuilder(map, layerRegistry) });
 
             return {
                 /**
@@ -103,12 +103,12 @@
         // will make an extent around a point, that is appropriate for the current map scale.
         // makes it easier for point clicks to instersect
         // the tolerance is distance in pixels from mouse point that qualifies as a hit
-        function makeClickBuffer(point, geoApi, map, tolerance = 5) {
+        function makeClickBuffer(point, map, tolerance = 5) {
             // take pixel tolerance, convert to map units at current scale. x2 to turn radius into diameter
             const buffSize = 2 * tolerance * map.extent.getWidth() / map.width;
 
             // Build tolerance envelope of correct size
-            const cBuff = new geoApi.mapManager.Extent(1, 1, buffSize, buffSize, point.spatialReference);
+            const cBuff = new gapi.gapi.mapManager.Extent(1, 1, buffSize, buffSize, point.spatialReference);
 
             // move the envelope so it is centered around the point
             return cBuff.centerAt(point);
@@ -123,7 +123,7 @@
             }
         }
 
-        function clickHandlerBuilder(geoApi, map, layerRegistry) {
+        function clickHandlerBuilder(map, layerRegistry) {
 
             /**
              * Handles global map clicks.  Currently configured to walk through all registered dynamic
@@ -163,7 +163,7 @@
                     };
                     opts.tolerance = getTolerance(layerRegistry, layer);
                     details.data.push(result);
-                    return geoApi.layer.serverLayerIdentify(layer, opts)
+                    return gapi.gapi.layer.serverLayerIdentify(layer, opts)
                         .then(clickResults => {
                             console.log('got a click result');
                             console.log(clickResults);
@@ -214,10 +214,9 @@
                     details.data.push(result);
 
                     // run a spatial query
-                    const qry = new geoApi.layer.Query();
+                    const qry = new gapi.gapi.layer.Query();
                     qry.outFields = ['*']; // this will result in just objectid fields, as that is all we have in feature layers
-                    qry.geometry = makeClickBuffer(clickEvent.mapPoint, geoApi, map,
-                        getTolerance(layerRegistry, layer));
+                    qry.geometry = makeClickBuffer(clickEvent.mapPoint, map, getTolerance(layerRegistry, layer));
 
                     return $q((resolve, reject) => {
 

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -9,280 +9,319 @@
      */
     angular
         .module('app.geo')
-        .factory('identifyService', identifyService);
+        .factory('identifyService', identifyServiceFactory);
 
-    function identifyService($q, gapiService, mapService, layerRegistry, stateManager, layerTypes) {
+    function identifyServiceFactory($q, gapiService, stateManager, layerTypes) {
+        return geoState => identifyService(geoState);
 
-        const service = {
-            init
-        };
+        function identifyService(geoState) {
 
-        return service;
+            // commonly used references
+            const ref = {
+                map: geoState.mapService.mapObject,
+                layerRegistry: geoState.layerRegistry,
+                layers: geoState.layerRegistry.layers
+            };
 
-        /***/
+            return init();
 
-        /**
-         * Initializes identify service. This needs to be called everytime the map is created.
-         */
-        function init() {
-            gapiService.gapi.events.wrapEvents(
-                mapService.map, { click: clickHandlerBuilder(mapService.map) });
-        }
-
-        /**
-         * Retrieves dynamic layers
-         * @return {Array} array of dynamic layers
-         */
-        function getDynamicLayers() {
-            console.log(layerRegistry.layers);
-
-            // TODO: Pretty experimental, but how about Object.entries instead of having to go with keys().map(key => object)?
-            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
-            // TODO: this and `getFeatureLayers` might be simplified and moved to the `layerRegistry`
-            return Object.keys(layerRegistry.layers)
-                .map(key => layerRegistry.layers[key])
-                .filter(layer => layer.state.layerType === layerTypes.esriDynamic);
-        }
-
-        /**
-         * Retrieves feature layers
-         * @return {Array} array of feature layers
-         */
-        function getFeatureLayers() {
-            console.log(layerRegistry.layers);
-            return Object.keys(layerRegistry.layers)
-                .map(key => layerRegistry.layers[key])
-                .filter(layer => layer.state.layerType === layerTypes.esriFeature);
-        }
-
-        /******/
-
-        // returns the number of visible layers that have been registered with the identify service
-        function getVisibleLayers() {
-            // use .filter to count boolean true values
-            // TODO: make nicer
-            return getDynamicLayers().concat(getFeatureLayers()).filter(l => l.layer.visibleAtMapScale).length;
-        }
-
-        // takes an attribute set (key-value mapping) and converts it to a format
-        // suitable for the details pane.
-        // the fields param is optional field information containing alias data
-        // TODO make this extensible / modifiable / configurable to allow different details looks for different data
-        function attributesToDetails(attribs, fields) {
-            // simple array of text mapping for demonstration purposes. fancy grid formatting later?
-
-            return Object.keys(attribs).map(key => {
-                let fieldName = layerRegistry.aliasedFieldName(key, fields);
-
-                return {
-                    key: fieldName,
-                    value: attribs[key]
-                };
-            });
-        }
-
-        // extract the feature name from a feature as best we can.
-        // takes feature attribute set, layer state, and object id
-        function getFeatureName(attribs, state, objId) {
-            // FIXME : display field is not yet defined in the config schema.  in particular, we need to account
-            //        for different name fields in child-layers of dynamic layers.
-            //        may be easier to just store the display field from the server when we download attributes,
-            //        though this would not allow us to override the server-defined field in the config.
-            if (state.displayField) {
-                // until schema & approach is finalized, this will never run
-                return attribs[state.displayField];
-            } else {
-                // FIXME wire in "feature" to translation service
-                return 'Feature ' + objId;
-            }
-        }
-
-        // will make an extent around a point, that is appropriate for the current map scale.
-        // makes it easier for point clicks to instersect
-        // the tolerance is distance in pixels from mouse point that qualifies as a hit
-        function makeClickBuffer(point, map, tolerance = 5) {
-            // take pixel tolerance, convert to map units at current scale. x2 to turn radius into diameter
-            const buffSize = 2 * tolerance * map.extent.getWidth() / map.width;
-
-            // Build tolerance envelope of correct size
-            const cBuff = new gapiService.gapi.mapManager.Extent(1, 1, buffSize, buffSize, point.spatialReference);
-
-            // move the envelope so it is centered around the point
-            return cBuff.centerAt(point);
-        }
-
-        // attempt to get a tolerance from the layer state, otherwise return a default
-        function getTolerance(layer) {
-            if (layerRegistry.layers[layer.id] && layerRegistry.layers[layer.id].state &&
-                layerRegistry.layers[layer.id].state.tolerance) {
-                return layerRegistry.layers[layer.id].state.tolerance;
-            } else {
-                return 5;
-            }
-        }
-
-        function clickHandlerBuilder(map) {
+            /***/
 
             /**
-             * Handles global map clicks.  Currently configured to walk through all registered dynamic
-             * layers and trigger service side identify queries, and perform client side spatial queries
-             * on registered feature layers.  TODO: add WMS support
-             * @name clickHandler
-             * @param {Object} clickEvent an ESRI event object for map click events
+             * Initializes identify service. This needs to be called everytime the map is created.
              */
-            return clickEvent => {
-                if (getVisibleLayers() === 0) { return; }
-
-                console.info('Click start');
-                const details = { data: [] };
-
-                const opts = {
-                    geometry: clickEvent.mapPoint,
-                    width: map.width,
-                    height: map.height,
-                    mapExtent: map.extent,
-                };
-
-                // run through all registered dynamic layers and trigger
-                // an identify task for each layer
-                let idPromises = getDynamicLayers().map(item => {
-                    const layer = item.layer;
-                    const name = item.state.name;
-
-                    if (!layer.visibleAtMapScale) {
-                        return $q.resolve(null);
-                    }
-
-                    const result = {
-                        isLoading: true,
-                        requestId: -1,
-                        requester: {
-                            name,
-                            format: 'EsriFeature'
-                        },
-                        data: []
-                    };
-                    opts.tolerance = getTolerance(layerRegistry, layer);
-                    details.data.push(result);
-                    return gapiService.gapi.layer.serverLayerIdentify(layer, opts)
-                        .then(clickResults => {
-                            console.log('got a click result');
-                            console.log(clickResults);
-
-                            // transform attributes of click results into {name,data} objects
-                            // one object per identified feature
-                            //
-                            // each feature will have its attributes converted into a table
-                            // placeholder for now until we figure out how to signal the panel that
-                            // we want to make a nice table
-                            result.data = clickResults.map(ele => {
-                                // NOTE: the identify service returns aliased field names, so no need to look them up here
-                                return {
-                                    name: ele.value,
-                                    data: attributesToDetails(ele.feature.attributes)
-                                };
-                            });
-                            result.isLoading = false;
-                            console.log(details);
-                        })
-                        .catch(err => {
-                            console.warn('Identify failed');
-                            console.warn(err);
-                            result.data = JSON.stringify(err);
-                            result.isLoading = false;
-                        });
-                });
-
-                // run through all registered feature layers and trigger
-                // an spatial query for each layer
-                idPromises = idPromises.concat(getFeatureLayers().map(item => {
-                    const layer = item.layer;
-                    const name = item.state.name;
-
-                    if (!layer.visibleAtMapScale) {
-                        return $q.resolve(null);
-                    }
-
-                    // FIXME  add a check to see if layer has config setting for not supporting a click
-
-                    const result = {
-                        isLoading: true,
-                        requestId: -1,
-                        requester: {
-                            name,
-                            format: 'EsriFeature'
-                        },
-                        data: []
-                    };
-                    details.data.push(result);
-
-                    // run a spatial query
-                    const qry = new gapiService.gapi.layer.Query();
-                    qry.outFields = ['*']; // this will result in just objectid fields, as that is all we have in feature layers
-                    qry.geometry = makeClickBuffer(clickEvent.mapPoint, map, getTolerance(layer));
-
-                    return $q((resolve, reject) => {
-
-                        // TODO might want to abstract some of this out into a "get attibutes from feature" function
-                        // get the id and attribute bundle of the layer belonging to the feature that was clicked
-                        if (!layerRegistry.layers[layer.id]) {
-                            throw new Error('Click on unregistered layer ' + layer.id);
-                        }
-                        const layerState = layerRegistry.layers[layer.id].state;
-
-                        // ensure attributes are downloaded.  wait for them if not.
-                        layerRegistry.layers[layer.id].attribs.then(attribsBundle => {
-
-                            if (attribsBundle.indexes.length === 0) {
-                                // TODO do we really want to error, or just do nothing (i.e. user clicks on no-data feature -- so what?)
-                                throw new Error('Click on layer without downloaded attributes ' + layer.id);
-                            }
-
-                            // feature layers have only one index, so the first one is ours. grab the attribute set for that index.
-                            const attribSet = attribsBundle[attribsBundle.indexes[0]];
-
-                            // queryFeatures returns a dojo-style promise, so cannot use .catch
-                            $q.resolve(layer.queryFeatures(qry)).then(queryResult => {
-
-                                // transform attributes of query results into {name,data} objects
-                                // one object per queried feature
-                                //
-                                // each feature will have its attributes converted into a table
-                                // placeholder for now until we figure out how to signal the panel that
-                                // we want to make a nice table
-                                result.data = queryResult.features.map(feat => {
-
-                                    // grab the object id of the feature we clicked on.
-                                    const objId = feat.attributes[attribSet.oidField].toString();
-
-                                    // use object id find location of our feature in the feature array, and grab its attributes
-                                    const featAttribs = attribSet.features[attribSet.oidIndex[objId]].attributes;
-
-                                    return {
-                                        name: getFeatureName(feat.attribs, layerState, objId),
-                                        data: attributesToDetails(featAttribs, attribSet.fields)
-                                    };
-                                });
-                                result.isLoading = false;
-                                resolve(true);
-
-                            }).catch(err => {
-                                console.warn('Layer query failed');
-                                console.warn(err);
-                                result.data = JSON.stringify(err);
-                                result.isLoading = false;
-                                reject(err);
-                            });
-                        });
+            function init() {
+                gapiService.gapi.events.wrapEvents(
+                    ref.map, {
+                        click: clickHandlerBuilder(ref.map)
                     });
 
-                }));
+                return null;
+            }
 
-                details.isLoaded = $q.all(idPromises).then(() => true);
+            /**
+             * Retrieves dynamic layers
+             * @return {Array} array of dynamic layers
+             */
+            function getDynamicLayers() {
+                // console.log(ref.layers);
 
-                stateManager.toggleDisplayPanel('mainDetails', details, {}, 0);
-            };
+                // TODO: Pretty experimental, but how about Object.entries instead of having to go with keys().map(key => object)?
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
+                // TODO: this and `getFeatureLayers` might be simplified and moved to the `layerRegistry`
+                return Object.keys(ref.layers)
+                    .map(key => ref.layers[key])
+                    .filter(layer => layer.state.layerType === layerTypes.esriDynamic);
+            }
+
+            /**
+             * Retrieves feature layers
+             * @return {Array} array of feature layers
+             */
+            function getFeatureLayers() {
+                // console.log(ref.layers);
+
+                return Object.keys(ref.layers)
+                    .map(key => ref.layers[key])
+                    .filter(layer => layer.state.layerType === layerTypes.esriFeature);
+            }
+
+            /******/
+
+            // returns the number of visible layers that have been registered with the identify service
+            function getVisibleLayers() {
+                // use .filter to count boolean true values
+                // TODO: make nicer
+                return getDynamicLayers()
+                    .concat(getFeatureLayers())
+                    .filter(l => l.layer.visibleAtMapScale)
+                    .length;
+            }
+
+            // takes an attribute set (key-value mapping) and converts it to a format
+            // suitable for the details pane.
+            // the fields param is optional field information containing alias data
+            // TODO make this extensible / modifiable / configurable to allow different details looks for different data
+            function attributesToDetails(attribs, fields) {
+                // simple array of text mapping for demonstration purposes. fancy grid formatting later?
+
+                return Object.keys(attribs)
+                    .map(key => {
+                        let fieldName = ref.layerRegistry.aliasedFieldName(key, fields);
+
+                        return {
+                            key: fieldName,
+                            value: attribs[key]
+                        };
+                    });
+            }
+
+            // extract the feature name from a feature as best we can.
+            // takes feature attribute set, layer state, and object id
+            function getFeatureName(attribs, state, objId) {
+                // FIXME : display field is not yet defined in the config schema.  in particular, we need to account
+                //        for different name fields in child-layers of dynamic layers.
+                //        may be easier to just store the display field from the server when we download attributes,
+                //        though this would not allow us to override the server-defined field in the config.
+                if (state.displayField) {
+                    // until schema & approach is finalized, this will never run
+                    return attribs[state.displayField];
+                } else {
+                    // FIXME wire in "feature" to translation service
+                    return 'Feature ' + objId;
+                }
+            }
+
+            // will make an extent around a point, that is appropriate for the current map scale.
+            // makes it easier for point clicks to instersect
+            // the tolerance is distance in pixels from mouse point that qualifies as a hit
+            function makeClickBuffer(point, map, tolerance = 5) {
+                // take pixel tolerance, convert to map units at current scale. x2 to turn radius into diameter
+                const buffSize = 2 * tolerance * map.extent.getWidth() / map.width;
+
+                // Build tolerance envelope of correct size
+                const cBuff = new gapiService.gapi.mapManager.Extent(1, 1, buffSize, buffSize, point.spatialReference);
+
+                // move the envelope so it is centered around the point
+                return cBuff.centerAt(point);
+            }
+
+            // attempt to get a tolerance from the layer state, otherwise return a default
+            function getTolerance(layer) {
+                if (ref.layers[layer.id] && ref.layers[layer.id].state &&
+                    ref.layers[layer.id].state.tolerance) {
+                    return ref.layers[layer.id].state.tolerance;
+                } else {
+                    return 5;
+                }
+            }
+
+            function clickHandlerBuilder(map) {
+
+                /**
+                 * Handles global map clicks.  Currently configured to walk through all registered dynamic
+                 * layers and trigger service side identify queries, and perform client side spatial queries
+                 * on registered feature layers.  TODO: add WMS support
+                 * @name clickHandler
+                 * @param {Object} clickEvent an ESRI event object for map click events
+                 */
+                return clickEvent => {
+                    if (getVisibleLayers() === 0) {
+                        return;
+                    }
+
+                    console.info('Click start');
+                    const details = {
+                        data: []
+                    };
+
+                    const opts = {
+                        geometry: clickEvent.mapPoint,
+                        width: map.width,
+                        height: map.height,
+                        mapExtent: map.extent,
+                    };
+
+                    // run through all registered dynamic layers and trigger
+                    // an identify task for each layer
+                    let idPromises = getDynamicLayers()
+                        .map(item => {
+                            const layer = item.layer;
+                            const name = item.state.name;
+
+                            if (!layer.visibleAtMapScale) {
+                                return $q.resolve(null);
+                            }
+
+                            const result = {
+                                isLoading: true,
+                                requestId: -1,
+                                requester: {
+                                    name,
+                                    format: 'EsriFeature'
+                                },
+                                data: []
+                            };
+                            opts.tolerance = getTolerance(layer);
+                            details.data.push(result);
+                            return gapiService.gapi.layer.serverLayerIdentify(layer, opts)
+                                .then(clickResults => {
+                                    console.log('got a click result');
+                                    console.log(clickResults);
+
+                                    // transform attributes of click results into {name,data} objects
+                                    // one object per identified feature
+                                    //
+                                    // each feature will have its attributes converted into a table
+                                    // placeholder for now until we figure out how to signal the panel that
+                                    // we want to make a nice table
+                                    result.data = clickResults.map(ele => {
+                                        // NOTE: the identify service returns aliased field names, so no need to look them up here
+                                        return {
+                                            name: ele.value,
+                                            data: attributesToDetails(ele.feature.attributes)
+                                        };
+                                    });
+                                    result.isLoading = false;
+                                    console.log(details);
+                                })
+                                .catch(err => {
+                                    console.warn('Identify failed');
+                                    console.warn(err);
+                                    result.data = JSON.stringify(err);
+                                    result.isLoading = false;
+                                });
+                        });
+
+                    // run through all registered feature layers and trigger
+                    // an spatial query for each layer
+                    idPromises = idPromises.concat(getFeatureLayers()
+                        .map(item => {
+                            const layer = item.layer;
+                            const name = item.state.name;
+
+                            if (!layer.visibleAtMapScale) {
+                                return $q.resolve(null);
+                            }
+
+                            // FIXME  add a check to see if layer has config setting for not supporting a click
+
+                            const result = {
+                                isLoading: true,
+                                requestId: -1,
+                                requester: {
+                                    name,
+                                    format: 'EsriFeature'
+                                },
+                                data: []
+                            };
+                            details.data.push(result);
+
+                            // run a spatial query
+                            const qry = new gapiService.gapi.layer.Query();
+                            qry.outFields = ['*']; // this will result in just objectid fields, as that is all we have in feature layers
+                            qry.geometry = makeClickBuffer(clickEvent.mapPoint, map, getTolerance(layer));
+
+                            return $q((resolve, reject) => {
+
+                                // TODO might want to abstract some of this out into a "get attibutes from feature" function
+                                // get the id and attribute bundle of the layer belonging to the feature that was clicked
+                                if (!ref.layers[layer.id]) {
+                                    throw new Error('Click on unregistered layer ' + layer.id);
+                                }
+                                const layerState = ref.layers[layer.id].state;
+
+                                // ensure attributes are downloaded.  wait for them if not.
+                                ref.layers[layer.id].attribs.then(attribsBundle => {
+
+                                    if (attribsBundle.indexes.length === 0) {
+                                        // TODO do we really want to error, or just do nothing (i.e. user clicks on no-data feature -- so what?)
+                                        throw new Error(
+                                            'Click on layer without downloaded attributes ' +
+                                            layer.id);
+                                    }
+
+                                    // feature layers have only one index, so the first one is ours. grab the attribute set for that index.
+                                    const attribSet = attribsBundle[attribsBundle.indexes[
+                                        0]];
+
+                                    // queryFeatures returns a dojo-style promise, so cannot use .catch
+                                    $q.resolve(layer.queryFeatures(qry))
+                                        .then(queryResult => {
+
+                                            // transform attributes of query results into {name,data} objects
+                                            // one object per queried feature
+                                            //
+                                            // each feature will have its attributes converted into a table
+                                            // placeholder for now until we figure out how to signal the panel that
+                                            // we want to make a nice table
+                                            result.data = queryResult.features.map(
+                                                feat => {
+
+                                                    // grab the object id of the feature we clicked on.
+                                                    const objId = feat.attributes[
+                                                            attribSet.oidField]
+                                                        .toString();
+
+                                                    // use object id find location of our feature in the feature array, and grab its attributes
+                                                    const featAttribs =
+                                                        attribSet.features[
+                                                            attribSet.oidIndex[
+                                                                objId]].attributes;
+
+                                                    return {
+                                                        name: getFeatureName(
+                                                            feat.attribs,
+                                                            layerState,
+                                                            objId),
+                                                        data: attributesToDetails(
+                                                            featAttribs,
+                                                            attribSet.fields
+                                                        )
+                                                    };
+                                                });
+                                            result.isLoading = false;
+                                            resolve(true);
+
+                                        })
+                                        .catch(err => {
+                                            console.warn('Layer query failed');
+                                            console.warn(err);
+                                            result.data = JSON.stringify(err);
+                                            result.isLoading = false;
+                                            reject(err);
+                                        });
+                                });
+                            });
+
+                        }));
+
+                    details.isLoaded = $q.all(idPromises)
+                        .then(() => true);
+
+                    stateManager.toggleDisplayPanel('mainDetails', details, {}, 0);
+                };
+            }
         }
-
     }
 })();

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -14,8 +14,7 @@
     function identifyService($q, gapiService, mapService, layerRegistry, stateManager, layerTypes) {
 
         const service = {
-            init,
-            aliasedFieldName
+            init
         };
 
         return service;
@@ -55,26 +54,6 @@
 
         /******/
 
-        /**
-         * Get the best user-friendly name of a field. Uses alias if alias is defined, else uses the system attribute name.
-         * @param {String} attribName the attribute name we want a nice name for
-         * @param {Object} fields array of field definitions. the attribute should belong to the provided set of fields
-         */
-        function aliasedFieldName(attribName, fields) {
-            let fName = attribName;
-
-            // search for aliases
-            if (fields) {
-                const attribField = fields.find(field => {
-                    return field.name === attribName;
-                });
-                if (attribField && attribField.alias && attribField.alias.length > 0) {
-                    fName = attribField.alias;
-                }
-            }
-            return fName;
-        }
-
         // returns the number of visible layers that have been registered with the identify service
         function getVisibleLayers() {
             // use .filter to count boolean true values
@@ -90,7 +69,7 @@
             // simple array of text mapping for demonstration purposes. fancy grid formatting later?
 
             return Object.keys(attribs).map(key => {
-                let fieldName = aliasedFieldName(key, fields);
+                let fieldName = layerRegistry.aliasedFieldName(key, fields);
 
                 return {
                     key: fieldName,

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -30,19 +30,22 @@
         }
 
         /**
-         * Retrieves dynamic layres
+         * Retrieves dynamic layers
          * @return {Array} array of dynamic layers
          */
         function getDynamicLayers() {
             console.log(layerRegistry.layers);
 
+            // TODO: Pretty experimental, but how about Object.entries instead of having to go with keys().map(key => object)?
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
+            // TODO: this and `getFeatureLayers` might be simplified and moved to the `layerRegistry`
             return Object.keys(layerRegistry.layers)
                 .map(key => layerRegistry.layers[key])
                 .filter(layer => layer.state.layerType === layerTypes.esriDynamic);
         }
 
         /**
-         * Retrieves feature layres
+         * Retrieves feature layers
          * @return {Array} array of feature layers
          */
         function getFeatureLayers() {

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -11,13 +11,13 @@
         .module('app.geo')
         .factory('identifyService', identifyService);
 
-    function identifyService($q, gapi, stateManager) {
+    function identifyService($q, gapiService, stateManager) {
 
         const dynamicLayers = [];
         const featureLayers = [];
 
         return (map, layerRegistry) => {
-            gapi.gapi.events.wrapEvents(map, { click: clickHandlerBuilder(map, layerRegistry) });
+            gapiService.gapi.events.wrapEvents(map, { click: clickHandlerBuilder(map, layerRegistry) });
 
             return {
                 /**
@@ -108,7 +108,7 @@
             const buffSize = 2 * tolerance * map.extent.getWidth() / map.width;
 
             // Build tolerance envelope of correct size
-            const cBuff = new gapi.gapi.mapManager.Extent(1, 1, buffSize, buffSize, point.spatialReference);
+            const cBuff = new gapiService.gapi.mapManager.Extent(1, 1, buffSize, buffSize, point.spatialReference);
 
             // move the envelope so it is centered around the point
             return cBuff.centerAt(point);
@@ -163,7 +163,7 @@
                     };
                     opts.tolerance = getTolerance(layerRegistry, layer);
                     details.data.push(result);
-                    return gapi.gapi.layer.serverLayerIdentify(layer, opts)
+                    return gapiService.gapi.layer.serverLayerIdentify(layer, opts)
                         .then(clickResults => {
                             console.log('got a click result');
                             console.log(clickResults);
@@ -214,7 +214,7 @@
                     details.data.push(result);
 
                     // run a spatial query
-                    const qry = new gapi.gapi.layer.Query();
+                    const qry = new gapiService.gapi.layer.Query();
                     qry.outFields = ['*']; // this will result in just objectid fields, as that is all we have in feature layers
                     qry.geometry = makeClickBuffer(clickEvent.mapPoint, map, getTolerance(layerRegistry, layer));
 

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -17,7 +17,8 @@
         const featureLayers = [];
 
         return (map, layerRegistry) => {
-            gapiService.gapi.events.wrapEvents(map, { click: clickHandlerBuilder(map, layerRegistry) });
+            gapiService.gapi.events.wrapEvents(
+                map, { click: clickHandlerBuilder(map, layerRegistry) });
 
             return {
                 /**

--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -15,7 +15,7 @@
         .module('app.geo')
         .directive('rvInitMap', rvInitMap);
 
-    function rvInitMap(geoService, configService) {
+    function rvInitMap(mapService) {
 
         const directive = {
             restrict: 'A',
@@ -23,8 +23,11 @@
         };
         return directive;
 
-        function linkFunc(scope, el, attr) {
+        function linkFunc(scope, el) {
 
+            mapService.registerMapNode(el[0]);
+
+            /*
             scope.$watch(attr.rvInitMap, val => {
                 if (val === true) {
                     console.log('Switched to true');
@@ -36,7 +39,7 @@
                         geoService.buildMap(el[0], config);
                     });
                 }
-            });
+            });*/
         }
     }
 

--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -24,7 +24,7 @@
         return directive;
 
         function linkFunc(scope, el) {
-            // degerister after the first `rvReady` event as it's fired only once
+            // deregister after the first `rvReady` event as it's fired only once
             const deRegister = scope.$on(events.rvReady, () => {
                 geoService.assembleMap(el[0]);
                 deRegister();

--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -26,20 +26,6 @@
         function linkFunc(scope, el) {
 
             mapService.registerMapNode(el[0]);
-
-            /*
-            scope.$watch(attr.rvInitMap, val => {
-                if (val === true) {
-                    console.log('Switched to true');
-                    console.log(el);
-
-                    // there should only be one instance of the directive as the application bootstrap takes care
-                    // of handling multiple instances at that level
-                    configService.getCurrent().then(config => {
-                        geoService.buildMap(el[0], config);
-                    });
-                }
-            });*/
         }
     }
 

--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -15,7 +15,7 @@
         .module('app.geo')
         .directive('rvInitMap', rvInitMap);
 
-    function rvInitMap(geoService) {
+    function rvInitMap(geoService, events) {
 
         const directive = {
             restrict: 'A',
@@ -24,9 +24,11 @@
         return directive;
 
         function linkFunc(scope, el) {
-
-            geoService.registerMapNode(el[0]);
+            // degerister after the first `rvReady` event as it's fired only once
+            const deRegister = scope.$on(events.rvReady, () => {
+                geoService.assembleMap(el[0]);
+                deRegister();
+            });
         }
     }
-
 })();

--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -15,7 +15,7 @@
         .module('app.geo')
         .directive('rvInitMap', rvInitMap);
 
-    function rvInitMap(mapService) {
+    function rvInitMap(geoService) {
 
         const directive = {
             restrict: 'A',
@@ -25,7 +25,7 @@
 
         function linkFunc(scope, el) {
 
-            mapService.registerMapNode(el[0]);
+            geoService.registerMapNode(el[0]);
         }
     }
 

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -15,7 +15,7 @@
         .module('app.geo')
         .factory('layerRegistry', layerRegistry);
 
-    function layerRegistry(gapiService, identifyService, layerTypes, configDefaults) {
+    function layerRegistry(gapiService, layerTypes, configDefaults) {
 
         const layers = {}; // layer collection
         const legend = []; // legend construct, to be consumed by toc; deflection +2
@@ -115,7 +115,7 @@
          * @param {object} layerConfig a configuration fragment for a single layer
          * @return {object} a layer object matching one of the esri/layers objects based on the layer type
          */
-        function generateLayer(layerConfig, map) {
+        function generateLayer(layerConfig) {
             const handlers = {};
             const commonConfig = {
                 id: layerConfig.id,
@@ -126,8 +126,6 @@
             handlers[layerTypes.esriDynamic] = config => {
                 const l = new gapiService.gapi.layer.ArcGISDynamicMapServiceLayer(config.url, commonConfig);
 
-                identifyService(map, layerRegistry.layers)
-                    .addDynamicLayer(l, config.name);
                 return l;
             };
             handlers[layerTypes.esriFeature] = config => {
@@ -136,8 +134,6 @@
                     gapiService.gapi.layer.FeatureLayer.MODE_ONDEMAND;
                 const l = new gapiService.gapi.layer.FeatureLayer(config.url, commonConfig);
 
-                identifyService(map, layerRegistry.layers)
-                    .addFeatureLayer(l, config.name);
                 return l;
             };
             handlers[layerTypes.esriImage] = config => {

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -15,7 +15,7 @@
         .module('app.geo')
         .factory('layerRegistry', layerRegistry);
 
-    function layerRegistry(gapiService, layerTypes, configDefaults) {
+    function layerRegistry(gapiService, mapService, layerTypes, configDefaults) {
 
         const layers = {}; // layer collection
         const legend = []; // legend construct, to be consumed by toc; deflection +2
@@ -24,6 +24,7 @@
             legend,
             layers, // TODO: remove raw layer array
 
+            reset,
             generateLayer,
             registerLayer,
             getFormattedAttributes,
@@ -35,6 +36,16 @@
         return service;
 
         /***/
+
+        function reset() {
+            // clear layers array
+            Object.keys(layers)
+                .forEach(key => delete layers[key]);
+
+            // clear legend: http://stackoverflow.com/questions/1232040/how-do-i-empty-an-array-in-javascript
+            // I want to preserve the array reference
+            legend.splice(0, legend.length);
+        }
 
         /**
          * Sets layer visiblity value.
@@ -63,7 +74,7 @@
                 return;
             }
 
-            // map.removeLayer(l.layer);
+            mapService.map.removeLayer(l.layer);
 
             // TODO: needs more work to manager layerOrder
             const index = service.legend.indexOf(layerId);

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -1,0 +1,164 @@
+(() => {
+    'use strict';
+
+    /**
+     * @ngdoc service
+     * @name layerRegistry
+     * @module app.geo
+     * @requires
+     * @description
+     *
+     * The `layerRegistry` factory description.
+     *
+     */
+    angular
+        .module('app.geo')
+        .factory('layerRegistry', layerRegistry);
+
+    function layerRegistry(gapiService, identifyService, layerTypes, configDefaults) {
+
+        const layers = {}; // layer collection
+        const legend = []; // legend construct, to be consumed by toc; deflection +2
+
+        const service = {
+            legend,
+            layers, // TODO: remove raw layer array
+
+            generateLayer,
+            registerLayer,
+            removeLayer,
+            setLayerVisibility
+        };
+
+        return service;
+
+        /***/
+
+        /**
+         * Sets layer visiblity value.
+         * @param {Number} layerId id of the layer in the layer registry
+         * @param {String} value   visibility state; Visibility value has four states: 'on', 'off', 'zoomIn', and 'zoomOut'. The first two can be set as initial layer visibility states; the last two are for internal use only. Any value except for 'on' means the layer is hidden. 'off', 'zoomIn', and 'zoomOut' specify an icon and action for the layer toggle.
+         * TODO: needs more work for toggling on/off dynamic layers and its children;
+         */
+        function setLayerVisibility(layerId, value) {
+            const l = layers[layerId];
+
+            if (l) {
+                l.state.options.visibility.value = value; // update layer state value
+                l.layer.setVisibility(value === 'on' ? true : false);
+            }
+        }
+
+        /**
+         * Removes the layer from the map and from the layer registry
+         * @param {Number} layerId  the id of the layer to be removed
+         * TODO: needs more work for removing dynamic layers and its children;
+         */
+        function removeLayer(layerId) {
+            const l = layers[layerId];
+
+            if (!l) {
+                return;
+            }
+
+            // map.removeLayer(l.layer);
+
+            // TODO: needs more work to manager layerOrder
+            const index = service.legend.indexOf(layerId);
+            if (index !== -1) {
+                service.legend.splice(index, 1);
+            }
+        }
+
+        /**
+         * Adds a layer object to the layers registry
+         * @param {object} layer the API layer object
+         * @param {object} initialState a configuration fragment used to generate the layer
+         * @param {promise} attribs a promise resolving with the attributes associated with the layer (empty set if no attributes)
+         * @param {number} position an optional index indicating at which position the layer was added to the map
+         * (if supplied it is the caller's responsibility to make sure the layer is added in the correct location)
+         */
+        function registerLayer(layer, initialState, attribs, position) {
+            // TODO determine the proper docstrings for a non-service function that lives in a service
+
+            if (!layer.id) {
+                console.error('Attempt to register layer without id property');
+                console.log(layer);
+                console.log(initialState);
+            }
+
+            if (layers[layer.id]) {
+                console.error('attempt to register layer already registered.  id: ' + layer.id);
+            }
+
+            const l = {
+                layer,
+                attribs,
+
+                // apply layer option defaults
+                state: angular.merge({}, configDefaults.layerOptions, configDefaults.layerFlags, initialState)
+            };
+
+            layers[layer.id] = l;
+
+            if (position === undefined) {
+                position = service.legend.length;
+            }
+            service.legend.splice(position, 0, layer.id);
+
+            // TODO: apply config values
+            service.setLayerVisibility(l.layer.id, l.state.options.visibility.value);
+        }
+
+        /**
+         * Takes a layer in the config format and generates an appropriate layer object.
+         * @param {object} layerConfig a configuration fragment for a single layer
+         * @return {object} a layer object matching one of the esri/layers objects based on the layer type
+         */
+        function generateLayer(layerConfig, map) {
+            const handlers = {};
+            const commonConfig = {
+                id: layerConfig.id,
+                visible: layerConfig.visibility === 'on',
+                opacity: layerConfig.opacity || 1
+            };
+
+            handlers[layerTypes.esriDynamic] = config => {
+                const l = new gapiService.gapi.layer.ArcGISDynamicMapServiceLayer(config.url, commonConfig);
+
+                identifyService(map, layerRegistry.layers)
+                    .addDynamicLayer(l, config.name);
+                return l;
+            };
+            handlers[layerTypes.esriFeature] = config => {
+                commonConfig.mode = config.snapshot ?
+                    gapiService.gapi.layer.FeatureLayer.MODE_SNAPSHOT :
+                    gapiService.gapi.layer.FeatureLayer.MODE_ONDEMAND;
+                const l = new gapiService.gapi.layer.FeatureLayer(config.url, commonConfig);
+
+                identifyService(map, layerRegistry.layers)
+                    .addFeatureLayer(l, config.name);
+                return l;
+            };
+            handlers[layerTypes.esriImage] = config => {
+
+                // FIXME don't hardcode opacity
+                commonConfig.opacity = 0.3;
+                return new gapiService.gapi.layer.ArcGISImageServiceLayer(config.url, commonConfig);
+            };
+            handlers[layerTypes.esriTile] = config => {
+                return new gapiService.gapi.layer.TileLayer(config.url, commonConfig);
+            };
+            handlers[layerTypes.ogcWms] = config => {
+                commonConfig.visibleLayers = [config.layerName];
+                return new gapiService.gapi.layer.WmsLayer(config.url, commonConfig);
+            };
+
+            if (handlers.hasOwnProperty(layerConfig.layerType)) {
+                return handlers[layerConfig.layerType](layerConfig);
+            } else {
+                throw new Error('Your layer type is unacceptable');
+            }
+        }
+    }
+})();

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -13,246 +13,289 @@
      */
     angular
         .module('app.geo')
-        .factory('layerRegistry', layerRegistry);
+        .factory('layerRegistry', layerRegistryFactory);
 
-    function layerRegistry(gapiService, mapService, layerTypes, configDefaults) {
+    function layerRegistryFactory($q, gapiService, layerTypes, configService, configDefaults) {
+        return geoState => layerRegistry(geoState);
 
-        const layers = {}; // layer collection
-        const legend = []; // legend construct, to be consumed by toc; deflection +2
-
-        const service = {
-            legend,
-            layers,
-
-            reset,
-
-            generateLayer,
-            registerLayer,
-            getFormattedAttributes,
-            removeLayer,
-            setLayerVisibility,
-            aliasedFieldName
-        };
-
-        return service;
-
-        /***/
-
-        /**
-         * Resets layer and legend storage.
-         */
-        function reset() {
-            // clear layers array
-            Object.keys(layers)
-                .forEach(key => delete layers[key]);
-
-            // clear legend: http://stackoverflow.com/questions/1232040/how-do-i-empty-an-array-in-javascript
-            // I want to preserve the array reference
-            legend.splice(0, legend.length);
-        }
-
-        /**
-         * Sets layer visiblity value.
-         * @param {Number} layerId id of the layer in the layer registry
-         * @param {String} value   visibility state; Visibility value has four states: 'on', 'off', 'zoomIn', and 'zoomOut'. The first two can be set as initial layer visibility states; the last two are for internal use only. Any value except for 'on' means the layer is hidden. 'off', 'zoomIn', and 'zoomOut' specify an icon and action for the layer toggle.
-         * TODO: needs more work for toggling on/off dynamic layers and its children;
-         */
-        function setLayerVisibility(layerId, value) {
-            const l = layers[layerId];
-
-            if (l) {
-                l.state.options.visibility.value = value; // update layer state value
-                l.layer.setVisibility(value === 'on' ? true : false);
-            }
-        }
-
-        /**
-         * Removes the layer from the map and from the layer registry
-         * @param {Number} layerId  the id of the layer to be removed
-         * TODO: needs more work for removing dynamic layers and its children;
-         */
-        function removeLayer(layerId) {
-            const l = layers[layerId];
-
-            // TODO: don't fail silently; thrown and error; maybe shown message to the user.
-            if (!l) {
-                return;
-            }
-
-            mapService.map.removeLayer(l.layer);
-
-            // TODO: needs more work to manager layerOrder
-            const index = service.legend.indexOf(layerId);
-            if (index !== -1) {
-                service.legend.splice(index, 1);
-            }
-        }
-
-        /**
-         * Adds a layer object to the layers registry
-         * @param {object} layer the API layer object
-         * @param {object} initialState a configuration fragment used to generate the layer
-         * @param {promise} attribs a promise resolving with the attributes associated with the layer (empty set if no attributes)
-         * @param {number} position an optional index indicating at which position the layer was added to the map
-         * (if supplied it is the caller's responsibility to make sure the layer is added in the correct location)
-         */
-        function registerLayer(layer, initialState, attribs, position) {
-            // TODO determine the proper docstrings for a non-service function that lives in a service
-
-            if (!layer.id) {
-                console.error('Attempt to register layer without id property');
-                console.log(layer);
-                console.log(initialState);
-            }
-
-            if (layers[layer.id]) {
-                console.error('attempt to register layer already registered.  id: ' + layer.id);
-            }
-
-            const l = {
-                layer,
-                attribs,
-
-                // apply layer option defaults
-                state: angular.merge({}, configDefaults.layerOptions, configDefaults.layerFlags, initialState)
+        function layerRegistry(geoState) {
+            // keep useful references from geoState
+            const ref = {
+                map: geoState.mapService.mapObject
             };
 
-            layers[layer.id] = l;
+            const layers = {}; // layer collection
+            const legend = []; // legend construct, to be consumed by toc; deflection +2
 
-            if (position === undefined) {
-                position = service.legend.length;
-            }
-            service.legend.splice(position, 0, layer.id);
+            // this `service` object will be exposed through `geoService`
+            const service = {
+                legend,
+                layers,
 
-            // TODO: apply config values
-            service.setLayerVisibility(l.layer.id, l.state.options.visibility.value);
-        }
-
-        /**
-         * Takes a layer in the config format and generates an appropriate layer object.
-         * @param {object} layerConfig a configuration fragment for a single layer
-         * @return {object} a layer object matching one of the esri/layers objects based on the layer type
-         */
-        function generateLayer(layerConfig) {
-            const handlers = {};
-            const commonConfig = {
-                id: layerConfig.id,
-                visible: layerConfig.visibility === 'on',
-                opacity: layerConfig.opacity || 1
+                generateLayer,
+                registerLayer,
+                getFormattedAttributes,
+                removeLayer,
+                setLayerVisibility,
+                aliasedFieldName
             };
 
-            handlers[layerTypes.esriDynamic] = config => {
-                const l = new gapiService.gapi.layer.ArcGISDynamicMapServiceLayer(config.url, commonConfig);
+            return constructLayers();
 
-                return l;
-            };
-            handlers[layerTypes.esriFeature] = config => {
-                commonConfig.mode = config.snapshot ?
-                    gapiService.gapi.layer.FeatureLayer.MODE_SNAPSHOT :
-                    gapiService.gapi.layer.FeatureLayer.MODE_ONDEMAND;
-                const l = new gapiService.gapi.layer.FeatureLayer(config.url, commonConfig);
+            /***/
 
-                return l;
-            };
-            handlers[layerTypes.esriImage] = config => {
+            function constructLayers() {
+                return configService.getCurrent()
+                    .then(config => {
 
-                // FIXME don't hardcode opacity
-                commonConfig.opacity = 0.3;
-                return new gapiService.gapi.layer.ArcGISImageServiceLayer(config.url, commonConfig);
-            };
-            handlers[layerTypes.esriTile] = config => {
-                return new gapiService.gapi.layer.TileLayer(config.url, commonConfig);
-            };
-            handlers[layerTypes.ogcWms] = config => {
-                commonConfig.visibleLayers = [config.layerName];
-                return new gapiService.gapi.layer.WmsLayer(config.url, commonConfig);
-            };
+                        config.layers.forEach(layerConfig => {
+                            // TODO: decouple identifyservice from everything
+                            const l = service.generateLayer(layerConfig);
+                            const pAttrib = $q((resolve, reject) => { // handles the asynch loading of attributes
 
-            if (handlers.hasOwnProperty(layerConfig.layerType)) {
-                return handlers[layerConfig.layerType](layerConfig);
-            } else {
-                throw new Error('Your layer type is unacceptable');
-            }
-        }
+                                // TODO investigate potential issue -- load event finishes prior to this event registration, thus attributes are never loaded
+                                gapiService.gapi.events.wrapEvents(l, {
+                                    load: () => {
+                                        // FIXME look at layer config for flags indicating not to load attributes
+                                        // FIXME if layer type is not an attribute-having type (WMS, Tile, Image, Raster, more?), resolve an empty attribute set instead
 
-        /**
-         * Returns nicely bundled attributes for the layer described by layerId.
-         * The bundles are used in the datatable.
-         *
-         * @param   {String} layerId        The id for the layer
-         * @param   {String} featureIndex   The index for the feature (attribute set) within the layer
-         * @return  {Promise}               Resolves with the column headers and data to show in the datatable
-         */
-        function getFormattedAttributes(layerId, featureIndex) {
-            // FIXME change to new promise format of attributes.  return a promise from this function.
+                                        // get the attributes for the layer
+                                        const a = gapiService.gapi.attribs.loadLayerAttribs(
+                                            l);
 
-            if (!layers[layerId]) {
-                throw new Error('Cannot get attributes for unregistered layer');
+                                        a
+                                            .then(data => {
+                                                // registerAttributes(data);
+                                                resolve(data);
+                                            })
+                                            .catch(exception => {
+                                                console.error(
+                                                    'Error getting attributes for ' +
+                                                    l.name + ': ' +
+                                                    exception);
+                                                console.log(l);
+
+                                                // TODO we may want to resolve with an empty attribute item. depends how breaky things get with the bad layer
+                                                reject(exception);
+                                            });
+                                    }
+                                });
+                            });
+                            service.registerLayer(l, layerConfig, pAttrib); // https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/286#-K9cmkUQO7pwtwEPOjmK
+                            ref.map.addLayer(l);
+                        });
+
+                        // store service in geoState
+                        geoState.layerRegistry = service;
+
+                        return service;
+                    });
             }
 
-            // waits for attributes to be loaded, then resolves with formatted data
-            return layers[layerId].attribs.then(attribBundle => {
-                if (!attribBundle[featureIndex] || attribBundle[featureIndex].features.length === 0) {
-                    throw new Error('Cannot get attributes for feature set that does not exist');
+            /**
+             * Sets layer visiblity value.
+             * @param {Number} layerId id of the layer in the layer registry
+             * @param {String} value   visibility state; Visibility value has four states: 'on', 'off', 'zoomIn', and 'zoomOut'. The first two can be set as initial layer visibility states; the last two are for internal use only. Any value except for 'on' means the layer is hidden. 'off', 'zoomIn', and 'zoomOut' specify an icon and action for the layer toggle.
+             * TODO: needs more work for toggling on/off dynamic layers and its children;
+             */
+            function setLayerVisibility(layerId, value) {
+                const l = layers[layerId];
+
+                if (l) {
+                    l.state.options.visibility.value = value; // update layer state value
+                    l.layer.setVisibility(value === 'on' ? true : false);
+                }
+            }
+
+            /**
+             * Removes the layer from the map and from the layer registry
+             * @param {Number} layerId  the id of the layer to be removed
+             * TODO: needs more work for removing dynamic layers and its children;
+             */
+            function removeLayer(layerId) {
+                const l = layers[layerId];
+
+                // TODO: don't fail silently; thrown and error; maybe shown message to the user.
+                if (!l) {
+                    return;
                 }
 
-                // get the attributes and single out the first one
-                const attr = attribBundle[featureIndex];
-                const first = attr.features[0];
+                ref.map.removeLayer(l.layer);
 
-                // columns for the data table
-                const columns = [];
+                // TODO: needs more work to manager layerOrder
+                const index = service.legend.indexOf(layerId);
+                if (index !== -1) {
+                    service.legend.splice(index, 1);
+                }
+            }
 
-                // data for the data table
-                const data = [];
+            /**
+             * Adds a layer object to the layers registry
+             * @param {object} layer the API layer object
+             * @param {object} initialState a configuration fragment used to generate the layer
+             * @param {promise} attribs a promise resolving with the attributes associated with the layer (empty set if no attributes)
+             * @param {number} position an optional index indicating at which position the layer was added to the map
+             * (if supplied it is the caller's responsibility to make sure the layer is added in the correct location)
+             */
+            function registerLayer(layer, initialState, attribs, position) {
+                // TODO determine the proper docstrings for a non-service function that lives in a service
 
-                // used to track order of columns
-                const columnOrder = [];
+                if (!layer.id) {
+                    console.error('Attempt to register layer without id property');
+                    console.log(layer);
+                    console.log(initialState);
+                }
 
-                // get the attribute keys to use as column headers
-                Object.keys(first.attributes)
-                    .forEach((key, index) => {
-                        const title = aliasedFieldName(key, attr.fields);
+                if (layers[layer.id]) {
+                    console.error('attempt to register layer already registered.  id: ' + layer.id);
+                }
 
-                        columns[index] = {
-                            title
-                        };
-                        columnOrder[index] = key;
-                    });
+                const l = {
+                    layer,
+                    attribs,
 
-                // get the attribute data from every feature
-                attr.features.forEach((feat, index) => {
-                    data[index] = [];
-                    angular.forEach(feat.attributes, (value, key) => {
-                        data[index][columnOrder.indexOf(key)] = value;
-                    });
-                });
-
-                return {
-                    columns,
-                    data
+                    // apply layer option defaults
+                    state: angular.merge({}, configDefaults.layerOptions, configDefaults.layerFlags,
+                        initialState)
                 };
-            });
-        }
 
-        /**
-         * Get the best user-friendly name of a field. Uses alias if alias is defined, else uses the system attribute name.
-         * @param {String} attribName the attribute name we want a nice name for
-         * @param {Object} fields array of field definitions. the attribute should belong to the provided set of fields
-         */
-        function aliasedFieldName(attribName, fields) {
-            let fName = attribName;
+                layers[layer.id] = l;
 
-            // search for aliases
-            if (fields) {
-                const attribField = fields.find(field => {
-                    return field.name === attribName;
-                });
-                if (attribField && attribField.alias && attribField.alias.length > 0) {
-                    fName = attribField.alias;
+                if (position === undefined) {
+                    position = service.legend.length;
+                }
+                service.legend.splice(position, 0, layer.id);
+
+                // TODO: apply config values
+                service.setLayerVisibility(l.layer.id, l.state.options.visibility.value);
+            }
+
+            /**
+             * Takes a layer in the config format and generates an appropriate layer object.
+             * @param {object} layerConfig a configuration fragment for a single layer
+             * @return {object} a layer object matching one of the esri/layers objects based on the layer type
+             */
+            function generateLayer(layerConfig) {
+                const handlers = {};
+                const commonConfig = {
+                    id: layerConfig.id,
+                    visible: layerConfig.visibility === 'on',
+                    opacity: layerConfig.opacity || 1
+                };
+
+                handlers[layerTypes.esriDynamic] = config => {
+                    const l = new gapiService.gapi.layer.ArcGISDynamicMapServiceLayer(config.url, commonConfig);
+
+                    return l;
+                };
+                handlers[layerTypes.esriFeature] = config => {
+                    commonConfig.mode = config.snapshot ?
+                        gapiService.gapi.layer.FeatureLayer.MODE_SNAPSHOT :
+                        gapiService.gapi.layer.FeatureLayer.MODE_ONDEMAND;
+                    const l = new gapiService.gapi.layer.FeatureLayer(config.url, commonConfig);
+
+                    return l;
+                };
+                handlers[layerTypes.esriImage] = config => {
+
+                    // FIXME don't hardcode opacity
+                    commonConfig.opacity = 0.3;
+                    return new gapiService.gapi.layer.ArcGISImageServiceLayer(config.url, commonConfig);
+                };
+                handlers[layerTypes.esriTile] = config => {
+                    return new gapiService.gapi.layer.TileLayer(config.url, commonConfig);
+                };
+                handlers[layerTypes.ogcWms] = config => {
+                    commonConfig.visibleLayers = [config.layerName];
+                    return new gapiService.gapi.layer.WmsLayer(config.url, commonConfig);
+                };
+
+                if (handlers.hasOwnProperty(layerConfig.layerType)) {
+                    return handlers[layerConfig.layerType](layerConfig);
+                } else {
+                    throw new Error('Your layer type is unacceptable');
                 }
             }
-            return fName;
+
+            /**
+             * Returns nicely bundled attributes for the layer described by layerId.
+             * The bundles are used in the datatable.
+             *
+             * @param   {String} layerId        The id for the layer
+             * @param   {String} featureIndex   The index for the feature (attribute set) within the layer
+             * @return  {Promise}               Resolves with the column headers and data to show in the datatable
+             */
+            function getFormattedAttributes(layerId, featureIndex) {
+                // FIXME change to new promise format of attributes.  return a promise from this function.
+
+                if (!layers[layerId]) {
+                    throw new Error('Cannot get attributes for unregistered layer');
+                }
+
+                // waits for attributes to be loaded, then resolves with formatted data
+                return layers[layerId].attribs.then(attribBundle => {
+                    if (!attribBundle[featureIndex] || attribBundle[featureIndex].features.length === 0) {
+                        throw new Error('Cannot get attributes for feature set that does not exist');
+                    }
+
+                    // get the attributes and single out the first one
+                    const attr = attribBundle[featureIndex];
+                    const first = attr.features[0];
+
+                    // columns for the data table
+                    const columns = [];
+
+                    // data for the data table
+                    const data = [];
+
+                    // used to track order of columns
+                    const columnOrder = [];
+
+                    // get the attribute keys to use as column headers
+                    Object.keys(first.attributes)
+                        .forEach((key, index) => {
+                            const title = aliasedFieldName(key, attr.fields);
+
+                            columns[index] = {
+                                title
+                            };
+                            columnOrder[index] = key;
+                        });
+
+                    // get the attribute data from every feature
+                    attr.features.forEach((feat, index) => {
+                        data[index] = [];
+                        angular.forEach(feat.attributes, (value, key) => {
+                            data[index][columnOrder.indexOf(key)] = value;
+                        });
+                    });
+
+                    return {
+                        columns,
+                        data
+                    };
+                });
+            }
+
+            /**
+             * Get the best user-friendly name of a field. Uses alias if alias is defined, else uses the system attribute name.
+             * @param {String} attribName the attribute name we want a nice name for
+             * @param {Object} fields array of field definitions. the attribute should belong to the provided set of fields
+             */
+            function aliasedFieldName(attribName, fields) {
+                let fName = attribName;
+
+                // search for aliases
+                if (fields) {
+                    const attribField = fields.find(field => {
+                        return field.name === attribName;
+                    });
+                    if (attribField && attribField.alias && attribField.alias.length > 0) {
+                        fName = attribField.alias;
+                    }
+                }
+                return fName;
+            }
         }
     }
 })();

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -16,13 +16,9 @@
         .factory('layerRegistry', layerRegistryFactory);
 
     function layerRegistryFactory($q, gapiService, layerTypes, configService, configDefaults) {
-        return geoState => layerRegistry(geoState);
+        return geoState => layerRegistry(geoState, geoState.mapService.mapObject);
 
-        function layerRegistry(geoState) {
-            // keep useful references from geoState
-            const ref = {
-                map: geoState.mapService.mapObject
-            };
+        function layerRegistry(geoState, mapObject) {
 
             const layers = {}; // layer collection
             const legend = []; // legend construct, to be consumed by toc; deflection +2
@@ -82,7 +78,7 @@
                                 });
                             });
                             service.registerLayer(l, layerConfig, pAttrib); // https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/286#-K9cmkUQO7pwtwEPOjmK
-                            ref.map.addLayer(l);
+                            mapObject.addLayer(l);
                         });
 
                         // store service in geoState
@@ -120,7 +116,7 @@
                     return;
                 }
 
-                ref.map.removeLayer(l.layer);
+                mapObject.removeLayer(l.layer);
 
                 // TODO: needs more work to manager layerOrder
                 const index = service.legend.indexOf(layerId);

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -5,10 +5,10 @@
      * @ngdoc service
      * @name layerRegistry
      * @module app.geo
-     * @requires
+     * @requires gapiService, mapService, layerTypes, configDefaults
      * @description
      *
-     * The `layerRegistry` factory description.
+     * The `layerRegistry` factory tracks active layers and constructs legend, provide all layer-related functionality like registering, removing, changing visibility, changing opacity, etc.
      *
      */
     angular
@@ -22,9 +22,10 @@
 
         const service = {
             legend,
-            layers, // TODO: remove raw layer array
+            layers,
 
             reset,
+
             generateLayer,
             registerLayer,
             getFormattedAttributes,
@@ -37,6 +38,9 @@
 
         /***/
 
+        /**
+         * Resets layer and legend storage.
+         */
         function reset() {
             // clear layers array
             Object.keys(layers)
@@ -70,6 +74,7 @@
         function removeLayer(layerId) {
             const l = layers[layerId];
 
+            // TODO: don't fail silently; thrown and error; maybe shown message to the user.
             if (!l) {
                 return;
             }

--- a/src/app/geo/layer-registry.spec.js
+++ b/src/app/geo/layer-registry.spec.js
@@ -21,11 +21,11 @@ describe('layerRegistry', () => {
 
         // check registering a layer
         it('should register a layer', () => {
-            let tempLayer = {
+            const tempLayer = {
                 id: 'sausages',
                 setVisibility: () => {}
             };
-            let tempConfig = {
+            const tempConfig = {
                 url: 'http://www.sausagelayer.com/'
             };
             layerRegistry.registerLayer(tempLayer, tempConfig, {});
@@ -53,14 +53,14 @@ describe('layerRegistry', () => {
         });
 
         it('should bundle attributes correctly', () => {
-            let tempLayer = {
+            const tempLayer = {
                 id: 'sausages',
                 setVisibility: () => {}
             };
-            let tempConfig = {
+            const tempConfig = {
                 url: 'http://www.sausagelayer.com/'
             };
-            let tempAttribPromise = $q.resolve({
+            const tempAttribPromise = $q.resolve({
                 layerId: 'sausages',
                 0: {
                     features: [{
@@ -81,6 +81,5 @@ describe('layerRegistry', () => {
                         .toBeDefined();
                 });
         });
-
     });
 });

--- a/src/app/geo/layer-registry.spec.js
+++ b/src/app/geo/layer-registry.spec.js
@@ -1,0 +1,86 @@
+/* global bard, layerRegistry, $q */
+
+describe('layerRegistry', () => {
+
+    // fake gapi service
+    function mockGapiService($provide) {
+        $provide.factory('gapiService', () => {
+            return {};
+        });
+    }
+
+    beforeEach(() => {
+
+        bard.appModule('app.geo', mockGapiService);
+
+        // inject services
+        bard.inject('layerRegistry', '$q');
+    });
+
+    describe('layerRegistry', () => {
+
+        // check registering a layer
+        it('should register a layer', () => {
+            let tempLayer = {
+                id: 'sausages',
+                setVisibility: () => {}
+            };
+            let tempConfig = {
+                url: 'http://www.sausagelayer.com/'
+            };
+            layerRegistry.registerLayer(tempLayer, tempConfig, {});
+
+            // layer is now in registry
+            expect(layerRegistry.layers.sausages)
+                .toBeDefined();
+            expect(layerRegistry.layers.sausages.layer)
+                .toBeDefined();
+            expect(layerRegistry.layers.sausages.layer.id)
+                .toBe('sausages');
+            expect(layerRegistry.layers.sausages.state)
+                .toBeDefined();
+            expect(layerRegistry.layers.sausages.attribs)
+                .toBeDefined();
+            expect(layerRegistry.layers.sausages.state.url)
+                .toBe('http://www.sausagelayer.com/');
+            expect(layerRegistry.legend)
+                .toContain('sausages');
+
+            expect(layerRegistry.layers.sausages.state.options)
+                .toBeDefined();
+            expect(layerRegistry.layers.sausages.state.options.visibility.value)
+                .toBe('on');
+        });
+
+        it('should bundle attributes correctly', () => {
+            let tempLayer = {
+                id: 'sausages',
+                setVisibility: () => {}
+            };
+            let tempConfig = {
+                url: 'http://www.sausagelayer.com/'
+            };
+            let tempAttribPromise = $q.resolve({
+                layerId: 'sausages',
+                0: {
+                    features: [{
+                        attributes: {
+                            abc: '123'
+                        }
+                    }]
+                }
+            });
+
+            layerRegistry.registerLayer(tempLayer, tempConfig, tempAttribPromise);
+
+            layerRegistry.getFormattedAttributes(tempLayer.id, '0')
+                .then(bundledAttributes => {
+                    expect(bundledAttributes.data)
+                        .toBeDefined();
+                    expect(bundledAttributes.columns)
+                        .toBeDefined();
+                });
+        });
+
+    });
+});

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -5,10 +5,10 @@
      * @ngdoc service
      * @name mapService
      * @module app.geo
-     * @requires dependencies
+     * @requires $q
      * @description
      *
-     * The `mapService` factory description.
+     * The `mapService` factory holds references to the map dom node and the currently active map object.
      *
      */
     angular
@@ -21,8 +21,10 @@
             map: null, // contains a reference to `mapManager`
             // { mapManager: <Object>, fullExtent: <Object> }
 
+            buildMapObject,
+
             isReady: null,
-            registerMapNode: null,
+            registerMapNode: null
         };
 
         init();
@@ -31,28 +33,29 @@
 
         /***/
 
+        // TODO: placeholder function
+        function buildMapObject() {}
+
         /**
          * Sets an `isReady` promise resolving when the map node is registered.
          */
         function init() {
             service.isReady =
-                $q((resolve, reject) =>
-                    service.registerMapNode = (node => registerMapNode(resolve, reject, node))
+                $q(resolve =>
+                    service.registerMapNode = (node => registerMapNode(resolve, node))
                 );
         }
 
         /**
          * Stores a reference to the map node.
          * @param  {Function} resolve function to resolve ready promise
-         * @param  {Function} reject  function to reject ready promise
          * @param  {Object} node    dom node to build the map on
          */
-        function registerMapNode(resolve, reject, node) {
-            if (service.mapNode === null && node) {
+        function registerMapNode(resolve, node) {
+            if (service.mapNode === null) {
                 service.mapNode = node;
                 resolve();
             }
         }
-
     }
 })();

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -1,0 +1,62 @@
+(() => {
+    'use strict';
+
+    /**
+     * @ngdoc service
+     * @name mapService
+     * @module app.geo
+     * @requires dependencies
+     * @description
+     *
+     * The `mapService` factory description.
+     *
+     */
+    angular
+        .module('app.geo')
+        .factory('mapService', mapService);
+
+    function mapService($q, gapiService) {
+        let mapNode;
+
+        const service = {
+            map: null,
+
+            mapNode: null,
+
+            isReady: null,
+            registerMapNode: null,
+        };
+
+        init();
+
+        console.log(gapiService);
+
+        return service;
+
+        /***/
+
+        /**
+         * Sets an `isReady` promise resolving when the map node is registered.
+         */
+        function init() {
+            service.isReady =
+                $q((resolve, reject) =>
+                    service.registerMapNode = (node => registerMapNode(resolve, reject, node))
+                );
+        }
+
+        /**
+         * Stores a reference to the map node.
+         * @param  {Function} resolve function to resolve ready promise
+         * @param  {Function} reject  function to reject ready promise
+         * @param  {Object} node    dom node to build the map on
+         */
+        function registerMapNode(resolve, reject, node) {
+            if (typeof mapNode === 'undefined' && node) {
+                mapNode = node;
+                service.mapNode = node;
+                resolve();
+            }
+        }
+    }
+})();

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -48,14 +48,14 @@
                     .then(config => {
                         let mapObject;
 
-                        // reset before rebuilding the map
-                        if (service.mapObject !== null) {
+                        // reset before rebuilding the map if `geoState` already has an instance of mapService
+                        if (typeof geoState.mapService !== 'undefined') {
                             // NOTE: Possible to have dom listeners stick around after the node is destroyed
-                            mapObject = service.mapObject;
-                            mapObject.destroy();
-                            mapObject.mapManager.ScalebarControl.destroy();
-                            mapObject.mapManager.OverviewMapControl.destroy();
-                            mapObject = null;
+                            const mapService = geoState.mapService;
+                            mapService.mapObject.destroy();
+                            mapService.mapManager.ScalebarControl.destroy();
+                            mapService.mapManager.OverviewMapControl.destroy();
+                            mapService.mapObject = null;
                         }
 
                         // FIXME remove the hardcoded settings when we have code which does this properly

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -15,21 +15,17 @@
         .module('app.geo')
         .factory('mapService', mapService);
 
-    function mapService($q, gapiService) {
-        let mapNode;
-
+    function mapService($q) {
         const service = {
-            map: null,
-
             mapNode: null,
+            map: null, // contains a reference to `mapManager`
+            // { mapManager: <Object>, fullExtent: <Object> }
 
             isReady: null,
             registerMapNode: null,
         };
 
         init();
-
-        console.log(gapiService);
 
         return service;
 
@@ -52,11 +48,11 @@
          * @param  {Object} node    dom node to build the map on
          */
         function registerMapNode(resolve, reject, node) {
-            if (typeof mapNode === 'undefined' && node) {
-                mapNode = node;
+            if (service.mapNode === null && node) {
                 service.mapNode = node;
                 resolve();
             }
         }
+
     }
 })();

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -13,48 +13,222 @@
      */
     angular
         .module('app.geo')
-        .factory('mapService', mapService);
+        .factory('mapService', mapServiceFactory);
 
-    function mapService($q) {
-        const service = {
-            mapNode: null,
-            map: null, // contains a reference to `mapManager`
-            // { mapManager: <Object>, fullExtent: <Object> }
+    function mapServiceFactory($q, gapiService, configService) {
+        return geoState => mapService(geoState);
 
-            buildMapObject,
+        function mapService(geoState) {
+            const ref = {
+                fullExtent: null // Object
+            };
 
-            isReady: null,
-            registerMapNode: null
-        };
+            // this `service` object will be exposed through `geoService`
+            const service = {
+                mapObject: null,
+                mapManager: null, // Object
 
-        init();
+                setZoom,
+                shiftZoom,
+                selectBasemap,
+                setFullExtent,
+                zoomToGraphic,
+            };
 
-        return service;
+            return buildMapObject();
 
-        /***/
+            /***/
 
-        // TODO: placeholder function
-        function buildMapObject() {}
+            /**
+             * Builds an actual esri map object
+             * @return {Object} returns `service` object
+             */
+            function buildMapObject() {
+                return configService.getCurrent()
+                    .then(config => {
+                        let mapObject;
 
-        /**
-         * Sets an `isReady` promise resolving when the map node is registered.
-         */
-        function init() {
-            service.isReady =
-                $q(resolve =>
-                    service.registerMapNode = (node => registerMapNode(resolve, node))
-                );
-        }
+                        // reset before rebuilding the map
+                        if (service.mapObject !== null) {
+                            // NOTE: Possible to have dom listeners stick around after the node is destroyed
+                            mapObject = service.mapObject;
+                            mapObject.destroy();
+                            mapObject.mapManager.ScalebarControl.destroy();
+                            mapObject.mapManager.OverviewMapControl.destroy();
+                            mapObject = null;
+                        }
 
-        /**
-         * Stores a reference to the map node.
-         * @param  {Function} resolve function to resolve ready promise
-         * @param  {Object} node    dom node to build the map on
-         */
-        function registerMapNode(resolve, node) {
-            if (service.mapNode === null) {
-                service.mapNode = node;
-                resolve();
+                        // FIXME remove the hardcoded settings when we have code which does this properly
+                        mapObject = gapiService.gapi.mapManager.Map(geoState.mapNode, {
+                            basemap: 'gray',
+                            zoom: 6,
+                            center: [-100, 50]
+                        });
+
+                        // store map object in service
+                        service.mapObject = mapObject;
+
+                        if (config.services && config.services.proxyUrl) {
+                            gapiService.gapi.mapManager.setProxy(config.services.proxyUrl);
+                        }
+
+                        // setup map using configs
+                        // FIXME: I should be migrated to the new config schema when geoApi is updated
+                        const mapSettings = {
+                            basemaps: [],
+                            scalebar: {},
+                            overviewMap: {}
+                        };
+
+                        if (config.baseMaps) {
+                            mapSettings.basemaps = config.baseMaps;
+                        }
+
+                        if (config.map.components.scaleBar) {
+                            mapSettings.scalebar = {
+                                attachTo: 'bottom-left',
+                                scalebarUnit: 'dual'
+                            };
+                        }
+
+                        if (config.map.components.overviewMap && config.map.components.overviewMap.enabled) {
+
+                            // FIXME: overviewMap has more settings
+                            mapSettings.overviewMap = config.map.components.overviewMap;
+                        }
+
+                        if (config.map.extentSets) {
+                            let lFullExtent = getFullExtFromExtentSets(config.map.extentSets);
+
+                            // map extent is not available until map is loaded
+                            if (lFullExtent) {
+                                gapiService.gapi.events.wrapEvents(mapObject, {
+                                    load: () => {
+
+                                        // compare map extent and setting.extent spatial-references
+                                        // make sure the full extent has the same spatial reference as the map
+                                        if (gapiService.gapi.proj.isSpatialRefEqual(mapObject.extent
+                                                .spatialReference,
+                                                lFullExtent.spatialReference)) {
+
+                                            // same spatial reference, no reprojection required
+                                            ref.fullExtent = gapiService.gapi.mapManager.getExtentFromJson(
+                                                lFullExtent);
+                                        } else {
+
+                                            // need to re-project
+                                            ref.fullExtent = gapiService.gapi.proj.projectEsriExtent(
+                                                gapiService.gapi.mapManager.getExtentFromJson(
+                                                    lFullExtent),
+                                                mapObject.extent.spatialReference);
+                                        }
+                                    }
+                                });
+                            }
+                        }
+
+                        service.mapManager = gapiService.gapi.mapManager.setupMap(mapObject, mapSettings);
+
+                        // FIXME temp link for debugging
+                        window.FGPV = {
+                            layers: service.layers
+                        };
+
+                        // store service in geoState
+                        geoState.mapService = service;
+
+                        return service;
+                    });
+            }
+
+            /*
+             * Retrieve full extent from extentSets
+             * [private]
+             */
+            function getFullExtFromExtentSets(extentSets) {
+
+                // FIXME: default basemap should be indicated in the config as well
+                const currentBasemapExtentSetId = '123456789';
+
+                // In configSchema, at least one extent for a basemap
+                const extentSetForId = extentSets.find(extentSet => {
+                    if (extentSet.id === currentBasemapExtentSetId) {
+                        return true;
+                    }
+                });
+
+                // no matching id in the extentset
+                if (angular.isUndefined(extentSetForId)) {
+                    throw new Error('could not find an extent set with matching id.');
+                }
+
+                // find the full extent type from extentSetForId
+                const lFullExtent = (extentSetForId.full) ? extentSetForId.full :
+                    (extentSetForId.default) ? extentSetForId.default :
+                    (extentSetForId.maximum) ? extentSetForId.maximum : null;
+
+                return lFullExtent;
+            }
+
+            /**
+             * Switch basemap based on the uid provided.
+             * @param {string} id identifier for a specific basemap layerbower
+             */
+            function selectBasemap(id) {
+                const mapManager = service.mapManager;
+
+                if (typeof mapManager === 'undefined' || !mapManager.BasemapControl) {
+                    console.error('Error: Map manager or basemap control is not setup,' +
+                        ' please setup map manager by calling setupMap().');
+                } else {
+                    mapManager.BasemapControl.setBasemap(id);
+                }
+            }
+
+            /**
+             * Sets zoom level of the map to the specified level
+             * @param {number} value a zoom level number
+             */
+            function setZoom(value) {
+                service.mapObject.setZoom(value);
+            }
+
+            /**
+             * Changes the zoom level by the specified value relative to the current level; can be negative
+             * @param  {number} byValue a number of zoom levels to shift by
+             */
+            function shiftZoom(byValue) {
+                const map = service.mapObject;
+                let newValue = map.getZoom() + byValue;
+                map.setZoom(newValue);
+            }
+
+            /**
+             * Set the map to full extent
+             */
+            function setFullExtent() {
+                const map = service.mapObject;
+                if (ref.fullExtent) {
+                    map.setExtent(map.fullExtent);
+                } else {
+                    console.warn('GeoService: fullExtent value is not set.');
+                }
+            }
+
+            // only handles feature layers right now. zoom to dynamic/wms layers obj won't work
+            /**
+             * Fetches a point in a layer given the layerUrl and objId of the object and then zooms to it
+             * @param  {layerUrl} layerUrl is the URL that the point to be zoomed to belongs to
+             * @param  {objId} objId is ID of object that was clicked on datatable to be zoomed to
+             */
+            function zoomToGraphic(layerUrl, objId) {
+                const map = service.mapObject;
+                const geo = gapiService.gapi.layer.getFeatureInfo(layerUrl, objId);
+                geo.then(geoInfo => {
+                    if (geoInfo) {
+                        map.centerAndZoom(geoInfo.feature.geometry, 10);
+                    }
+                });
             }
         }
     }

--- a/src/app/global-registry.js
+++ b/src/app/global-registry.js
@@ -1,0 +1,37 @@
+/* global geoapi */
+(() => {
+
+    /**
+     * These are global values defined in the RV registry. They can be overridden by creating a global `RV` object with the same properties __before__ `injector.js` is executed.
+     */
+    const rvDefaults = {
+        dojoURL: 'http://js.arcgis.com/3.14/'
+    };
+
+    // check if the global RV registry object already extists
+    if (typeof window.RV === 'undefined') {
+        window.RV = {};
+    }
+
+    const RV = window.RV; // just a reference
+
+    // apply default values to the global RV registry
+    Object.keys(rvDefaults)
+        .forEach(key => applyDefault(key, rvDefaults[key]));
+
+    // initialize gapi and store a return promise
+    RV.gapiPromise = geoapi(RV.dojoURL, window);
+
+    /***/
+
+    /**
+     * Checks if a property is already set and applies the default.
+     * @param  {String} name  property name
+     * @param  {String|Object|Number} value default value
+     */
+    function applyDefault(name, value) {
+        if (typeof RV[name] === 'undefined') {
+            RV[name] = value;
+        }
+    }
+})();

--- a/src/app/layout/shell.directive.js
+++ b/src/app/layout/shell.directive.js
@@ -1,7 +1,4 @@
 /* global HolderIpsum */
-/* jshint maxparams: 999 */
-
-// TODO: re-enable maxparam rule
 (() => {
     'use strict';
 
@@ -12,9 +9,9 @@
      * @restrict E
      * @description
      *
+     * // TODO: update comments since it's a directive now and much had changed.
      * The `ShellController` controller handles the shell which is the visible part of the layout.
      * `self.isLoading` is initially `true` and causes the loading overlay to be displayed; when `configService` resolves, it's set to `false` and the loading overly is removed.
-     * // TODO: update comments since it's a directive now.
      */
     angular
         .module('app.layout')
@@ -40,18 +37,17 @@
         }
     }
 
-    // disable jshint maxparam rule; this module will be trimmed down - there is a lot of garbage/demo code here
-    function Controller($timeout, $q, configService, $rootScope, $mdDialog, events, version, sideNavigationService,
-        stateManager, $translate, geoService) {
-        /* jshint maxparams: 10 */
+    // TODO: clean; there is a lot of garbage/demo code here
+    function Controller($timeout, $q, $mdDialog, version, stateManager, sideNavigationService, $translate,
+        geoService) {
         'ngInject';
         const self = this;
 
-        configService.getCurrent().then(config => {
-            self.config = config;
-        });
-        self.isLoading = true;
+        self.geoService = geoService;
+
         self.version = version;
+
+        /***/
 
         self.singlePoint = singlePoint;
         self.multiplePoints = multiplePoints;
@@ -108,7 +104,7 @@
             }
         ];
 
-        activate();
+        /***/
 
         /**************/
 
@@ -133,20 +129,6 @@
                 self.helpSummary.push(section);
             }
             console.log(self);
-        }
-
-        /**
-         * Controller's activate function.
-         */
-        function activate() {
-            $rootScope.$on(events.rvReady, hideLoadingScreen);
-        }
-
-        /**
-         * Sets `self.isLoading` to false which hides the loading overlay.
-         */
-        function hideLoadingScreen() {
-            self.isLoading = false;
         }
 
         // FIXME: move to a directive or sidenav

--- a/src/app/layout/shell.directive.js
+++ b/src/app/layout/shell.directive.js
@@ -153,11 +153,8 @@
         function languageSwitch(lang) {
             $translate.use(lang);
 
-            // TODO: Make init-map register its node with config/geo so that
-            //       dom manipulations stay in link functions
-            configService.getCurrent().then(config => {
-                geoService.buildMap($('div[rv-init-map]')[0], config);
-            });
+            // TODO: move this somewhere more appropriate
+            geoService.buildMap();
         }
 
         // TODO: hack

--- a/src/app/layout/shell.directive.js
+++ b/src/app/layout/shell.directive.js
@@ -154,7 +154,7 @@
             $translate.use(lang);
 
             // TODO: move this somewhere more appropriate
-            geoService.buildMap();
+            geoService.assembleMap();
         }
 
         // TODO: hack

--- a/src/app/layout/shell.directive.spec.js
+++ b/src/app/layout/shell.directive.spec.js
@@ -5,6 +5,23 @@ describe('rvShell', () => {
     let directiveScope; // needed since directive requests an isolated scope
     let directiveElement;
 
+    // fake gapi service
+    function mockGapiService($provide) {
+        $provide.factory('gapiService', () => {
+            return {};
+        });
+    }
+
+    // fake gapi service
+    function mockGeoService($provide) {
+        $provide.factory('geoService', () => {
+            return {
+                assembleMap: angular.noop,
+                registerMapNode: angular.noop,
+            };
+        });
+    }
+
     // mock custom loader module
     function customTranslateLoader($provide, $translateProvider) {
         // for customLoader use a function returning a self-fulfilling promise to mock the service
@@ -29,7 +46,8 @@ describe('rvShell', () => {
 
     beforeEach(() => {
         // mock the module with bardjs; include templates modules
-        bard.appModule('app.layout', 'app.templates', 'app.ui', customTranslateLoader, mockConfigService);
+        bard.appModule('app.layout', 'app.templates', 'app.ui', customTranslateLoader,
+            mockConfigService, mockGapiService, mockGeoService);
 
         // inject angular services
         bard.inject('$compile', '$rootScope', '$httpBackend', '$q');

--- a/src/app/layout/shell.html
+++ b/src/app/layout/shell.html
@@ -3,13 +3,13 @@
 
         <!-- TODO: add proper loading message or animation to the loading splash -->
         <div class="rv-loading" layout layout-align="center center"
-            ng-class="{ 'rv-loaded': !self.isLoading }">
+            ng-class="{ 'rv-loaded': self.geoService.isReady }">
             <div class="rv-loading-section rv-left"></div>
             <div class="rv-loading-section rv-right"></div>
             <div class="rv-spinner google-spin-wrapper"><div class="google-spin"></div></div>
         </div>
 
-        <div class="rv-esri-map" rv-init-map="!self.isLoading"></div>
+        <div class="rv-esri-map" rv-init-map></div>
 
         <rv-mapnav rv-morph="mapnav"></rv-mapnav>
 
@@ -38,10 +38,7 @@
 
         <!--div ng-class="{ active: self.active }" ui-view="geoSearchPlug"></div-->
 
-        <md-whiteframe class="md-whiteframe-z1" layout layout-align="center center" style="display: none;">I'm
-            {{ self.config.title }}
-            and
-            {{ 'page.title' | translate }}</md-whiteframe>
+        <!-- TODO: The following is garbage and should be removed at some point before release -->
 
             <md-button class="md-raised" ng-click="self.loaderFile()" style="    left: 50%;
         position: fixed; bottom: 150px;">Layer Loader File</md-button>

--- a/src/app/layout/shell.html
+++ b/src/app/layout/shell.html
@@ -3,7 +3,7 @@
 
         <!-- TODO: add proper loading message or animation to the loading splash -->
         <div class="rv-loading" layout layout-align="center center"
-            ng-class="{ 'rv-loaded': self.geoService.isReady }">
+            ng-class="{ 'rv-loaded': self.geoService.isMapReady }">
             <div class="rv-loading-section rv-left"></div>
             <div class="rv-loading-section rv-right"></div>
             <div class="rv-spinner google-spin-wrapper"><div class="google-spin"></div></div>

--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -18,7 +18,7 @@
      *
      * @return {object} directive body
      */
-    function rvFiltersDefault($timeout, $q, stateManager, geoService) {
+    function rvFiltersDefault($timeout, $q, stateManager, geoService, layerRegistry) {
         const directive = {
             restrict: 'E',
             templateUrl: 'app/ui/filters/filters-default.html',
@@ -89,9 +89,9 @@
                     const objId = dt.context[0].aoData[indexes[0]]._aData[0];
                     const layerId = self.display.requester.id;
                     const featureIndex = self.display.data.featureIndex;
-                    let layerUrl = geoService.layers[layerId].layer.url + '/';
+                    let layerUrl = layerRegistry.layers[layerId].layer.url + '/';
 
-                    if (geoService.layers[layerId].layer.layerInfos) {
+                    if (layerRegistry.layers[layerId].layer.layerInfos) {
                         layerUrl += featureIndex + '/';
                     }
 

--- a/src/app/ui/mapnav/mapnav.service.spec.js
+++ b/src/app/ui/mapnav/mapnav.service.spec.js
@@ -12,6 +12,13 @@ describe('mapNavigationService', () => {
         });
     }
 
+    // fake gapi service
+    function mockGeoService($provide) {
+        $provide.factory('geoService', () => {
+            return {};
+        });
+    }
+
     beforeEach(() => {
         /*
             mock the module with bardjs: https://github.com/wardbell/bardjs#appmodule
@@ -20,7 +27,7 @@ describe('mapNavigationService', () => {
             Here 'app.ui.mapnav' module is identified as we are testing `mapNavigationService` service. We also need 'app.common.router' module since mapNavigationService uses StateManager.
         */
         bard.appModule('app.ui.mapnav', 'app.common.router', 'app.geo', 'pascalprecht.translate',
-            mockConfigService);
+            mockConfigService, mockGeoService);
 
         /*
             injects angular components needed for testing and stores them on the global window object: https://github.com/wardbell/bardjs#inject

--- a/src/app/ui/mapnav/mapnav.service.spec.js
+++ b/src/app/ui/mapnav/mapnav.service.spec.js
@@ -5,6 +5,13 @@
 */
 
 describe('mapNavigationService', () => {
+
+    function mockConfigService($provide) {
+        $provide.factory('configService', () => {
+            return {};
+        });
+    }
+
     beforeEach(() => {
         /*
             mock the module with bardjs: https://github.com/wardbell/bardjs#appmodule
@@ -12,7 +19,8 @@ describe('mapNavigationService', () => {
 
             Here 'app.ui.mapnav' module is identified as we are testing `mapNavigationService` service. We also need 'app.common.router' module since mapNavigationService uses StateManager.
         */
-        bard.appModule('app.ui.mapnav', 'app.common.router', 'app.geo', 'pascalprecht.translate');
+        bard.appModule('app.ui.mapnav', 'app.common.router', 'app.geo', 'pascalprecht.translate',
+            mockConfigService);
 
         /*
             injects angular components needed for testing and stores them on the global window object: https://github.com/wardbell/bardjs#inject

--- a/src/app/ui/toc/layer-group-toggle-button.directive.spec.js
+++ b/src/app/ui/toc/layer-group-toggle-button.directive.spec.js
@@ -25,6 +25,13 @@ describe('rvLayerGroupToggleButton', () => {
         $provide.factory('layoutService', $q => () => $q(fulfill => fulfill()));
     }
 
+    // fake gapi service
+    function mockGeoService($provide) {
+        $provide.factory('geoService', () => {
+            return {};
+        });
+    }
+
     function mockToast($provide) {
         $provide.service('$mdToast', () => {});
     }
@@ -32,7 +39,7 @@ describe('rvLayerGroupToggleButton', () => {
     beforeEach(() => {
         // mock the module with bardjs; include templates modules
         bard.appModule('app.ui.toc', 'app.templates', 'app.common.router', 'app.geo',
-            'pascalprecht.translate', mockLayoutService, mockToast);
+            'pascalprecht.translate', mockLayoutService, mockGeoService, mockToast);
 
         // inject angular services
         bard.inject('$compile', '$rootScope', '$httpBackend', 'tocService');

--- a/src/app/ui/toc/layer-group-toggle.directive.spec.js
+++ b/src/app/ui/toc/layer-group-toggle.directive.spec.js
@@ -24,6 +24,13 @@ describe('rvLayerGroupToggle', () => {
         $provide.factory('layoutService', $q => () => $q(fulfill => fulfill()));
     }
 
+    // fake gapi service
+    function mockGeoService($provide) {
+        $provide.factory('geoService', () => {
+            return {};
+        });
+    }
+
     function mockToast($provide) {
         $provide.service('$mdToast', () => {});
     }
@@ -37,7 +44,7 @@ describe('rvLayerGroupToggle', () => {
     beforeEach(() => {
         // mock the module with bardjs; include templates modules
         bard.appModule('app.ui.toc', 'app.templates', mockMdDialog, 'app.common.router', 'app.geo',
-            'pascalprecht.translate', mockLayoutService, mockToast);
+            'pascalprecht.translate', mockLayoutService, mockGeoService, mockToast);
 
         // inject angular services
         bard.inject('$compile', '$rootScope', 'tocService');

--- a/src/app/ui/toc/layer-item-button.directive.spec.js
+++ b/src/app/ui/toc/layer-item-button.directive.spec.js
@@ -25,6 +25,13 @@ describe('rvLayerItemButton', () => {
         $provide.factory('layoutService', $q => () => $q(fulfill => fulfill()));
     }
 
+    // fake gapi service
+    function mockGeoService($provide) {
+        $provide.factory('geoService', () => {
+            return {};
+        });
+    }
+
     function mockToast($provide) {
         $provide.service('$mdToast', () => {});
     }
@@ -32,7 +39,7 @@ describe('rvLayerItemButton', () => {
     beforeEach(() => {
         // mock the module with bardjs; include templates modules
         bard.appModule('app.ui.toc', 'app.templates', 'app.common.router', 'app.geo',
-            'pascalprecht.translate', mockLayoutService, mockToast);
+            'pascalprecht.translate', mockLayoutService, mockGeoService, mockToast);
 
         // inject angular services
         bard.inject('$compile', '$rootScope', '$httpBackend', 'tocService');

--- a/src/app/ui/toc/layer-item-flag.directive.spec.js
+++ b/src/app/ui/toc/layer-item-flag.directive.spec.js
@@ -24,6 +24,13 @@ describe('rvLayerItemFlag', () => {
         $provide.factory('layoutService', $q => () => $q(fulfill => fulfill()));
     }
 
+    // fake gapi service
+    function mockGeoService($provide) {
+        $provide.factory('geoService', () => {
+            return {};
+        });
+    }
+
     function mockToast($provide) {
         $provide.service('$mdToast', () => {});
     }
@@ -31,7 +38,7 @@ describe('rvLayerItemFlag', () => {
     beforeEach(() => {
         // mock the module with bardjs; include templates modules
         bard.appModule('app.ui.toc', 'app.templates', 'app.common.router', 'app.geo',
-            'pascalprecht.translate', mockLayoutService, mockToast);
+            'pascalprecht.translate', mockLayoutService, mockGeoService, mockToast);
 
         // inject angular services
         bard.inject('$compile', '$rootScope');

--- a/src/app/ui/toc/layer-item.directive.spec.js
+++ b/src/app/ui/toc/layer-item.directive.spec.js
@@ -30,6 +30,13 @@ describe('rvLayerItem', () => {
         $provide.factory('layoutService', $q => () => $q(fulfill => fulfill()));
     }
 
+    // fake gapi service
+    function mockGeoService($provide) {
+        $provide.factory('geoService', () => {
+            return {};
+        });
+    }
+
     function mockToast($provide) {
         $provide.service('$mdToast', () => {});
     }
@@ -37,7 +44,7 @@ describe('rvLayerItem', () => {
     beforeEach(() => {
         // mock the module with bardjs; include templates modules
         bard.appModule('app.ui.toc', 'app.templates', 'app.common.router', 'app.geo',
-            'pascalprecht.translate', mockLayoutService, mockToast);
+            'pascalprecht.translate', mockLayoutService, mockGeoService, mockToast);
 
         // inject angular services
         bard.inject('$compile', '$rootScope', '$httpBackend', 'tocService');

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -19,7 +19,7 @@
         .factory('tocService', tocService);
 
     function tocService($timeout, $q, $rootScope, $mdToast, layoutService, stateManager,
-        layerRegistry, metadataService) {
+        geoService, metadataService) {
         // TODO: remove after switching to the real config
         // jscs:disable maximumLineLength
         const service = {
@@ -806,22 +806,23 @@
 
         // remove
         $timeout(() => {
-            service.data.items[0].items = layerRegistry.legend.map(id => {
+            console.info(geoService);
+            service.data.items[0].items = geoService.legend.map(id => {
                 // add some fake symbology for now
-                layerRegistry.layers[id].state.symbology = [
+                geoService.layers[id].state.symbology = [
                     {
                         icon: 'url',
                         name: HolderIpsum.words(3, true)
                     }
                 ];
-                layerRegistry.layers[id].state.cache = {};
-                layerRegistry.layers[id].state.flags.type.value = layerRegistry.layers[id].state.layerType;
+                geoService.layers[id].state.cache = {};
+                geoService.layers[id].state.flags.type.value = geoService.layers[id].state.layerType;
 
-                return layerRegistry.layers[id].state;
+                return geoService.layers[id].state;
             });
 
             // console.log('--->', service.data.items[0]);
-        }, 7000); // FIXME: wait for layer to be added to the layer registry; this will not be needed as we are going to bind directly to layer/legend construction from layerRegistry; this is needed right now to keep the fake layers in the layer selector as well.
+        }, 7000); // FIXME: wait for layer to be added to the layer registry; this will not be needed as we are going to bind directly to layer/legend construction from geoService; this is needed right now to keep the fake layers in the layer selector as well.
 
         // set state change watches on metadata, settings and filters panel
         watchPanelState('sideMetadata', 'metadata');
@@ -894,7 +895,7 @@
                         toggleVisiblity(layer, layerOriginalVisibility);
                     } else {
                         // remove layer for real now
-                        layerRegistry.removeLayer(layer.id);
+                        geoService.removeLayer(layer.id);
                     }
                 });
         }
@@ -940,7 +941,7 @@
 
             value = value || toggle[control.value];
 
-            layerRegistry.setLayerVisibility(layer.id, value);
+            geoService.setLayerVisibility(layer.id, value);
         }
 
         // temp function to open layer groups
@@ -978,7 +979,7 @@
             };
 
             // wait for attributes to be loaded, then process them into grid format
-            const dataPromise = layerRegistry.layers[layer.id].attribs.then(attribBundle => {
+            const dataPromise = geoService.layers[layer.id].attribs.then(attribBundle => {
                 let layerId = layer.id;
                 let layerIdx;
 
@@ -994,7 +995,7 @@
                     layerIdx = attribBundle.indexes[0];
                 }
 
-                return layerRegistry.getFormattedAttributes(layerId, layerIdx);
+                return geoService.getFormattedAttributes(layerId, layerIdx);
             }).then(attrs => {
                 return {
                     data: {

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -18,7 +18,7 @@
         .module('app.ui.toc')
         .factory('tocService', tocService);
 
-    function tocService($timeout, $q, $rootScope, $mdToast, layoutService, stateManager, geoService, metadataService) {
+    function tocService($timeout, $q, $rootScope, $mdToast, layoutService, stateManager, layerRegistry, metadataService) {
         // TODO: remove after switching to the real config
         // jscs:disable maximumLineLength
         const service = {
@@ -805,22 +805,22 @@
 
         // remove
         $timeout(() => {
-            service.data.items[0].items = geoService.layerOrder.map(id => {
+            service.data.items[0].items = layerRegistry.legend.map(id => {
                 // add some fake symbology for now
-                geoService.layers[id].state.symbology = [
+                layerRegistry.layers[id].state.symbology = [
                     {
                         icon: 'url',
                         name: HolderIpsum.words(3, true)
                     }
                 ];
-                geoService.layers[id].state.cache = {};
-                geoService.layers[id].state.flags.type.value = geoService.layers[id].state.layerType;
+                layerRegistry.layers[id].state.cache = {};
+                layerRegistry.layers[id].state.flags.type.value = layerRegistry.layers[id].state.layerType;
 
-                return geoService.layers[id].state;
+                return layerRegistry.layers[id].state;
             });
 
             // console.log('--->', service.data.items[0]);
-        }, 7000); // FIXME: wait for layer to be added to the layer registry; this will not be needed as we are going to bind directly to layer/legend construction from geoservice; this is needed right now to keep the fake layers in the layer selector as well.
+        }, 7000); // FIXME: wait for layer to be added to the layer registry; this will not be needed as we are going to bind directly to layer/legend construction from layerRegistry; this is needed right now to keep the fake layers in the layer selector as well.
 
         // set state change watches on metadata, settings and filters panel
         watchPanelState('sideMetadata', 'metadata');
@@ -852,7 +852,7 @@
          * Simple function to remove layers.
          * TODO: needs more work to handle dynamic layer and other crazy stuff
          * TODO: need to consider what happens when removing the only layer in the group; remove the group as well? etc.
-         * Hides the layer data and removes the node from the layer selector; removes the layer from geoservice after toast delay has passed;adds the layer back to the layer selctor if user click `undo`.
+         * Hides the layer data and removes the node from the layer selector; removes the layer from
          * @param  {Object} layer layerItem object from the layer selector
          */
         function removeLayer(layer) {
@@ -893,7 +893,7 @@
                         toggleVisiblity(layer, layerOriginalVisibility);
                     } else {
                         // remove layer for real now
-                        geoService.removeLayer(layer.id);
+                        layerRegistry.removeLayer(layer.id);
                     }
                 });
         }
@@ -939,7 +939,7 @@
 
             value = value || toggle[control.value];
 
-            geoService.setLayerVisibility(layer.id, value);
+            layerRegistry.setLayerVisibility(layer.id, value);
         }
 
         // temp function to open layer groups
@@ -977,7 +977,7 @@
             };
 
             // wait for attributes to be loaded, then process them into grid format
-            const dataPromise = geoService.layers[layer.id].attribs.then(attribBundle => {
+            const dataPromise = layerRegistry.layers[layer.id].attribs.then(attribBundle => {
                 let layerId = layer.id;
                 let layerIdx;
 
@@ -993,7 +993,7 @@
                     layerIdx = attribBundle.indexes[0];
                 }
 
-                return geoService.getFormattedAttributes(layerId, layerIdx);
+                return layerRegistry.getFormattedAttributes(layerId, layerIdx);
             }).then(attrs => {
                 return {
                     data: {

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -18,7 +18,8 @@
         .module('app.ui.toc')
         .factory('tocService', tocService);
 
-    function tocService($timeout, $q, $rootScope, $mdToast, layoutService, stateManager, layerRegistry, metadataService) {
+    function tocService($timeout, $q, $rootScope, $mdToast, layoutService, stateManager,
+        layerRegistry, metadataService) {
         // TODO: remove after switching to the real config
         // jscs:disable maximumLineLength
         const service = {

--- a/src/config.fr.json
+++ b/src/config.fr.json
@@ -48,7 +48,7 @@
   "layers": [
     {
       "id":"ecogeo",
-      "name": "Eco Geo",
+      "name": "[fr] Eco Geo",
       "layerType":"esriDynamic",
       "layerEntries": [{"index": 0}],
       "url":"http://maps-cartes.ec.gc.ca/ArcGIS/rest/services/ECNY/MapServer"
@@ -68,9 +68,9 @@
     },
     {
       "id":"rail_wms",
-      "name": "Railways",
+      "name": "French Railways",
       "layerType":"ogcWms",
-      "url":"http://maps.geogratis.gc.ca/wms/railway_en",
+      "url":"http://maps.geogratis.gc.ca/wms/railway_fr",
       "layerEntries": [ {"id": "railway.track"} ]
     },
     {


### PR DESCRIPTION
Causes __Panic__ for 60min.

New services created: `layerRegistry`, `mapService` and `gapiService`. They do not directly depend on `geoService`.

`layerRegistry` manipulation with layers mostly (generate, register, remove, etc.)
`mapService` used to register map node and hold reference to the map object
`gapiService` holds reference to gapi

`gapi` loading is hoisted and now starts when the lib package is download, even before `app-seed` initializes app instances.

`identifyService` now accesses layers directly from `layerRegistry`, not storing them itself. This solves the growing number of layers when swapping configs. #367

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/381)
<!-- Reviewable:end -->
