### PR TITLE
Turn datatable "details" and "zoom in/out" "buttons" into real buttons

### DIFF
--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -1,5 +1,6 @@
 (() => {
     // button blueprints to be added to the table rows
+    // `self` property is named so intentionally, as it will be passed on a scope to the ROW_BUTTON_TEMPLATE
     const ROW_BUTTONS = {
         details: {
             name: 'rv-details-marker',
@@ -196,6 +197,8 @@
 
                 /**
                  * Table initialization callback. This will hide the loading indicator.
+                 * @function onTableInit
+                 * @private
                  */
                 function onTableInit() {
                     // turn off loading indicator after the table initialized or the forced delay whichever takes longer; cancel loading timeout as well
@@ -208,6 +211,8 @@
 
                 /**
                  * Table draw callback. This will replace row placeholder button with real angular directives.
+                 * @function onTableDraw
+                 * @private
                  */
                 function onTableDraw() {
                     console.log('rows are drawn');
@@ -230,6 +235,8 @@
 
                 /**
                  * Row zoom click handler. Will zoom to the feature clicked.
+                 * @function onZoomClick
+                 * @private
                  * @param  {Number} rowNumber number of the row clicked
                  */
                 function onZoomClick(rowNumber) {
@@ -245,6 +252,8 @@
 
                 /**
                  * Row details click handler. Will display details for the feature clicked.
+                 * @function onDetailsClick
+                 * @private
                  * @param  {Number} rowNumber number of the row clicked
                  */
                 function onDetailsClick(rowNumber) {
@@ -300,6 +309,10 @@
                 function addColumnInteractivity(column, buttons) {
                     // use render function to augment button to displayed data when the table is rendered
 
+                    // we have to do some horrible string manipulations because Datatables required the `render` function to return a string
+                    // it's not possble to return a compiled directive from the `render` function since directives compile directly into dom nodes
+                    // first, button placeholder nodes are rendered as part of the cell data
+                    // then, on `draw.dt`, these placeholders are replaced with proper compiled button directives
                     column.render = (data, type, row, meta) => {
                         const buttonPlaceholdersTemplate = Object.values(buttons).map(button =>
                             `<${button.name} row="${meta.row}"></${button.name}>`)

--- a/src/content/styles/modules/_filters.scss
+++ b/src/content/styles/modules/_filters.scss
@@ -35,42 +35,28 @@
                         background: lighten($divider-color, 20%);
 
                         tbody {
-                            .rv-wrapper {
-                                display: flex;
-                                align-items: center;
-
-                                &.rv-symbol {
-                                    justify-content: center;
-                                    img {
-                                        display: block;
-                                    }
-                                }
-                            }
 
                             .rv-data {
                                 // flex: flex-grow flex-shrink flex-basis; IE sets flex-basis as 0px which collapses the span instead of 0% as Chrome does;
                                 flex: 1 1 auto;
                             }
 
-                            // FIXME: should be removed when using real button in datatables
-                            .rv-icon {
-                                cursor: pointer;
-                                margin: 0 0 0 rem(0.6);
-                            }
+                            .rv-wrapper {
+                                display: flex;
+                                align-items: center;
 
-                            .rv-zoom-to, .rv-description {
+                                button {
+                                    margin-left: rem(0.3);
+                                    margin-right: rem(0.3);
 
-                                md-tooltip {
-                                    display: none;
+                                    &:first-of-type {
+                                        margin-left: rem(3.6);
+                                    }
+
+                                    &:last-of-type {
+                                        margin-right: 0;
+                                    }
                                 }
-
-                                &:hover md-tooltip {
-                                    display: block;
-                                }
-                            }
-
-                            .disabled {
-                                color: rgba(0, 0, 0, 0.26);
                             }
                         }
                     }


### PR DESCRIPTION
It's not possible to reuse a single compiled directive for all the zoom and details button in the table. We have to compile a directive for each button with a shared scope.

When table is being rendered, placeholder markers for zoom and details buttons are inserted. On the `draw.dt` event, placeholders are replaced with properly compiled buttons.

Closes #766

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1024)
<!-- Reviewable:end -->
