### PR TITLE
Fix broken sample layers

### DIFF
--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -237,17 +237,18 @@
                         // we want to make a nice table
                         clickResults.forEach(ele => {
                             // NOTE: the identify service returns aliased field names, so no need to look them up here.
-                            //       however, this means we need to un-alias the data when using the symbol lookup.
+                            //       however, this means we need to un-alias the data when doing field lookups.
                             // NOTE: ele.layerId is what we would call featureIdx
                             layerRecord.attributeBundle[ele.layerId].layerData.then(lData => {
+                                const unAliasAtt = unAliasAttribs(ele.feature.attributes, lData.fields);
                                 const identifyResult = identifyResults[ele.layerId];
+
                                 identifyResult.data.push({
                                     name: ele.value,
                                     data: attributesToDetails(ele.feature.attributes),
-                                    oid: ele.feature.attributes[lData.oidField],
+                                    oid: unAliasAtt[lData.oidField],
                                     symbology: [{
-                                        icon: geoState.mapService.retrieveSymbol(
-                                            unAliasAttribs(ele.feature.attributes, lData.fields), lData.renderer)
+                                        icon: geoState.mapService.retrieveSymbol(unAliasAtt, lData.renderer)
                                     }]
                                 });
                                 identifyResult.isLoading = false;

--- a/src/app/geo/layer-blueprint.class.js
+++ b/src/app/geo/layer-blueprint.class.js
@@ -130,8 +130,8 @@
                     // TODO: throw error ?
                     console.error('Service layer needs a url.');
                     return;
-                } else {
-                    // `replace` strips trailing slashes
+                } else if (initialConfig.layerType === Geo.Layer.Types.FeatureLayer) {
+                    // `replace` strips trailing slashes. Assists in plucking index off url.
                     initialConfig.url = initialConfig.url.replace(/\/+$/, '');
                 }
 

--- a/src/app/ui/details/details.directive.js
+++ b/src/app/ui/details/details.directive.js
@@ -79,8 +79,9 @@
             self.display.selectedItem = self.selectedItem;
 
             // add hilights to all things in the layer.
+            // featureIdx can be 0, so no falsy checks allowed
             // TODO is this the appropriate place for hilighting code?
-            if (item && item.requester && item.requester.featureIdx) {
+            if (item && item.requester && typeof item.requester.featureIdx !== 'undefined') {
                 geoService.hilightGraphic(item.requester.layerRec, item.requester.featureIdx,
                     item.data.map(d => d.oid));
             }

--- a/src/config.en-CA.json
+++ b/src/config.en-CA.json
@@ -131,7 +131,10 @@
       "id":"stb_eos",
       "name": "STB EOS 2014 CI ON 30m v2",
       "layerType":"esriTile",
-      "url":"http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+      "url":"http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer",
+      "options": {
+        "opacity": { "value": 0.5 }
+      }
     },
     {
       "id":"ecogeo",

--- a/src/config.en-CA.json
+++ b/src/config.en-CA.json
@@ -131,7 +131,7 @@
       "id":"stb_eos",
       "name": "STB EOS 2014 CI ON 30m v2",
       "layerType":"esriTile",
-      "url":"http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3857/MapServer"
+      "url":"http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
     },
     {
       "id":"ecogeo",


### PR DESCRIPTION
* change sample tile to be in same projection as app default
* make url slash-stripping only occur on feature layers to stop breaking geomet
* incidental fix to object id lookup on aliased object id field when doing identify on dynamic layers
* incidental fix to identify group hilight where feature index of `0` would trigger a falsy check

Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/843

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/915)
<!-- Reviewable:end -->
