### PR TITLE
fix(ui): omit loading layers from identify

### DIFF
--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -205,7 +205,7 @@
                 const legendEntry = layerRecord.legendEntry;
 
                 // ignore invisible layers by returning empty object
-                if (!layerRecord.visibleAtMapScale || !layerRecord.visible) {
+                if (!layerRecord.visibleAtMapScale || !layerRecord.visible || legendEntry.isLoading) {
                     return {};
                 }
 
@@ -295,7 +295,8 @@
                 // ignore layers with no mime type or invisible layers and those where query option is false by returning empty object
                 if (!infoMap.hasOwnProperty(legendEntry.featureInfoMimeType) ||
                     !layerRecord.visible ||
-                    !legendEntry.options.query.value) {
+                    !legendEntry.options.query.value ||
+                    legendEntry.isLoading) {
                     return {};
                 }
 
@@ -335,7 +336,8 @@
                 const legendEntry = layerRecord.legendEntry;
 
                 // ignore invisible layers and those where identify option is false by returning empty object
-                if (!layerRecord.visibleAtMapScale || !layerRecord.visible || !legendEntry.options.query.value) {
+                if (!layerRecord.visibleAtMapScale || !layerRecord.visible ||
+                    !legendEntry.options.query.value || legendEntry.isLoading) {
                     return {};
                 }
 


### PR DESCRIPTION
Resolves various errors caused by code execution on loading legend entry
items. Loading entries will not be displayed.

Closes #790

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/999)
<!-- Reviewable:end -->
