### PR TITLE
fix(ui): scrollbar removed from collapsed group layer

### DIFF
--- a/src/content/styles/modules/_toc.scss
+++ b/src/content/styles/modules/_toc.scss
@@ -44,7 +44,6 @@ $layer-item-height: rem(6.0);
 
         > li {
             position: relative;
-            overflow: auto;
         }
         // rotate the icon on the toggle button on open
         .md-toggle-icon {


### PR DESCRIPTION
This issue is not related to style collisions in WET pages, those issues
are not addressed in this fix.

Closes #482

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/602)
<!-- Reviewable:end -->
