### PR TITLE
fix(ui): layer symbology graphics enlarged on legend expansion

### DIFF
--- a/src/app/ui/toc/entry-symbology.directive.js
+++ b/src/app/ui/toc/entry-symbology.directive.js
@@ -143,13 +143,13 @@
                     // in pixels
                     const symbologyListTopOffset = 48;
                     const symbologyListTopMargin = 8;
-                    const symbologyListLabelOffset = 28;
+                    const symbologyListLabelOffset = ctrl.itemNameOnTop ? 28 : 8; // more space needed for item names positioned above symbols
                     let totalHeight = 0;
 
                     items.reverse().forEach(img => {
 
                         const imageElem = img[0].firstChild;
-                        const imageHeight = Math.max(32, imageElem.naturalHeight);
+                        const imageHeight = Math.max(32, imageElem.naturalHeight); // do not allow images less than 32px
                         const imageWidth = Math.max(32, imageElem.naturalWidth);
 
                         tlshift.to(imageElem, RV_DURATION, {
@@ -161,6 +161,7 @@
                             top: (symbologyListTopOffset + symbologyListTopMargin + totalHeight),
                             autoAlpha: 1,
                             height: imageHeight + symbologyListLabelOffset,
+                            left: 0,
                             ease: RV_SWIFT_IN_OUT_EASE
                         }, 0);
 

--- a/src/app/ui/toc/entry-symbology.directive.js
+++ b/src/app/ui/toc/entry-symbology.directive.js
@@ -140,6 +140,7 @@
                             $q.resolve().then(() => self.expanded = false)
                     });
 
+                    // in pixels
                     const symbologyListTopOffset = 48;
                     const symbologyListTopMargin = 8;
                     const symbologyListLabelOffset = 28;
@@ -147,9 +148,9 @@
 
                     items.reverse().forEach(img => {
 
-                        let imageElem = img[0].firstChild;
-                        let imageHeight = Math.max(32, imageElem.naturalHeight);
-                        let imageWidth = Math.max(32, imageElem.naturalWidth);
+                        const imageElem = img[0].firstChild;
+                        const imageHeight = Math.max(32, imageElem.naturalHeight);
+                        const imageWidth = Math.max(32, imageElem.naturalWidth);
 
                         tlshift.to(imageElem, RV_DURATION, {
                             width: imageWidth,

--- a/src/app/ui/toc/entry-symbology.directive.js
+++ b/src/app/ui/toc/entry-symbology.directive.js
@@ -140,46 +140,44 @@
                             $q.resolve().then(() => self.expanded = false)
                     });
 
-                    // in pixels
                     const symbologyListTopOffset = 48;
                     const symbologyListTopMargin = 8;
-                    const symbologyListBottomMargin = 15;
-                    const symbologyItemHeight = 36;
+                    const symbologyListLabelOffset = 28;
+                    let totalHeight = 0;
 
-                    // move all the symbology items from stack into list
-                    // TODO: I think hardcoding '300px' has something to do with https://github.com/fgpv-vpgf/fgpv-vpgf/issues/262
-                    items.forEach(img => tlshift.set(img, {
-                        width: '300px'
-                    }, 0));
-                    items.reverse().forEach((img, index) => {
+                    items.reverse().forEach(img => {
+
+                        let imageElem = img[0].firstChild;
+                        let imageHeight = Math.max(32, imageElem.naturalHeight);
+                        let imageWidth = Math.max(32, imageElem.naturalWidth);
+
+                        tlshift.to(imageElem, RV_DURATION, {
+                            width: imageWidth,
+                            height: imageHeight,
+                        }, 0);
+
                         tlshift.to(img, RV_DURATION, {
-                            left: 0,
-                            top: (symbologyListTopOffset + symbologyListTopMargin + index * symbologyItemHeight) +
-                                'px',
-                            ease: RV_SWIFT_IN_OUT_EASE
-                        }, 0);
-
-                        // make the rest of the symbology items visible when expanding
-                        tlshift.to(img, RV_DURATION / 3, {
+                            top: (symbologyListTopOffset + symbologyListTopMargin + totalHeight),
                             autoAlpha: 1,
+                            height: imageHeight + symbologyListLabelOffset,
                             ease: RV_SWIFT_IN_OUT_EASE
                         }, 0);
 
+                        totalHeight += imageHeight + symbologyListLabelOffset;
                     });
 
                     // make symbology names visible
-                    names.forEach(name => tlshift.to(name, RV_DURATION - 0.1, {
-                        opacity: 1,
-                        display: 'block',
-                        ease: RV_SWIFT_IN_OUT_EASE
-                    }, 0.1));
+                    names.forEach(name =>
+                        tlshift.to(name, RV_DURATION - 0.1, {
+                            opacity: 1,
+                            display: 'block',
+                            ease: RV_SWIFT_IN_OUT_EASE
+                        }, 0.1)
+                    );
 
                     // expand layer item container (ctrl.element) to accomodate symbology list
                     tlshift.to(ctrl.element, RV_DURATION, {
-                        marginBottom: symbologyListTopMargin +
-                            items.length *
-                            symbologyItemHeight +
-                            symbologyListBottomMargin,
+                        marginBottom: totalHeight + symbologyListLabelOffset,
                         ease: RV_SWIFT_IN_OUT_EASE
                     }, 0);
 

--- a/src/app/ui/toc/entry.directive.js
+++ b/src/app/ui/toc/entry.directive.js
@@ -59,6 +59,8 @@
                 // call toggleGroup function on the tocController with the group object (see template)
                 self.defaultAction = tocService.actions.toggleLayerGroup;
             }
+
+            self.itemNameOnTop = self.entry.layerType === 'ogcWms';
         }
     }
 })();

