### PR TITLE
fix(ui): basemap check in front, set on init

### DIFF
--- a/src/app/ui/basemap/basemap-item.html
+++ b/src/app/ui/basemap/basemap-item.html
@@ -15,11 +15,13 @@
 
         <div class="rv-basemap-footer">
             <span>
+                <md-icon class="rv-basemap-check" md-svg-src="navigation:check" ng-if="self.basemap.selected"></md-icon>
+            </span>
+            <span>
                 <span class="rv-basemap-name md-body-2">{{ self.basemap.name }}</span>,
                 <span class="rv-basemap-type md-caption">{{ self.basemap.type }}</span>
             </span>
             <span flex></span>
-            <md-icon class="rv-basemap-check" md-svg-src="navigation:check" ng-if="self.basemap.selected"></md-icon>
         </div>
     </md-button>
 

--- a/src/app/ui/basemap/basemap.directive.js
+++ b/src/app/ui/basemap/basemap.directive.js
@@ -138,6 +138,14 @@
 
                 });
 
+                // FIXME add appropriate safeguards for no basemaps, if not handled by fixme above.
+                try {
+                    // select first basemap so UI displays it
+                    self.projections[0].items[0].selected = true;
+                } catch (e) {
+                    // no basemaps. ignore :'D
+                }
+
                 console.log(basemaps);
             });
 


### PR DESCRIPTION
Place selected basemap checkmark before the text, so people can see it.  
Set the selected property at init so the first basemap has the checkmark.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/436)
<!-- Reviewable:end -->
