### PR TITLE
Legend Service cont.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,14 +26,14 @@
     "holder-ipsum": "https://github.com/euangoddard/holder-ipsum.git",
     "datatables.net": "~1.10.10",
     "datatables.net-dt": "~1.10.10",
-        "datatables-scroller": "~1.4.0",
-        "datatables-select":"~1.1.2",
-        "ng-flow": "~2.7.1"
+    "datatables-scroller": "~1.4.0",
+    "datatables-select": "~1.1.2",
+    "ng-flow": "~2.7.1"
   },
   "overrides": {
-        "ng-flow": {
-            "main": "dist/ng-flow-standalone.js"
-        },
+    "ng-flow": {
+      "main": "dist/ng-flow-standalone.js"
+    },
     "datatables-scroller": {
       "main": "js/dataTables.scroller.js",
       "dependencies": null
@@ -70,6 +70,6 @@
     }
   },
   "resolutions": {
-    "angular": "1.4.9"
+    "angular": "1.4.10"
   }
 }

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -46,6 +46,11 @@
 
             /***/
 
+            /**
+             * Creates esri layer object for a set of layers provided by the config, triggers attribute loading on layer load event and adds it to the legend afterwards.
+             * // TODO: might need to abstract this further to accomodate user-added layers as they need to go through the same process
+             * @return {Object} self for chaining
+             */
             function constructLayers() {
                 config.layers.forEach(layerConfig => {
                     // TODO: decouple identifyservice from everything
@@ -76,12 +81,13 @@
                 return service;
             }
 
+            /**
+             * Starts loading attributes for the specified layer.
+             * @param  {Object} layer esri layer object
+             * @return {Promise} a promise resolving with the retrieved attribute data
+             */
             function loadLayerAttributes(layer) {
                 return gapiService.gapi.attribs.loadLayerAttribs(layer)
-                    /*.then(data => {
-                        // registerAttributes(data);
-                        resolve(data);
-                    })*/
                     .catch(exception => {
                         console.error(
                             'Error getting attributes for ' +

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -264,6 +264,7 @@
 
         /**
          * TODO: Work in progress... Works fine for feature layers only right now; everything else gest a generic icon;
+         * TODO: move to geoapi as it's stateless and very specific
          * Scrapes feaure and dynamic layers for their symbology;
          *
          * * data.layers [

--- a/src/app/ui/toc/layer-item-flag.html
+++ b/src/app/ui/toc/layer-item-flag.html
@@ -1,7 +1,7 @@
 <div class="rv-icon-14 rv-layer-item-flag" ng-if="self.control.visible" rv-help="layer-flag"
     aria-label="{{ self.template.tooltip[self.control.value] || self.template.tooltip | translate }}">
 
-    <md-tooltip md-direction="top">{{ self.template.tooltip[self.control.value] || self.template.tooltip | translate }}</md-tooltip>
+    <md-tooltip md-direction="right">{{ self.template.tooltip[self.control.value] || self.template.tooltip | translate }}</md-tooltip>
     <md-icon md-svg-src="{{ self.template.icon[self.control.value] || self.template.icon }}"></md-icon>
 
 </div>

--- a/src/app/ui/toc/layer-item-symbology.html
+++ b/src/app/ui/toc/layer-item-symbology.html
@@ -1,7 +1,7 @@
 <div class="rv-layer-item-icon rv-single" ng-if="self.symbology.length == 1">
 
     <div class="rv-symbology-item">
-        <img alt="" class="md-whiteframe-z1" ng-src="http://lorempixel.com/32/32/?{{self.random}}"/>
+        <img alt="" class="md-whiteframe-z1" ng-src="{{ self.symbology[0].icon }}"/>
     </div>
 </div>
 
@@ -21,8 +21,8 @@
     <div class="rv-symbology-container">
 
         <div class="rv-symbology-item" ng-repeat="symbol in self.symbology">
-            <img class="md-whiteframe-z1" alt="" ng-src="http://lorempixel.com/32/32/?{{self.random}}{{$index}}"/>
-            <span class="rv-symbology-item-name">{{symbol.name}}</span>
+            <img class="md-whiteframe-z1" alt="" ng-src="{{ symbol.icon }}"/>
+            <span class="rv-symbology-item-name">{{ symbol.name }}</span>
         </div>
 
     </div>

--- a/src/app/ui/toc/layer-item.html
+++ b/src/app/ui/toc/layer-item.html
@@ -3,6 +3,7 @@
     <md-button
         class="rv-layer-body-button rv-button-square"
         rv-help="layer-item"
+        ng-if="self.layer.options.data"
         ng-click="self.toggleLayerFiltersPanel(self.layer)">
         <!-- TODO: add aria attribues on the button to provide context on what it does; also mute the actual layer name below, so a screen reader wouldn't pronounce it twice-->
     </md-button>

--- a/src/app/ui/toc/layer-item.html
+++ b/src/app/ui/toc/layer-item.html
@@ -1,6 +1,7 @@
 <div class="rv-layer-item-inner-container" ng-class="{ 'rv-selected': self.layer.selected }">
 
     <md-button
+        aria-label='layer data'
         class="rv-layer-body-button rv-button-square"
         rv-help="layer-item"
         ng-if="self.layer.options.data"

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -1144,7 +1144,7 @@
                 layer.options[optionName].selected = newValue; // select the toggle to stay visible
 
                 // check if any toggle is selected; if so, select the layer
-                let layerSelectedValue = Object.keys(DISPLAY_SWITCH)
+                const layerSelectedValue = Object.keys(DISPLAY_SWITCH)
                     .some(key => {
                         const value = DISPLAY_SWITCH[key];
                         return layer.options[value].selected;

--- a/src/config.en.json
+++ b/src/config.en.json
@@ -61,6 +61,13 @@
       "url":"http://maps-cartes.ec.gc.ca/ArcGIS/rest/services/OilSands/MapServer/0"
     },
     {
+      "id":"aafc_plant_hardiness_zones",
+      "name": "AAFC Plant Hardiness Zones",
+      "layerType":"esriDynamic",
+      "layerEntries": [{"index": 0}],
+      "url":"http://www.agr.gc.ca/atlas/rest/services/mapservices/aafc_plant_hardiness_zones/MapServer"
+    },
+    {
       "id":"aafc_dynamic_layer",
       "name": "AAFC Census of Agriculture 2011",
       "layerType":"esriDynamic",


### PR DESCRIPTION
Added more stuff to `legendService`:
- generates dynamic legend layer entries with symbology
- generates feature legend entries with symbology
- generates esri image with default symbology

Next:
- ~~if dynamic layer has only one child layer, omit the group entry~~ :point_up: [March 17, 2016 10:23 AM](https://gitter.im/fgpv-vpgf?at=56eabdda3194fbd11097e879)
- add wms legend to the layer selector
- connect dynamic layer children to the appropriate datatables
- generate options/flags for dynamic layer children 
- connect settings/visibility/opacity of dynamic layer children to layer selector
- include only dynamic layer children specified in the config layerEntries
- omit data/image groups if they have no layers
- add options to remove groups (dynamic layer)
- add options to change settings to group (dynamic layer)
- do whatever I forgot

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/394)
<!-- Reviewable:end -->