--- a/src/app/ui/toc/templates/layer-entry.html
+++ b/src/app/ui/toc/templates/layer-entry.html
@@ -7,7 +7,7 @@
     <!-- TODO: add aria attribues on the button to provide context on what it does; also mute the actual layer name below, so a screen reader wouldn't pronounce it twice-->
 </md-button>
 
-<rv-toc-entry-symbology symbology="self.entry.symbology"></rv-toc-entry-symbology>
+<rv-toc-entry-symbology ng-class="{'item-name-on-top': self.itemNameOnTop}" symbology="self.entry.symbology"></rv-toc-entry-symbology>
 
 <div class="rv-layer-item-content">
     <div class="rv-layer-item-name">

--- a/src/content/styles/modules/_symbology.scss
+++ b/src/content/styles/modules/_symbology.scss
@@ -26,11 +26,15 @@
             position: absolute;
             left: 0;
             top: 0;
+            padding-left: 15px;
 
             // hide symbology name in collapsed state
             .rv-symbology-item-name {
                 opacity: 0;
                 display: none;
+                position: absolute;
+                left: 0;
+                width: 300px;
             }
         }
 

--- a/src/content/styles/modules/_symbology.scss
+++ b/src/content/styles/modules/_symbology.scss
@@ -31,8 +31,6 @@
             .rv-symbology-item-name {
                 opacity: 0;
                 display: none;
-                position: absolute;
-                left: 0;
                 width: 300px;
             }
         }

--- a/src/content/styles/modules/_symbology.scss
+++ b/src/content/styles/modules/_symbology.scss
@@ -26,7 +26,6 @@
             position: absolute;
             left: 0;
             top: 0;
-            padding-left: 15px;
 
             // hide symbology name in collapsed state
             .rv-symbology-item-name {

--- a/src/content/styles/modules/_toc.scss
+++ b/src/content/styles/modules/_toc.scss
@@ -136,8 +136,17 @@ $layer-item-height: rem(6.0);
             padding-left: $offset * ($index) + rem(1.6) + $toc-padding;
         }
 
-        .rv-toc-layer-entry{
+        .rv-toc-layer-entry {
             padding-left: $offset * ($index) + rem(1.6) + $toc-padding;
+            
+            .item-name-on-top {
+            
+                .rv-symbology-item-name {
+                    position: absolute;
+                    left: -10px;
+                }
+               
+            }
         }
 
         .rv-toc-group-entry {

--- a/src/content/styles/modules/_toc.scss
+++ b/src/content/styles/modules/_toc.scss
@@ -138,14 +138,13 @@ $layer-item-height: rem(6.0);
 
         .rv-toc-layer-entry {
             padding-left: $offset * ($index) + rem(1.6) + $toc-padding;
-            
+
             .item-name-on-top {
-            
+
                 .rv-symbology-item-name {
                     position: absolute;
                     left: -10px;
                 }
-               
             }
         }
 


### PR DESCRIPTION
Layer name now above graphic, resizing done with GreenSock lib.

Closes #517

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/588)
<!-- Reviewable:end -->
