### PR TITLE
chore(build): add sourcemaps to prod build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -277,7 +277,7 @@ gulp.task('jsrollup', 'Roll up all js into one file',
             // can't use lazy pipe with uglify
             .pipe($.if(PROD_MODE, $.sourcemaps.init()))
             .pipe($.if(PROD_MODE, $.uglify()))
-            .pipe($.if(PROD_MODE, $.sourcemaps.write('/maps')))
+            .pipe($.if(PROD_MODE, $.sourcemaps.write('./maps')))
             .pipe(gulp.dest(config.libBuild));
     });
 
@@ -300,7 +300,7 @@ gulp.task('jsinjector', 'Copy fixed assets to the build directory',
             // can't use lazy pipe with uglify
             .pipe($.if(PROD_MODE, $.sourcemaps.init()))
             .pipe($.if(PROD_MODE, $.uglify()))
-            .pipe($.if(PROD_MODE, $.sourcemaps.write('/maps')))
+            .pipe($.if(PROD_MODE, $.sourcemaps.write('./maps')))
             .pipe(gulp.dest(config.libBuild));
     });
 


### PR DESCRIPTION
Moves uglify task to the end of the concat chain - instead of uglifying parts, uglify two resulting files only (core.js and bootstrap.js).
Generates external sourcemaps with `--prod`. This won't give you proper sourcemaps - this let's you somewhat debug production builds.
In Chrome, currently, mapping local variables doesn't work when names are mangled (uglified); see this issue https://github.com/gruntjs/grunt-contrib-uglify/issues/325; it works in latest Canary.

In support of #293

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/882)
<!-- Reviewable:end -->
