### PR TITLE
chore(build): add lazyguts mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "karma-phantomjs-launcher": "^0.2.0",
     "karma-sinon": "^1.0.4",
     "karma-spec-reporter": "0.0.23",
+    "lazypipe": "^1.0.1",
     "lodash": "^3.10.1",
     "main-bower-files": "^2.9.0",
     "merge-stream": "^1.0.0",


### PR DESCRIPTION
run `gulp serve --guts` to skip js style checks

P.S.: wanted `lazy` flag, but node already has one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/792)
<!-- Reviewable:end -->
