### PR TITLE
Toc update (< 30 files)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "gsap": "^1.18.0",
     "bezier-easing": "^1.0.0",
     "dotjem-angular-tree": "~0.2.1",
-    "geoapi": "http://fgpv.cloudapp.net/demo/gapi/geoapi-0.9.0-3.tgz",
+    "geoapi": "http://fgpv.cloudapp.net/demo/gapi/geoapi-0.9.0-4.tgz",
     "holder-ipsum": "https://github.com/euangoddard/holder-ipsum.git",
     "datatables.net": "~1.10.10",
     "datatables.net-dt": "~1.10.10",

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -38,8 +38,7 @@
                 registerLayer,
                 getFormattedAttributes,
                 removeLayer,
-                aliasedFieldName,
-                setLayerOpacity
+                aliasedFieldName
             };
 
             return constructLayers();
@@ -166,7 +165,6 @@
                 layers[layer.id] = layerRecord;
 
                 // TODO: apply config values
-                // -->>>> service.setLayerOpacity(layer, initialState.options.opacity.value);
                 ref.legendService.addLayer(layerRecord);
 
                 // FIXME:
@@ -200,9 +198,6 @@
                     return l;
                 };
                 handlers[layerTypes.esriImage] = config => {
-
-                    // FIXME don't hardcode opacity
-                    commonConfig.opacity = 0.3;
                     return new gapiService.gapi.layer.ArcGISImageServiceLayer(config.url, commonConfig);
                 };
                 handlers[layerTypes.esriTile] = config => {
@@ -298,15 +293,6 @@
                     }
                 }
                 return fName;
