### PR TITLE
fix(layout): overwite padding set by wet css class on .container

### DIFF
--- a/src/content/styles/modules/_esri-map.scss
+++ b/src/content/styles/modules/_esri-map.scss
@@ -15,12 +15,6 @@
             clip: auto !important;
         }
 
-        .container {
-            // to overwrite WET padding on container object; this solve the problem of offset
-            // when you shift click zoom or do identify feature
-            padding: 0px!important;
-        }
-
         .layerTile {
             // tiles don't line up properly otherwise
             position: absolute;

--- a/src/content/styles/modules/_esri-map.scss
+++ b/src/content/styles/modules/_esri-map.scss
@@ -15,6 +15,12 @@
             clip: auto !important;
         }
 
+        .container {
+            // to overwrite WET padding on container object; this solve the problem of offset
+            // when you shift click zoom or do identify feature
+            padding: 0px!important;
+        }
+
         .layerTile {
             // tiles don't line up properly otherwise
             position: absolute;

--- a/src/content/styles/vendor/_all.scss
+++ b/src/content/styles/vendor/_all.scss
@@ -14,7 +14,9 @@ md-icon {
 @import "_datatable.scss";
 @import "_esri.scss";
 @import "_dragula.scss";
+@import "_wet.scss";
 
 @include datatable;
 @include esri;
 @include dragula;
+@include wet;

--- a/src/content/styles/vendor/_wet.scss
+++ b/src/content/styles/vendor/_wet.scss
@@ -1,0 +1,8 @@
+@mixin wet {
+    .container {
+        // to overwrite WET padding on container object; this solve the problem of offset
+        // when you shift click zoom or do identify feature
+        padding: 0;
+        margin: 0;
+    }
+}


### PR DESCRIPTION
All clicks on the map was offset so it creates problem for identify click and shift-zoom. WET does not prefix their css class so this kind of problem may append again

Closes #623

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/631)
<!-- Reviewable:end -->
