### PR TITLE
fix(core): set default language at configService init

### DIFF
--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -96,6 +96,9 @@
                         langs = ['en-CA', 'fr-CA'];
                     }
 
+                    // set the language right away and not wait the initialization to be fullfilled
+                    $translate.use(langs[0]);
+
                     langs.forEach(lang => partials[lang] = []);
 
                     if (svcAttr) {

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -36,9 +36,6 @@
         // $rootScope.$on('$translateLoadingSuccess', data => console.log(data));
         $rootScope.$on('$translateLoadingSuccess', () => console.log(
             '$translateLoadingSuccess ->'));
-
-        // TODO: write language detection routine
-        $translate.use('en-CA');
     }
 
     function apiBlock($translate, $rootElement, $rootScope, globalRegistry, geoService, configService, events,


### PR DESCRIPTION
RunBlock (core.run) execution set the language by default to en-CA
while the configService generate fr-CA as the only key
if rv-langs = '[fr-CA]' so a conflict is generate at configService.getCurrent() call
Solution: remove RunBlock language setting and set the config or default language
in configService right after the rv-langs value extraction

Closes #620

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/757)
<!-- Reviewable:end -->
