### PR TITLE
Use geoApi v1.0.1-5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "gsap": "^1.18.0",
     "bezier-easing": "^1.0.0",
     "dotjem-angular-tree": "~0.2.1",
-    "geoapi": "http://fgpv.cloudapp.net/demo/gapi/geoapi-1.0.1-4.tgz",
+    "geoapi": "http://fgpv.cloudapp.net/demo/gapi/geoapi-1.0.1-5.tgz",
     "datatables.net": "~1.10.10",
     "datatables.net-dt": "~1.10.10",
     "datatables-scroller": "~1.4.0",


### PR DESCRIPTION
Allow app to use geoApi version containing fix for https://github.com/fgpv-vpgf/fgpv-vpgf/issues/948

Please review thoroughly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1002)
<!-- Reviewable:end -->
