### PR TITLE
Focusfix 815

### DIFF
--- a/src/app/common/router/statemanager.service.js
+++ b/src/app/common/router/statemanager.service.js
@@ -170,6 +170,7 @@
          * @param {String} property  property name to modify
          * @param {Boolean} value  target state value
          * @param {Boolean} skip skips animation, defaults to false
+         * @return {Promise} resolving when transition (if any) ends
          */
         function setItemProperty(itemName, property, value, skip = false) {
             const item = service.state[itemName];
@@ -345,7 +346,8 @@
             if (typeof panelToClose.item.parent === 'undefined') {
                 animationPromise = setItemProperty(panelToClose.name, 'active', false)
                     .then(() =>
-                        propagate ? getChildren(panelToClose.name).forEach(child => closePanel(child, false))
+                        // wait for all child transition promises to resolve
+                        propagate ? $q.all(getChildren(panelToClose.name).map(child => closePanel(child, false)))
                                   : true
                     );
 

--- a/src/app/common/router/statemanager.service.js
+++ b/src/app/common/router/statemanager.service.js
@@ -143,12 +143,16 @@
          * @return  {Promise}   resolves when a panel has finished its closing animation
          */
         function closePanelFromHistory() {
-            return service.panelHistory.length > 0 ? setActive({ [service.panelHistory.pop()]: false }) : $q.resolve();
+            const promise = service.panelHistory.length > 0 ? closePanel(getItem(service.panelHistory.pop()))
+                                                            : $q.resolve();
+            // set focus after the panel is closed
+            promise.then(() => setPanelFocus(service.panelHistory[service.panelHistory.length - 1]));
+
+            return promise;
         }
 
         /**
          * Closes fromPanel and opens toPanel so that the parent panel remains unchanged.
-         *
          * Generally you should only use this function to swap sibling panels.
          *
          * @function togglePanel
@@ -156,8 +160,13 @@
          * @param  {String}   toPanelName the name of a child panel
          */
         function togglePanel(fromPanelName, toPanelName) {
-            return setActive({ [fromPanelName]: false })
-                .then(() => setActive({ [toPanelName]: true }));
+            const fromPanel = getItem(fromPanelName);
+            const toPanel = getItem(toPanelName);
+
+            return closePanel(fromPanel, false)
+                .then(() => openPanel(toPanel, false))
+                // set focus after the child pane swap
+                .then(() => setPanelFocus(toPanelName));
         }
 
         /* PRIVATE HELPERS */

--- a/src/app/common/router/statemanager.service.spec.js
+++ b/src/app/common/router/statemanager.service.spec.js
@@ -1,6 +1,9 @@
 /* global bard, stateManager, $rootScope */
 
 describe('stateManager', () => {
+
+    const mainPanelNames = ['main', 'mainToc', 'mainToolbox', 'mainDetails', 'mainLoaderFile', 'mainLoaderService'];
+
     beforeEach(() => {
 
         bard.appModule('app.common.router');
@@ -101,8 +104,9 @@ describe('stateManager', () => {
 
             // open main; should auto-open one of the children
             // need to listen on item state changes and resolve locks on the stateManager
-            $rootScope.$watch(() => state.main.active, () =>
-                stateManager.callback('main', 'active'));
+            mainPanelNames.forEach(panelName =>
+                $rootScope.$watch(() => state[panelName].active, () =>
+                    stateManager.callback(panelName, 'active')));
 
             $rootScope.$digest();
 


### PR DESCRIPTION
The focus was being set to the close button on the main panel at the beginning of the transition (not waiting for child promises to resolve). The initial panel's position (shifted upwards) put the button above the app container (even above the top border of the page) and by focusing on it, the page would scroll up.

Closes #815

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/880)
<!-- Reviewable:end -->
