### PR TITLE
fix(ui): expand panel position and data

### DIFF
--- a/src/app/layout/shell.directive.js
+++ b/src/app/layout/shell.directive.js
@@ -45,7 +45,7 @@
     }
 
     function Controller($rootElement, $mdDialog, version, sideNavigationService, geoService, fullScreenService,
-        helpService, configService) {
+        helpService, configService, storageService) {
         'ngInject';
         const self = this;
 
@@ -83,7 +83,7 @@
                         controller: helpService.HelpSummaryController,
                         controllerAs: 'self',
                         templateUrl: 'app/ui/help/help-summary.html',
-                        parent: $rootElement,
+                        parent: storageService.panels.shell,
                         disableParentScroll: false,
                         targetEvent: event,
                         clickOutsideToClose: true,

--- a/src/app/layout/shell.html
+++ b/src/app/layout/shell.html
@@ -1,7 +1,7 @@
 <ng-include src="'app/ui/sidenav/sidenav.html'"></ng-include>
 
 <!-- TODO: add proper loading message or animation to the loading splash -->
-<div class="rv-loading" layout layout-align="center center" ng-class="{ 'rv-loaded': self.geoService.isMapReady }">
+<div class="rv-loading-screen" layout layout-align="center center" ng-class="{ 'rv-loaded': self.geoService.isMapReady }">
     <div class="rv-loading-section rv-left"></div>
     <div class="rv-loading-section rv-right"></div>
     <div class="rv-spinner google-spin-wrapper">

--- a/src/app/ui/details/details-expand.directive.js
+++ b/src/app/ui/details/details-expand.directive.js
@@ -34,7 +34,7 @@
         return directive;
     }
 
-    function Controller(stateManager, $mdDialog) {
+    function Controller(stateManager, $mdDialog, storageService) {
         'ngInject';
         const self = this;
 
@@ -43,12 +43,14 @@
         function expandPanel() {
             $mdDialog.show({
                 controller: () => {},
+                parent: storageService.panels.shell,
                 locals: {
                     item: stateManager.display.details.selectedItem,
                     cancel: $mdDialog.cancel
                 },
                 templateUrl: 'app/ui/details/details-modal.html',
                 clickOutsideToClose: true,
+                disableParentScroll: false,
                 escapeToClose: true,
                 controllerAs: 'self',
                 bindToController: true

--- a/src/app/ui/details/details-modal.html
+++ b/src/app/ui/details/details-modal.html
@@ -3,7 +3,7 @@
     <rv-content-pane
         close-panel="self.cancel()"
         title-style="title"
-        title-value="{{ 'details.title' | translate }}: {{ self.item.requester.name }}, {{ self.item.requester.caption }} ">
+        title-value="{{ 'details.title' | translate }}: {{ self.item.requester.name }} {{ self.item.requester.caption }} ">
 
         <div class="rv-details">
             <md-content class="rv-details-data rv-content"

--- a/src/app/ui/details/details.directive.js
+++ b/src/app/ui/details/details.directive.js
@@ -66,6 +66,8 @@
         function selectItem(item) {
             self.selectedItem = item;
             self.selectedInfo = (item) ? `${item.requester.caption}${item.requester.name}` : null;
+
+            self.display.selectedItem = self.selectedItem;
         }
 
         $scope.$watch('self.display.data', newValue => {
@@ -73,9 +75,7 @@
             // if multiple points added to the details panel ...
             if (newValue && newValue.length > 0) {
                 // pick selected item user previously selected one, otherwise pick the first one
-                // do not use selectItem() because we want to update selectedInfo only when user do it
-                const item = (self.selectedInfo) ? getSelectedItem(newValue) : newValue[0];
-                self.selectedItem = item;
+                selectItem(self.selectedInfo ? getSelectedItem(newValue) : newValue[0]);
             } else {
                 self.selectItem(null);
             }

--- a/src/app/ui/metadata/metadata-content.directive.js
+++ b/src/app/ui/metadata/metadata-content.directive.js
@@ -48,6 +48,7 @@
                         pElem.html($compile(
                             `<rv-truncate max-text-length="${maxTextLength}">${pElem.html()}</rv-truncate>`)(scope));
                     });
+                    el.empty();
                     el.append(metadata);
                 }
             });

--- a/src/app/ui/metadata/metadata-expand.directive.js
+++ b/src/app/ui/metadata/metadata-expand.directive.js
@@ -34,7 +34,7 @@
         return directive;
     }
 
-    function Controller(stateManager, $mdDialog) {
+    function Controller(stateManager, $mdDialog, storageService) {
         'ngInject';
         const self = this;
 
@@ -56,7 +56,9 @@
                 clickOutsideToClose: true,
                 escapeToClose: true,
                 controllerAs: 'self',
-                bindToController: true
+                disableParentScroll: false,
+                bindToController: true,
+                parent: storageService.panels.shell
             });
         }
     }

--- a/src/content/styles/modules/_loading.scss
+++ b/src/content/styles/modules/_loading.scss
@@ -1,7 +1,7 @@
 // loading spals
 @mixin loading {
     // takes the entire viewer viewport
-    .rv-loading {
+    .rv-loading-screen {
         position: absolute;
         top: 0;
         bottom: 0;


### PR DESCRIPTION
The disableParentScroll property of $mdDialog must be false for correct placement of the expand panel. See https://github.com/angular/material/blob/master/src/components/backdrop/backdrop.js#L35 for more details.

Closes #669, #717, #718, #763

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/781)
<!-- Reviewable:end -->