-            }
-
-            /**
-             * Set the opacity of given layer to a value.
-             * @param {Object} layer set the opacity value of this layer
-             * @param {Number} opacity value that layer will be set to
-             */
-            function setLayerOpacity(layer, opacity) {
-                layer.setOpacity(opacity);
             }
         }
     }

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -204,7 +204,7 @@
                 };
                 handlers[layerTypes.ogcWms] = config => {
                     commonConfig.visibleLayers = [config.layerName];
-                    return new gapiService.gapi.layer.WmsLayer(config.url, commonConfig);
+                    return new gapiService.gapi.layer.ogc.WmsLayer(config.url, commonConfig);
                 };
 
                 if (handlers.hasOwnProperty(layerConfig.layerType)) {

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -181,8 +181,7 @@
                 const handlers = {};
 
                 const commonConfig = {
-                    id: layerConfig.id,
-                    visible: layerConfig.visibility === 'on',
+                    id: layerConfig.id
                 };
                 handlers[layerTypes.esriDynamic] = config => {
                     const l = new gapiService.gapi.layer.ArcGISDynamicMapServiceLayer(config.url, commonConfig);

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -377,12 +377,15 @@
 
             // well, if it's not supported, we can't set opacity for sublayers, bummer
             if (this._layerRef.supportsDynamicLayers) {
-                const optionsArray = subIds.map(subId => {
+                const optionsArray = [];
+
+                // create an array of drawing options
+                subIds.forEach(subId => {
                     const opacityValue = this.slaves[subId].options.opacity.value;
                     const drawingOptions = new gapiService.gapi.layer.LayerDrawingOptions();
                     drawingOptions.transparency = (opacityValue - 1) * -100; // instead of being consistent, esri using value from 0 to 100 for sublayer transparency where 100 is fully transparent
 
-                    return drawingOptions;
+                    optionsArray[subId] = drawingOptions;
                 });
 
                 this._layerRef.setLayerDrawingOptions(optionsArray);

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -35,12 +35,15 @@
 
         const service = {
             singleLayerEntry,
-            dynamicLayerEntry
+            dynamicLayerEntry,
+            entryGroup,
+            dynamicEntryGroup,
+            dynamicEntryMasterGroup
         };
 
         // jscs doesn't like enhanced object notation
         // jscs:disable requireSpacesInAnonymousFunctionExpression
-        const LAYER_ENTRY = {
+        const ENTRY_ITEM = {
             _layerRef: null,
             type: 'layer',
             name: 'dogguts',
@@ -48,7 +51,7 @@
             options: null,
             flags: null,
             state: 'rv-default', // TODO: replace
-            cache: {}, // to cache stuff like retrieved metadata info
+            cache: null, // to cache stuff like retrieved metadata info
             symbology: [{
                 icon: NO_IMAGE,
                 name: ''
@@ -81,8 +84,9 @@
 
                 this._layerRef = layerRef;
                 this.id = 'rv_lt_' + itemIdCounter++;
-                this.options = angular.extend({}, defaults.options);
-                this.flags = angular.extend({}, defaults.flags);
+                this.options = angular.merge({}, defaults.options);
+                this.flags = angular.merge({}, defaults.flags);
+                this.cache = {};
 
                 angular.merge(this, initialState);
 
@@ -101,53 +105,234 @@
             }
         };
 
+        const ENTRY_GROUP = {
+            type: 'group',
+            name: null,
+            id: 0,
+            expanded: null,
+            items: null,
+            cache: null, // to cache stuff like retrieved metadata info
+
+            // TODO: add hook to set group options
+            options: {
+                visibility: {
+                    value: 'on', // 'off', 'zoomIn', 'zoomOut'
+                    enabled: true
+                },
+                remove: {
+                    enabled: false
+                }
+            },
+
+            /**
+             * Adds an item (layer or another group) to a layer group.
+             * @param {Object} item     layer or group item to add
+             * @param {Number} position position to insert the item at; defaults to the last position in the array
+             */
+            add(item, position = this.items.length) { // <- awesome! default is re-evaluated everytime the function is called
+                item.parent = this;
+                this.items.splice(position, 0, item);
+            },
+
+            /**
+             * Removes a given item (layer or another group) from a layer group.
+             * @param {Object} item     layer or group item to add
+             * @return {Number}      index of the item before removal or -1 if the item is not in the group
+             */
+            remove(item) {
+                const index = this.items.indexOf(item);
+                if (index !== -1) {
+                    delete item.parent;
+                    this.items.splice(index, 1);
+                }
+
+                return index;
+            },
+
+            /**
+             * Sets or toggles visibility of the group legend entry and all it's children
+             * @param {Boolean|undefined} value target visibility value; toggles visibility if not set
+             * Other arguments are passed straight to child functions; useful for decorators;
+             */
+            setVisibility(value, ...arg) {
+                const option = this.options.visibility;
+                if (typeof value !== 'undefined') {
+                    option.value = value ? 'on' : 'off';
+                } else {
+                    option.value = VISIBILITY_TOGGLE[option.value];
+                }
+
+                if (this.type === 'group') {
+                    this.items.forEach(item => item.setVisibility(option.value === 'on', ...arg));
+                }
+            },
+
+            /**
+             * Returns visibility of the group legend entry
+             * @return {Boolean} true - visible; false - not visbile; undefined - visible and invisible at the same time
+             */
+            getVisibility() {
+                return this.options.visibility.value === 'on';
+            },
+
+            /**
+             * Walks child items executing the provided function on each leaf;
+             * Returns a flatten array of results from the provided function;
+             * @param  {Function} action function which is passed the following arguments: legend layer entry, its index in its parent's array, parent
+             * @return {Array}        flat array of results
+             */
+            walkItems(action) {
+                // roll in the results into a flat array
+                return [].concat.apply([], this.items.map((item, index) => {
+                    if (item.type === 'group') {
+                        return item.walkItems(action);
+                    } else {
+                        return action(item, index, this);
+                    }
+                }));
+            },
+
+            init(name, expanded = false) {
+                this.id = 'rv_lt_' + itemIdCounter++;
+                this.name = name;
+                this.expanded = expanded;
+                this.items = [];
+                this.cache = {};
+
+                return this;
+            },
+        };
+
         // jscs:enable requireSpacesInAnonymousFunctionExpression
 
-        const SINGLE_LAYER_ENTRY = Object.create(LAYER_ENTRY);
-        SINGLE_LAYER_ENTRY.init = function (initialState, layerRef) {
-            LAYER_ENTRY.init.call(this, initialState, layerRef);
+        const SINGLE_ENTRY_ITEM = Object.create(ENTRY_ITEM);
+        SINGLE_ENTRY_ITEM.init = function (initialState, layerRef) {
+            ENTRY_ITEM.init.call(this, initialState, layerRef);
 
             this.setVisibility(this.getVisibility());
+
+            return this;
         };
 
         /**
          * Sets visibility of a simple layer object, one which is represented by a single entry in the legend
          * @param  {Boolean} value visibility value
          */
-        SINGLE_LAYER_ENTRY.setVisibility = function (value) {
-            LAYER_ENTRY.setVisibility.call(this, value);
+        SINGLE_ENTRY_ITEM.setVisibility = function (value) {
+            ENTRY_ITEM.setVisibility.call(this, value);
             this._layerRef.setVisibility(this.getVisibility());
         };
 
-        const DYNAMIC_LAYER_ENTRY = Object.create(LAYER_ENTRY);
-        DYNAMIC_LAYER_ENTRY.init = function (initialState, layerRef) {
-            LAYER_ENTRY.init.call(this, initialState, layerRef);
+        const DYNAMIC_ENTRY_ITEM = Object.create(ENTRY_ITEM);
+        DYNAMIC_ENTRY_ITEM.init = function (initialState, layerRef) {
+            ENTRY_ITEM.init.call(this, initialState, layerRef);
 
             // this.setVisibility(this.getVisibility());
+
+            return this;
         };
 
         /**
          * Sets visibility of a simple layer object, one which is represented by a single entry in the legend
          * @param  {Boolean} value visibility value
          */
-        DYNAMIC_LAYER_ENTRY.setVisibility = function (value, notifyMaster = true) {
-            LAYER_ENTRY.setVisibility.call(this, value);
+        DYNAMIC_ENTRY_ITEM.setVisibility = function (value, isTrigger = true) {
+            ENTRY_ITEM.setVisibility.call(this, value, false);
 
-            // more stuff
+            if (isTrigger) {
+                this.master._setVisibility();
+            }
         };
 
+        const DYNAMIC_ENTRY_GROUP = Object.create(ENTRY_GROUP);
+
+        DYNAMIC_ENTRY_GROUP.init = function (initialState, layerRef, expanded) {
+            ENTRY_GROUP.init.call(this);
+
+            // get defaults for specific layerType
+            const defaults = layerDefaults[initialState.layerType] || {};
+
+            this._layerRef = layerRef;
+            this.expanded = expanded;
+            this.options = angular.merge({}, defaults.options)
+            angular.merge(this, initialState);
+
+            return this;
+        };
+
+        /**
+         * Sets visibility of a simple layer object, one which is represented by a single entry in the legend
+         * @param  {Boolean} value visibility value
+         */
+        DYNAMIC_ENTRY_GROUP.setVisibility = function (value, isTrigger = true) {
+            ENTRY_GROUP.setVisibility.call(this, value, false);
+
+            if (isTrigger) {
+                this.master._setVisibility();
+            }
+        };
+
+        const DYNAMIC_ENTRY_MASTER_GROUP = Object.create(DYNAMIC_ENTRY_GROUP);
+
+        DYNAMIC_ENTRY_MASTER_GROUP.init = function (initialState, layerRef, expanded) {
+            DYNAMIC_ENTRY_GROUP.init.call(this, initialState, layerRef, expanded);
+
+            return this;
+        };
+
+        /**
+         * Sets visibility of a simple layer object, one which is represented by a single entry in the legend
+         * @param  {Boolean} value visibility value
+         */
+        DYNAMIC_ENTRY_MASTER_GROUP.setVisibility = function (value, isTrigger = true) {
+            DYNAMIC_ENTRY_GROUP.setVisibility.call(this, value, false);
+
+            if (isTrigger) {
+                this._setVisibility();
+            }
+        };
+
+        DYNAMIC_ENTRY_MASTER_GROUP._setVisibility = function() {
+            // get an array of visible sublayers (e.g. [1,4,6])
+            const visibleSublayerIds = this.walkItems(item => {
+                // get sublayer index from the slaves array
+                const index = this.slaves.indexOf(item);
+                return item.getVisibility() ? index : -1;
+            }).filter(index => index !== -1);
+
+            console.log(this.name + ' set to ' + this.getVisibility() + ' ' + visibleSublayerIds);
+
+            // set visibility of the dynamic layer
+            this._layerRef.setVisibility(this.getVisibility());
+
+            // finally, set visibility of the sublayers
+            this._layerRef.setVisibleLayers(visibleSublayerIds);
+        }
+
         function singleLayerEntry(initialState, layerRef) {
-            const featureLayerEntry = Object.create(SINGLE_LAYER_ENTRY);
+            const featureLayerEntry = Object.create(SINGLE_ENTRY_ITEM);
             featureLayerEntry.init(initialState, layerRef);
 
             return featureLayerEntry;
         }
 
         function dynamicLayerEntry(initialState, layerRef) {
-            const dynamicLayerEntry = Object.create(DYNAMIC_LAYER_ENTRY);
+            const dynamicLayerEntry = Object.create(DYNAMIC_ENTRY_ITEM);
             dynamicLayerEntry.init(initialState, layerRef);
 
             return dynamicLayerEntry;
+        }
+
+        function entryGroup(name, expanded) {
+            return Object.create(ENTRY_GROUP).init(name, expanded);
+        }
+
+        function dynamicEntryGroup(initialState, layerRef, expanded) {
+            return Object.create(DYNAMIC_ENTRY_GROUP).init(initialState, layerRef, expanded);
+        }
+
+        function dynamicEntryMasterGroup(initialState, layerRef, expanded) {
+            return Object.create(DYNAMIC_ENTRY_MASTER_GROUP).init(initialState, layerRef, expanded);
         }
 
         return service;

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -79,6 +79,10 @@
                 return this.options.visibility.value === 'on';
             },
 
+            setOpacity(value) {
+                this.options.opacity.value = value;
+            },
+
             init(initialState, layerRef) {
                 const defaults = layerDefaults[initialState.layerType];
 
@@ -115,6 +119,11 @@
         SINGLE_ENTRY_ITEM.setVisibility = function (value) {
             ENTRY_ITEM.setVisibility.call(this, value);
             this._layerRef.setVisibility(this.getVisibility());
+        };
+
+        SINGLE_ENTRY_ITEM.setOpacity = function (value) {
+            ENTRY_ITEM.setOpacity.call(this, value);
+            this._layerRef.setOpacity(value);
         };
 
         const DYNAMIC_ENTRY_ITEM = Object.create(ENTRY_ITEM);

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -34,7 +34,8 @@
     function legendEntryFactory(layerDefaults) {
 
         const service = {
-            singleLayerEntry
+            singleLayerEntry,
+            dynamicLayerEntry
         };
 
         // jscs doesn't like enhanced object notation
@@ -75,21 +76,21 @@
                 return this.options.visibility.value === 'on';
             },
 
-            init(layer) {
-                const defaults = layerDefaults[layer.initialState.layerType];
+            init(initialState, layerRef) {
+                const defaults = layerDefaults[initialState.layerType];
 
-                this._layerRef = layer.layer;
+                this._layerRef = layerRef;
                 this.id = 'rv_lt_' + itemIdCounter++;
                 this.options = angular.extend({}, defaults.options);
                 this.flags = angular.extend({}, defaults.flags);
 
-                angular.extend(this, layer.initialState);
+                angular.merge(this, initialState);
 
                 // if there is no metadataurl, remove metadata options altogether
                 if (typeof this.metadataUrl === 'undefined') {
                     delete this.options.metadata;
                 }
-                
+
                 // this.state = layerStates.default; ??
             },
 
@@ -103,22 +104,50 @@
         // jscs:enable requireSpacesInAnonymousFunctionExpression
 
         const SINGLE_LAYER_ENTRY = Object.create(LAYER_ENTRY);
-        SINGLE_LAYER_ENTRY.init = function (layer) {
-            LAYER_ENTRY.init.call(this, layer);
+        SINGLE_LAYER_ENTRY.init = function (initialState, layerRef) {
+            LAYER_ENTRY.init.call(this, initialState, layerRef);
 
             this.setVisibility(this.getVisibility());
         };
 
+        /**
+         * Sets visibility of a simple layer object, one which is represented by a single entry in the legend
+         * @param  {Boolean} value visibility value
+         */
         SINGLE_LAYER_ENTRY.setVisibility = function (value) {
             LAYER_ENTRY.setVisibility.call(this, value);
             this._layerRef.setVisibility(this.getVisibility());
         };
 
-        function singleLayerEntry(layer) {
+        const DYNAMIC_LAYER_ENTRY = Object.create(LAYER_ENTRY);
+        DYNAMIC_LAYER_ENTRY.init = function (initialState, layerRef) {
+            LAYER_ENTRY.init.call(this, initialState, layerRef);
+
+            // this.setVisibility(this.getVisibility());
+        };
+
+        /**
+         * Sets visibility of a simple layer object, one which is represented by a single entry in the legend
+         * @param  {Boolean} value visibility value
+         */
+        DYNAMIC_LAYER_ENTRY.setVisibility = function (value, notifyMaster = true) {
+            LAYER_ENTRY.setVisibility.call(this, value);
+
+            // more stuff
+        };
+
+        function singleLayerEntry(initialState, layerRef) {
             const featureLayerEntry = Object.create(SINGLE_LAYER_ENTRY);
-            featureLayerEntry.init(layer);
+            featureLayerEntry.init(initialState, layerRef);
 
             return featureLayerEntry;
+        }
+
+        function dynamicLayerEntry(initialState, layerRef) {
+            const dynamicLayerEntry = Object.create(DYNAMIC_LAYER_ENTRY);
+            dynamicLayerEntry.init(initialState, layerRef);
+
+            return dynamicLayerEntry;
         }
 
         return service;

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -1,0 +1,127 @@
+(() => {
+    'use strict';
+
+    // layer group ids should not collide
+    let itemIdCounter = 0;
+
+    // visibility toggle logic goes here
+    // TODO: deal with out-of-scale visibility state
+    const VISIBILITY_TOGGLE = {
+        off: 'on',
+        on: 'off'
+    };
+
+    // TODO: move this somewhere later
+    // jscs:disable maximumLineLength
+    const NO_IMAGE =
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAUJJREFUeNrs172Kg0AQB/BcOLHSRhBFEF/B5/cBrMRGsLESFBFsFAs/ivuTheW4kOBN1mSLmWJB0PGHM6vjV5IkF/3ietEymMUsZjGLWcxiltas7+OnNk3T9/22bYTbGIbhum4QBIpZMJVl+coDGIYB60HZUVZd11ht27Ysi2CapmkcRyRRzFqWBWsYhp7nEVhd1xVFIZLwTnwQaMd1XfVi5XmOjZJlGUF2Pc8ktt48z23basGSpg/0FkqTpinKpNxEZ8GEpkGB0NS/ZUpMRJY0iUN8kdSaKKw/Jsdx4jhWa6KwsK3ONr3U8ueZ6KxTTf+btyQIw5MYBDAXuLd4fgnmDll3xSzTNPd9l5PJ/evqSWCkEecjiWKW7/tVVY23IJcGSRSzoihC7bQbmsW8ezwv/5Axi1nMYhazmMWst8ePAAMA0CzGRisOjIgAAAAASUVORK5CYII=';
+    // jscs:enable maximumLineLength
+
+    /**
+     * @ngdoc service
+     * @name factory
+     * @module app.geo
+     * @requires dependencies
+     * @description
+     *
+     * The `factory` factory description.
+     *
+     */
+    angular
+        .module('app.geo')
+        .service('legendEntryFactory', legendEntryFactory);
+
+    function legendEntryFactory(layerDefaults) {
+
+        const service = {
+            singleLayerEntry
+        };
+
+        // jscs doesn't like enhanced object notation
+        // jscs:disable requireSpacesInAnonymousFunctionExpression
+        const LAYER_ENTRY = {
+            _layerRef: null,
+            type: 'layer',
+            name: 'dogguts',
+            id: 0,
+            options: null,
+            flags: null,
+            state: 'rv-default', // TODO: replace
+            cache: {}, // to cache stuff like retrieved metadata info
+            symbology: [{
+                icon: NO_IMAGE,
+                name: ''
+            }],
+
+            /**
+             * Sets or toggles visibility of the layer legend entry
+             * @param {Boolean|undefined} value target visibility value; toggles visibiliyt if not set
+             */
+            setVisibility(value) {
+                const option = this.options.visibility;
+
+                if (typeof value !== 'undefined') {
+                    option.value = value ? 'on' : 'off';
+                } else {
+                    option.value = VISIBILITY_TOGGLE[option.value];
+                }
+            },
+
+            /**
+             * Returns visibility of the layer legend entry
+             * @return {Boolean} true - visible; false - not visbile; undefined - visible and invisible at the same time
+             */
+            getVisibility() {
+                return this.options.visibility.value === 'on';
+            },
+
+            init(layer) {
+                const defaults = layerDefaults[layer.initialState.layerType];
+
+                this._layerRef = layer.layer;
+                this.id = 'rv_lt_' + itemIdCounter++;
+                this.options = angular.extend({}, defaults.options);
+                this.flags = angular.extend({}, defaults.flags);
+
+                angular.extend(this, layer.initialState);
+
+                // if there is no metadataurl, remove metadata options altogether
+                if (typeof this.metadataUrl === 'undefined') {
+                    delete this.options.metadata;
+                }
+                
+                // this.state = layerStates.default; ??
+            },
+
+            // TODO: reMOVE!
+            decorate(name, wrapper) {
+                const target = this[name].bind(this);
+                this[name] = (...arg) => wrapper.bind(this)(target, ...arg);
+            }
+        };
+
+        // jscs:enable requireSpacesInAnonymousFunctionExpression
+
+        const SINGLE_LAYER_ENTRY = Object.create(LAYER_ENTRY);
+        SINGLE_LAYER_ENTRY.init = function (layer) {
+            LAYER_ENTRY.init.call(this, layer);
+
+            this.setVisibility(this.getVisibility());
+        };
+
+        SINGLE_LAYER_ENTRY.setVisibility = function (value) {
+            LAYER_ENTRY.setVisibility.call(this, value);
+            this._layerRef.setVisibility(this.getVisibility());
+        };
+
+        function singleLayerEntry(layer) {
+            const featureLayerEntry = Object.create(SINGLE_LAYER_ENTRY);
+            featureLayerEntry.init(layer);
+
+            return featureLayerEntry;
+        }
+
+        return service;
+    }
+
+})();

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -240,13 +240,18 @@
              * Walks child items executing the provided function on each leaf;
              * Returns a flatten array of results from the provided function;
              * @param  {Function} action function which is passed the following arguments: legend layer entry, its index in its parent's array, parent
+             * @param  {Boolean} defaults to false; includeGroups flag specifying if the action should be applied to group items as well.
              * @return {Array}        flat array of results
              */
-            walkItems(action) {
+            walkItems(action, includeGroups = false) {
                 // roll in the results into a flat array
                 return [].concat.apply([], this.items.map((item, index) => {
                     if (item.type === 'group') {
-                        return item.walkItems(action);
+                        if (includeGroups) {
+                            return [].concat(action(item, index, this), item.walkItems(action, true));
+                        } else {
+                            return item.walkItems(action);
+                        }
                     } else {
                         return action(item, index, this);
                     }

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -206,7 +206,9 @@
 
                 // set initial visibility of the sublayers;
                 // this cannot be set in `layerRegistry` because legend entry for dynamic layer didn't exist yet;
+                // TODO: move this to legendEntry service and apply during initialization of the entry
                 tocEntry._setVisibility();
+                tocEntry._setOpacity(); // apply initial opacity
 
                 return tocEntry;
             }

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -100,7 +100,8 @@
                         const groupItem = legendEntryFactory.dynamicEntryGroup({
                             name: layerInfo.name,
                             layerType: layerEntryType,
-                            options: layerEntryOptions
+                            options: layerEntryOptions,
+                            _subId: index
                         });
 
                         assignDirectMaster(groupItem, layerInfo.parentLayerId);
@@ -108,7 +109,8 @@
                         const layerItem = legendEntryFactory.dynamicEntryItem({
                             name: layerInfo.name,
                             layerType: layerEntryType,
-                            options: layerEntryOptions
+                            options: layerEntryOptions,
+                            _subId: index
                         });
 
                         assignDirectMaster(layerItem, layerInfo.parentLayerId);
@@ -125,6 +127,11 @@
                 if (typeof dynamicGroup.metadataUrl === 'undefined') {
                     delete dynamicGroup.options.metadata;
                     dynamicGroup.slaves.forEach(slave => delete slave.options.metadata);
+                }
+
+                // if the 'supportsDynamicLayers' flag is off, remove sublayer opacity options
+                if (!layer.layer.supportsDynamicLayers) {
+                    dynamicGroup.slaves.forEach(slave => delete slave.options.opacity);
                 }
 
                 return dynamicGroup;

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -35,7 +35,7 @@
             const ref = {
                 dataGroup: legendEntryFactory.entryGroup('Data layers', true),
                 imageGroup: legendEntryFactory.entryGroup('Image layers', true),
-                root: legend.items
+                legend: legend
             };
 
             // maps layerTypes to default layergroups
@@ -73,7 +73,8 @@
              * Initializes autolegend by adding data and image groups to it.
              */
             function init() {
-                ref.root.push(ref.dataGroup, ref.imageGroup);
+                ref.legend.items.push(ref.dataGroup, ref.imageGroup);
+                ref.legend.getLegendEntry = getLegendEntry;
             }
 
             /**
@@ -304,6 +305,20 @@
                 legendEntry.loadingTimeout = $timeout(() => {
                     legendEntry.isLoading = isLoading;
                 }, delay);
+            }
+
+            function getLegendEntry(id) {
+                let result;
+
+                ref.legend.items.forEach(entryGroup => {
+                    entryGroup.walkItems(item => {
+                        if (item.id === id) {
+                            result = item;
+                        }
+                    });
+                });
+
+                return result;
             }
         }
 

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -324,7 +324,7 @@
                         if (item.id === id) {
                             result = item;
                         }
-                    });
+                    }, true);
                 });
 
                 return result;

--- a/src/app/ui/settings/settings.directive.js
+++ b/src/app/ui/settings/settings.directive.js
@@ -1,6 +1,16 @@
 (() => {
     'use strict';
 
+    const SETTING_SECTIONS = {
+        display: [
+            'boundingBox',
+            'opacity'
+        ],
+        data: [
+            'snapshot'
+        ]
+    };
+
     /**
      * @ngdoc directive
      * @name rvSettings
@@ -38,6 +48,12 @@
         const self = this;
         self.Math = window.Math;
 
+        // indicates which setting sections are displayed based on the available toc entry settings
+        self.settingSectionVisibility = {
+            display: true,
+            data: true
+        };
+
         self.display = stateManager.display.settings;
         self.tocEntry = null;
         self.opacityValue = 0;
@@ -46,7 +62,17 @@
         $scope.$watch('self.display.data', newValue => {
             if (newValue) {
                 self.tocEntry = newValue;
-                self.opacityValue = self.tocEntry.options.opacity.value;
+                if (self.tocEntry.options.opacity) {
+                    self.opacityValue = self.tocEntry.options.opacity.value;
+                }
+
+                // check which setting sections should be visible
+                Object.entries(SETTING_SECTIONS)
+                    .forEach(([key, value]) =>
+                        self.settingSectionVisibility[key] = value.some(element =>
+                            typeof self.tocEntry.options[element] !== 'undefined'
+                        )
+                    );
             }
         });
 

--- a/src/app/ui/settings/settings.directive.js
+++ b/src/app/ui/settings/settings.directive.js
@@ -52,7 +52,7 @@
 
         activateOpacitySetting();
 
-        /*********/
+        /***/
 
         function activateOpacitySetting() {
             // flag indicating the opacity timeout is active
@@ -72,7 +72,7 @@
             });
 
             /**
-             * Sets actual opacity value on the tocEntry if it differs from the current opacity value.
+             * Applies current opacity value from the settings panel to the tocEntry if it differs from its current opacity value.
              */
             function setTocEntryOpacity() {
                 if (self.tocEntry.options.opacity.value !== self.opacityValue) {

--- a/src/app/ui/settings/settings.directive.js
+++ b/src/app/ui/settings/settings.directive.js
@@ -42,8 +42,6 @@
         self.tocEntry = null;
         self.opacityValue = 0;
 
-        let opacityTimoutActive = false;
-
         // watch for changing display value and store reference to new tocEntry and its opacity value
         $scope.$watch('self.display.data', newValue => {
             if (newValue) {
@@ -52,32 +50,38 @@
             }
         });
 
-        // watch for changing slider to set actual layer opacity
-        $scope.$watch('self.opacityValue', newValue => {
-            console.log('opacity --->', newValue);
-            if (angular.isNumber(newValue) && self.tocEntry && !opacityTimoutActive) {
-                console.log('         set--->', newValue);
-                self.tocEntry.setOpacity(newValue);
-
-                opacityTimoutActive = true;
-                $timeout(opacityTimeoutComplete, 20);
-            }
-        });
-
-        activate();
+        activateOpacitySetting();
 
         /*********/
 
-        function activate() {
+        function activateOpacitySetting() {
+            // flag indicating the opacity timeout is active
+            let opacityTimeoutActive = false;
+            const opacityTimeoutDuration = 30; // in ms
 
-        }
+            // watch for changing slider to set actual layer opacity
+            $scope.$watch('self.opacityValue', newValue => {
+                // console.log('opacity --->', newValue, self.opacityValue);
 
-        function opacityTimeoutComplete() {
-            if (self.tocEntry.options.opacity.value !== self.opacityValue) {
-                console.log('update opacity to', self.opacityValue);
-                self.tocEntry.setOpacity(self.opacityValue);
+                if (angular.isNumber(newValue) && self.tocEntry && !opacityTimeoutActive) {
+                    // set opacity immediately
+                    setTocEntryOpacity();
+                    opacityTimeoutActive = true;
+                    $timeout(setTocEntryOpacity, opacityTimeoutDuration); // wait a bit before setting opacity again
+                }
+            });
+
+            /**
+             * Sets actual opacity value on the tocEntry if it differs from the current opacity value.
+             */
+            function setTocEntryOpacity() {
+                if (self.tocEntry.options.opacity.value !== self.opacityValue) {
+                    console.log('update opacity to', self.opacityValue);
+                    self.tocEntry.setOpacity(self.opacityValue);
+                }
+
+                opacityTimeoutActive = false;
             }
-            opacityTimoutActive = false;
         }
     }
 })();

--- a/src/app/ui/settings/settings.directive.js
+++ b/src/app/ui/settings/settings.directive.js
@@ -33,16 +33,34 @@
         return directive;
     }
 
-    function Controller(stateManager, $scope) {
+    function Controller(stateManager, $scope, $timeout) {
         'ngInject';
         const self = this;
-        self.display = stateManager.display.settings;
         self.Math = window.Math;
 
-        // watch for changing slider to set actual layer opacity
-        $scope.$watch('self.display.data.opacity.value', newValue => {
+        self.display = stateManager.display.settings;
+        self.tocEntry = null;
+        self.opacityValue = 0;
+
+        let opacityTimoutActive = false;
+
+        // watch for changing display value and store reference to new tocEntry and its opacity value
+        $scope.$watch('self.display.data', newValue => {
             if (newValue) {
-                self.display.data.layerItem.setOpacity(newValue);
+                self.tocEntry = newValue;
+                self.opacityValue = self.tocEntry.options.opacity.value;
+            }
+        });
+
+        // watch for changing slider to set actual layer opacity
+        $scope.$watch('self.opacityValue', newValue => {
+            console.log('opacity --->', newValue);
+            if (angular.isNumber(newValue) && self.tocEntry && !opacityTimoutActive) {
+                console.log('         set--->', newValue);
+                self.tocEntry.setOpacity(newValue);
+
+                opacityTimoutActive = true;
+                $timeout(opacityTimeoutComplete, 20);
             }
         });
 
@@ -52,6 +70,14 @@
 
         function activate() {
 
+        }
+
+        function opacityTimeoutComplete() {
+            if (self.tocEntry.options.opacity.value !== self.opacityValue) {
+                console.log('update opacity to', self.opacityValue);
+                self.tocEntry.setOpacity(self.opacityValue);
+            }
+            opacityTimoutActive = false;
         }
     }
 })();

--- a/src/app/ui/settings/settings.html
+++ b/src/app/ui/settings/settings.html
@@ -7,18 +7,24 @@
             </div>
 
             <div class="rv-subcontent">
-                {{'settings.label.opacity' | translate}}
-                <div class="rv-icon-20 rv-slider-setting">
-                    <md-icon md-svg-icon="action:opacity"></md-icon>
-                    <div class="rv-slider-setting-body">
-                        <md-slider class="md-primary" max="1" min="0" step="0.01" ng-model="self.opacityValue"></md-slider>
+
+                <div class="rv-setting-option" ng-if="self.tocEntry.options.opacity">
+                    {{'settings.label.opacity' | translate}}
+                    <div class="rv-icon-20 rv-slider-setting">
+                        <md-icon md-svg-icon="action:opacity"></md-icon>
+                        <div class="rv-slider-setting-body">
+                            <md-slider class="md-primary" max="1" min="0" step="0.01" ng-model="self.opacityValue"></md-slider>
+                        </div>
+                        <span class="rv-slider-setting-indicator">{{ self.Math.round(self.opacityValue * 100) }}%</span>
                     </div>
-                    <span class="rv-slider-setting-indicator">{{ self.Math.round(self.opacityValue * 100) }}%</span>
                 </div>
 
-                <md-switch translate-attr-aria-label="settings.aria.boundingBox" class="md-primary rv-switch" ng-model="isChecked">
+                <div class="rv-setting-option">
+                    <md-switch translate-attr-aria-label="settings.aria.boundingBox" class="md-primary rv-switch" ng-model="isChecked">
                         {{'settings.label.boundingBox' | translate}}
-                </md-switch>
+                    </md-switch>
+                </div>
+
             </div>
 
         </div>
@@ -40,12 +46,13 @@
         </div>
 
         <p>
-            // TODO: remove
-            paragraph to show that panel content is actually changing </br>
-            layer display data: <b>{{ self.display.requester.id }}</b>
-            <b>{{ self.display.requester.layerItem.opacity }}</b>
-        </p>
+            // TODO: remove paragraph to show that panel content is actually changing
+        </br>
+        layer display data:
+        <b>{{ self.display.requester.id }}</b>
+        <b>{{ self.display.requester.layerItem.opacity }}</b>
+    </p>
 
-    </div>
+</div>
 
 </rv-content-pane>

--- a/src/app/ui/settings/settings.html
+++ b/src/app/ui/settings/settings.html
@@ -1,7 +1,7 @@
 <rv-content-pane title-style="title" title-value="{{'settings.title' | translate}}">
     <div>
 
-        <div class="rv-subsection">
+        <div class="rv-subsection" ng-if="self.settingSectionVisibility.display">
             <div class="rv-subheader">
                 <h4 translate class="md-subhead">settings.label.display</h4>
             </div>
@@ -19,7 +19,7 @@
                     </div>
                 </div>
 
-                <div class="rv-setting-option">
+                <div class="rv-setting-option" ng-if="self.tocEntry.options.boundingBox">
                     <md-switch translate-attr-aria-label="settings.aria.boundingBox" class="md-primary rv-switch" ng-model="isChecked">
                         {{'settings.label.boundingBox' | translate}}
                     </md-switch>
@@ -29,17 +29,19 @@
 
         </div>
 
-        <div class="rv-subsection">
+        <div class="rv-subsection" ng-if="self.settingSectionVisibility.data">
 
             <div class="rv-subheader">
                 <h4 translate class="md-subhead">settings.label.data</h4>
             </div>
             <div class="rv-subcontent">
 
-                <div class="rv-toggle-setting">
-                    <span translate>settings.label.snapshot</span>
-                    <span flex></span>
-                    <md-button class="rv-button-square">{{'settings.label.snapshotEnable' | translate}}</md-button>
+                <div class="rv-setting-option" ng-if="self.tocEntry.options.snapshot">
+                    <div class="rv-toggle-setting">
+                        <span translate>settings.label.snapshot</span>
+                        <span flex></span>
+                        <md-button class="rv-button-square">{{'settings.label.snapshotEnable' | translate}}</md-button>
+                    </div>
                 </div>
             </div>
 

--- a/src/app/ui/settings/settings.html
+++ b/src/app/ui/settings/settings.html
@@ -11,9 +11,9 @@
                 <div class="rv-icon-20 rv-slider-setting">
                     <md-icon md-svg-icon="action:opacity"></md-icon>
                     <div class="rv-slider-setting-body">
-                        <md-slider class="md-primary" max="1" min="0" step="0.01" ng-model="self.display.data.opacity.value"></md-slider>
+                        <md-slider class="md-primary" max="1" min="0" step="0.01" ng-model="self.opacityValue"></md-slider>
                     </div>
-                    <span class="rv-slider-setting-indicator">{{ self.Math.round(self.display.data.opacity.value * 100) }}%</span>
+                    <span class="rv-slider-setting-indicator">{{ self.Math.round(self.opacityValue * 100) }}%</span>
                 </div>
 
                 <md-switch translate-attr-aria-label="settings.aria.boundingBox" class="md-primary rv-switch" ng-model="isChecked">

--- a/src/app/ui/toc/toc.html
+++ b/src/app/ui/toc/toc.html
@@ -15,7 +15,11 @@
 
                 <div class="rv-layer-level rv-{{ $dxLevel }}" ng-if="item.items !== undefined">
 
-                    <rv-toc-entry class="rv-toc-{{ item.type }}-entry" entry="item" type="group"></rv-toc-entry>
+                    <rv-toc-entry
+                        class="rv-toc-{{ item.type }}-entry"
+                        ng-class="{ 'rv-selected': item.selected }"
+                        entry="item"
+                        type="group"></rv-toc-entry>
 
                     <ul class="rv-layer-list rv-toggle-slide" dx-connect="item" ng-show="item.expanded"></ul>
 

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -743,21 +743,27 @@
                     icon: {
                         esriFeature: 'community:vector-square',
                         esriDynamic: 'action:settings',
+                        esriDynamicLayerEntry: 'image:photo',
                         ogcWms: 'image:photo',
+                        ogcWmsLayerEntry: 'image:photo',
                         esriImage: 'image:photo',
                         esriTile: 'image:photo'
                     },
                     label: {
                         esriFeature: 'toc.label.flag.feature',
                         esriDynamic: 'toc.label.flag.dynamic',
+                        esriDynamicLayerEntry: 'toc.label.flag.dynamic',
                         ogcWms: 'toc.label.flag.wms',
+                        ogcWmsLayerEntry: 'toc.label.flag.wms',
                         esriImage: 'toc.label.flag.image',
                         esriTile: 'toc.label.flag.tile'
                     },
                     tooltip: {
                         esriFeature: 'toc.tooltip.flag.feature',
                         esriDynamic: 'toc.tooltip.flag.dynamic',
+                        esriDynamicLayerEntry: 'toc.tooltip.flag.dynamic',
                         ogcWms: 'toc.tooltip.flag.wms',
+                        ogcWmsLayerEntry: 'toc.tooltip.flag.wms',
                         esriImage: 'toc.tooltip.flag.image',
                         esriTile: 'toc.label.flag.tile'
                     }
@@ -870,16 +876,11 @@
         /**
          * Opens settings panel with settings from the provided layer object.
          * // FIXME: opens the same settings right now.
-         * @param  {Object} layer layer object whose settings should be opened.
+         * @param  {Object} entry layer object whose settings should be opened.
          */
-        function toggleSettings(layer) {
+        function toggleSettings(entry) {
             const requester = {
-                id: layer.id
-            };
-
-            const data = {
-                opacity: layer.options.opacity,
-                layerItem: geoService.layers[layer.id].layer
+                id: entry.id
             };
 
             const panelToClose = {
@@ -888,7 +889,7 @@
 
             stateManager
                 .setActive(panelToClose)
-                .then(() => stateManager.toggleDisplayPanel('sideSettings', data, requester));
+                .then(() => stateManager.toggleDisplayPanel('sideSettings', entry, requester));
         }
 
         /**

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -809,6 +809,8 @@
 
         // jscs:enable maximumLineLength
 
+        const selectedLayerLog = {};
+
         // set state change watches on metadata, settings and filters panel
         watchPanelState('sideMetadata', 'metadata');
         watchPanelState('sideSettings', 'settings');
@@ -1024,7 +1026,11 @@
         function setTocEntrySelectedState(id, value = true) {
             const entry = geoService.legend.getLegendEntry(id);
             if (entry) {
-                entry.selected = value;
+                // toc entry is considered selected if its metadata, settings, or data panel is opened;
+                // when switching between panels (opening metadata when settings is already open), events may happen out of order
+                // to ensure a toc entry is not deselected untimely, keep count of open/close events
+                selectedLayerLog[id] = (selectedLayerLog[id] || 0) + (value ? 1 : -1);
+                entry.selected = selectedLayerLog[id] > 0 ? true : false;
             }
         }
     }

--- a/src/config.en-CA.json
+++ b/src/config.en-CA.json
@@ -79,7 +79,7 @@
         ]
       },
       {
-        "id": "LOD_ESRI_World_AuxMerc_3857",       
+        "id": "LOD_ESRI_World_AuxMerc_3857",
         "lods": [
             { "level": 0, "resolution": 156543.03392800014, "scale": 591657527.591555 },
             { "level": 1, "resolution": 78271.51696399994, "scale": 295828763.795777 },
@@ -125,7 +125,7 @@
       "id":"aafc_agri_environmental_indicators",
       "name": "AAFC AGRI Environmental Indicators",
       "layerType":"esriDynamic",
-      "layerEntries": [{"index": 0, "visibility": { "value": "off" } }, {"index": 4}, {"index": 13}],
+      "layerEntries": [{"index": 0, "visibility": { "value": "off" }, "settings": { "enabled" : false} }, {"index": 4}, {"index": 13}],
       "url":"http://www.agr.gc.ca/atlas/rest/services/mapservices/aafc_agri_environmental_indicators/MapServer",
       "metadataUrl": "http://intranet.ecdmp-stage.cmc.ec.gc.ca/geonetwork/srv/eng/csw?service=CSW&version=2.0.2&request=GetRecordById&outputSchema=csw:IsoRecord&id=1c0eb1b2-93ae-49ae-a3ce-e495d8fd767b&_=1417717957845"
     },

--- a/src/config.en-CA.json
+++ b/src/config.en-CA.json
@@ -175,6 +175,9 @@
       "options": {
         "visibility": {
           "value": "off"
+        },
+        "opacity": {
+            "value": 0.5
         }
       }
     }

--- a/src/config.en-CA.json
+++ b/src/config.en-CA.json
@@ -157,7 +157,12 @@
       "id":"aafc_dynamic_layer",
       "name": "AAFC Census of Agriculture 2011",
       "layerType":"esriDynamic",
-      "layerEntries": [{"index": 0}],
+      "layerEntries": [{"index": 0, "opacity": { "value": 0.5 }}],
+      "options": {
+        "opacity": {
+          "value": 0.8
+        }
+      },
       "url":"http://www.agr.gc.ca/atlas/rest/services/mapservices/aafc_census_of_agriculture_2011_ccs/MapServer"
     },
     {

--- a/src/content/styles/modules/_setting-controls.scss
+++ b/src/content/styles/modules/_setting-controls.scss
@@ -1,12 +1,18 @@
 @mixin setting-controls {
+    @include setting-option;
     @include slider-setting;
-    @include toggle-setting;    
+    @include toggle-setting;
+}
+
+@mixin setting-option {
+    .rv-setting-option {
+        border-bottom: 1px dashed $divider-color-light;
+    }
 }
 
 // more styling on top of the default material slider control
 @mixin slider-setting {
     .rv-slider-setting {
-        border-bottom: 1px dashed $divider-color-light;
         display: flex;
         flex-direction: row;
         align-items: center;

--- a/src/content/styles/modules/_toc.scss
+++ b/src/content/styles/modules/_toc.scss
@@ -157,6 +157,7 @@ absolutely position a button underneath an item so it acts like a button body fo
     .rv-toc-group-entry {
 
         @include entry-controls;
+        @include selected-layer-entry;
 
         height: $group-item-height;
         position: relative;
@@ -201,11 +202,36 @@ absolutely position a button underneath an item so it acts like a button body fo
     }
 }
 
+@mixin selected-layer-entry {
+    // visually highlights selected layer item in the list
+    &.rv-selected {
+        // don't hide toggles on a selected layer
+        @include entry-controls-hover;
+
+        &:before {
+            background-color: $accent-color;
+        }
+    }
+
+    // selection indicator
+    &:before {
+        position: absolute;
+        content: "";
+        background-color: transparent;
+        width: rem(0.3);
+        right: 0;
+        height: 100%;
+        top: 0;
+        transition: background-color $swift-ease-in-duration $swift-ease-in-out-timing-function;
+    }
+}
+
 @mixin layer-item {
-    .rv-toc-layer-entry{
+    .rv-toc-layer-entry {
 
         @include entry-controls;
-
+        @include selected-layer-entry;
+        
         display: flex;
         align-items: center;
         height: $layer-item-height;
@@ -245,28 +271,6 @@ absolutely position a button underneath an item so it acts like a button body fo
                     margin-left: 0;
                 }
             }
-        }
-
-        // visually highlights selected layer item in the list
-        &.rv-selected {
-            // don't hide toggles on a selected layer
-            @include entry-controls-hover;
-
-            &:before {
-                background-color: $accent-color;
-            }
-        }
-
-        // selection indicator
-        &:before {
-            position: absolute;
-            content: "";
-            background-color: transparent;
-            width: rem(0.3);
-            right: 0;
-            height: 100%;
-            top: 0;
-            transition: background-color $swift-ease-in-duration $swift-ease-in-out-timing-function;
         }
 
         // TODO: fix


### PR DESCRIPTION
Opacity works for all layers except dynamic layers with `supportsDynamicLayers` set to false.
Initial opacity from config is applied correctly to all layers.
Fixed highlighting of toc entries (both groups and singles) when opening settings, metadata or attribute panels.
Settings like opacity and bounding box which are not supported by certain toc entries are hidden in the settings panel.
Empty setting sections in the settings panel are hidden.

Closes #434 and #442.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/481)
<!-- Reviewable:end -->
