### PR TITLE
Dont identify offscale dynamic sublayer

### DIFF
--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -210,15 +210,18 @@
                 }
 
                 const identifyResults = [];
+                opts.layerIds = [];
 
                 // every dynamic layer is a group in toc; walk its items to create an entry in details panel
                 legendEntry.walkItems(legendEntry => {
 
-                    // ignore invisible sublayers and those where query option is false by returning empty object
-                    if (!legendEntry.getVisibility() || !legendEntry.options.query.value) {
+                    // ignore invisible sublayers, offscale sublayers, and those where query option is false by returning empty object
+                    if (!legendEntry.getVisibility() || !legendEntry.options.query.value ||
+                        legendEntry.flags.scale.visible) {
                         return;
                     }
 
+                    opts.layerIds.push(legendEntry.featureIdx); // tell server to query this layer
                     const identifyResult =
                         IDENTIFY_RESULT(legendEntry.name, legendEntry.symbology, 'EsriFeature', layerRecord,
                             legendEntry.featureIdx, legendEntry.name);


### PR DESCRIPTION
Use offscale status when deciding if a dynamic sublayer should be part of the identify results.  Pass valid layers to server to prevent it from querying invalid sublayers

Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/664

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1023)
<!-- Reviewable:end -->
