### PR TITLE
fix(ui): ESRI generated svg elements no longer focusable in IE 11

### DIFF
--- a/src/app/layout/shell.directive.js
+++ b/src/app/layout/shell.directive.js
@@ -15,7 +15,7 @@
         .module('app.layout')
         .directive('rvShell', rvShell);
 
-    function rvShell(storageService, stateManager, $rootElement) {
+    function rvShell(storageService, stateManager, $rootElement, events, $rootScope) {
         const directive = {
             restrict: 'E',
             templateUrl: 'app/layout/shell.html',
@@ -30,6 +30,11 @@
 
         function link(scope, el) {
             storageService.panels.shell = el;
+
+            // fix for IE 11 where focus can move to esri generated svg elements
+            $rootScope.$on(events.rvApiReady, () => {
+                $rootElement.find('.rv-esri-map svg').attr('focusable', false);
+            });
 
             // close all panels when escape key is pressed
             $rootElement.on('keydown', event => {


### PR DESCRIPTION
Closes #889, #1036

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1045)
<!-- Reviewable:end -->
