### PR TITLE
fix(ui): layer group visibility updates on child layer visibility change

### DIFF
--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -24,7 +24,7 @@
         .module('app.geo')
         .service('legendEntryFactory', legendEntryFactory);
 
-    function legendEntryFactory($timeout, $translate, gapiService, Geo, layerDefaults) {
+    function legendEntryFactory($timeout, $translate, gapiService, Geo, layerDefaults, $rootScope) {
 
         const service = {
             placeholderEntryItem,
@@ -334,6 +334,17 @@
             add(item, position = this.items.length) { // <- awesome! default is re-evaluated everytime the function is called
                 item.parent = this;
                 this.items.splice(position, 0, item);
+
+                // Propagate item visibility changes up so group visibility is updated
+                $rootScope.$watch(() => item.options.visibility.value, () => {
+                    for (let i = 0; i < this.items.length; i++) {
+                        if (!this.items[i].getVisibility()) {
+                            this.options.visibility.value = false;
+                            return;
+                        }
+                    }
+                    this.options.visibility.value = true;
+                });
 
                 return position;
             },

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -283,27 +283,6 @@
         };
 
         /**
-         * Adds a dynamic item (layer or another group) to a layer group.
-         * @param {Object} item     layer or group item to add
-         * @param {Number} position position to insert the item at; defaults to the last position in the array
-         * @return position of the inserted item
-         */
-        DYNAMIC_ENTRY_GROUP.add = function (item, position) {
-            // Propagate item visibility changes up so group visibility is updated
-            $rootScope.$watch(() => item.options.visibility.value, () => {
-                for (let i = 0; i < this.items.length; i++) {
-                    if (this.items[i].getVisibility()) {
-                        this.options.visibility.value = true;
-                        return;
-                    }
-                }
-                this.options.visibility.value = false;
-            });
-
-            return ENTRY_GROUP.add.call(this, item, position);
-        };
-
-        /**
          * Sets visibility of a simple layer object, one which is represented by a single entry in the legend
          * @param  {Boolean} value visibility value
          * @param  {Boolean} isTrigger flag specifying if the visibility value should be applied to the actual layer; this is used to avoid setting visiblity multiple times for items in a subgroup when propagating
@@ -466,6 +445,27 @@
             checkSettings(this.options);
 
             return this;
+        };
+
+        /**
+         * Adds a dynamic item (layer or another group) to a layer group.
+         * @param {Object} item     layer or group item to add
+         * @param {Number} position position to insert the item at; defaults to the last position in the array
+         * @return position of the inserted item
+         */
+        DYNAMIC_ENTRY_GROUP.add = function (item, position) {
+            // Propagate item visibility changes up so group visibility is updated
+            $rootScope.$watch(() => item.options.visibility.value, () => {
+                for (let i = 0; i < this.items.length; i++) {
+                    if (this.items[i].getVisibility()) {
+                        this.options.visibility.value = true;
+                        return;
+                    }
+                }
+                this.options.visibility.value = false;
+            });
+
+            return ENTRY_GROUP.add.call(this, item, position);
         };
 
         /**

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -283,6 +283,27 @@
         };
 
         /**
+         * Adds a dynamic item (layer or another group) to a layer group.
+         * @param {Object} item     layer or group item to add
+         * @param {Number} position position to insert the item at; defaults to the last position in the array
+         * @return position of the inserted item
+         */
+        DYNAMIC_ENTRY_GROUP.add = function (item, position) {
+            // Propagate item visibility changes up so group visibility is updated
+            $rootScope.$watch(() => item.options.visibility.value, () => {
+                for (let i = 0; i < this.items.length; i++) {
+                    if (this.items[i].getVisibility()) {
+                        this.options.visibility.value = true;
+                        return;
+                    }
+                }
+                this.options.visibility.value = false;
+            });
+
+            return ENTRY_GROUP.add.call(this, item, position);
+        };
+
+        /**
          * Sets visibility of a simple layer object, one which is represented by a single entry in the legend
          * @param  {Boolean} value visibility value
          * @param  {Boolean} isTrigger flag specifying if the visibility value should be applied to the actual layer; this is used to avoid setting visiblity multiple times for items in a subgroup when propagating
@@ -334,17 +355,6 @@
             add(item, position = this.items.length) { // <- awesome! default is re-evaluated everytime the function is called
                 item.parent = this;
                 this.items.splice(position, 0, item);
-
-                // Propagate item visibility changes up so group visibility is updated
-                $rootScope.$watch(() => item.options.visibility.value, () => {
-                    for (let i = 0; i < this.items.length; i++) {
-                        if (!this.items[i].getVisibility()) {
-                            this.options.visibility.value = false;
-                            return;
-                        }
-                    }
-                    this.options.visibility.value = true;
-                });
 
                 return position;
             },

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -24,7 +24,7 @@
         .module('app.geo')
         .service('legendEntryFactory', legendEntryFactory);
 
-    function legendEntryFactory($timeout, $translate, gapiService, Geo, layerDefaults, $rootScope) {
+    function legendEntryFactory($timeout, $translate, gapiService, Geo, layerDefaults) {
 
         const service = {
             placeholderEntryItem,
@@ -448,27 +448,6 @@
         };
 
         /**
-         * Adds a dynamic item (layer or another group) to a layer group.
-         * @param {Object} item     layer or group item to add
-         * @param {Number} position position to insert the item at; defaults to the last position in the array
-         * @return position of the inserted item
-         */
-        DYNAMIC_ENTRY_GROUP.add = function (item, position) {
-            // Propagate item visibility changes up so group visibility is updated
-            $rootScope.$watch(() => item.options.visibility.value, () => {
-                for (let i = 0; i < this.items.length; i++) {
-                    if (this.items[i].getVisibility()) {
-                        this.options.visibility.value = true;
-                        return;
-                    }
-                }
-                this.options.visibility.value = false;
-            });
-
-            return ENTRY_GROUP.add.call(this, item, position);
-        };
-
-        /**
          * Sets visibility of a simple layer object, one which is represented by a single entry in the legend
          * @param  {Boolean} value visibility value
          * @param  {Boolean} isTrigger flag specifying if the visibility value should be applied to the actual layer; this is used to avoid setting visiblity multiple times for items in a subgroup when propagating
@@ -629,6 +608,7 @@
                 .filter(index => index !== -1); // filter out ones that are not visible
 
             // console.log(this.name + ' set to ' + this.getVisibility() + ' ' + visibleSublayerIds);
+            this.options.visibility.value = visibleSublayerIds.length > 0;
 
             // apply visibility to the dynamic layer itself
             this._layerRecord.setVisibility(this.getVisibility());


### PR DESCRIPTION
Previously the visibility of a layer group did not correctly update when the visibility of a child layer changed. If all child layers for example were hidden, the group layer would remain visible. Now changes to child layer visibility correctly update the group layer. A group is considered visible if all children in the group are visible, otherwise it is hidden.

Closes #663

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/722)
<!-- Reviewable:end -->
