### PR TITLE
Fix for Object.entries polyfill and phantomjs

### DIFF
--- a/src/polyfill/object.entries.js
+++ b/src/polyfill/object.entries.js
@@ -11,12 +11,22 @@ if (!Object.values) {
             return concat(v, typeof k === 'string' && isEnumerable(O, k) ? [O[k]] : []);
         }, []);
     };
+    /*
+Object.values = (object) => Object.keys(object).map(
+        (key) => object[key]
+    );
+    */
 }
 
 if (!Object.entries) {
+    /*
     Object.entries = function entries(O) {
         return reduce(keys(O), function (e, k) {
             return concat(e, typeof k === 'string' && isEnumerable(O, k) ? [[k, O[k]]] : []);
         }, []);
+    };
+    */
+    Object.entries = function (object) {
+        return Object.keys(object).map(function (key) { return [key, object[key]]; });
     };
 }


### PR DESCRIPTION
PhantomJS is old and doesn't deal with `bind` very well.  If we switch polyfills for Object.entries we can fix this.  PR outside of the window since `gulp test:auto` fails on every reload after the first test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/705)
<!-- Reviewable:end -->
