### PR TITLE
Make IE load polyfills consistently

### DIFF
--- a/src/index-fgp-en.html
+++ b/src/index-fgp-en.html
@@ -523,23 +523,6 @@
     </script>
 
     <script>
-    const importScript = (function (oHead) {
-        'use strict';
-
-        function loadError(oError) {
-            throw new URIError("The script " + oError.target.src + " is not accessible.");
-        }
-
-        return function (sSrc, fOnload) {
-            var oScript = document.createElement("script");
-            oScript.type = "text\/javascript";
-            oScript.async = false;
-            oScript.onerror = loadError;
-            if (fOnload) { oScript.onload = fOnload; }
-            oHead.appendChild(oScript);
-            oScript.src = sSrc;
-        };
-    })(document.head || document.getElementsByTagName("head")[0]);
     const needIePolyfills = [
         'Promise' in window,
         'TextDecoder' in window,
@@ -550,7 +533,7 @@
         'endsWith' in String.prototype
     ].some(function(x) { return !x; });
     if (needIePolyfills) {
-        importScript('../lib/ie-polyfills.js');
+        document.write('<script src="../lib/ie-polyfills.js"><\/script>');
     }
     </script>
 

--- a/src/index-fgp-en.html
+++ b/src/index-fgp-en.html
@@ -498,8 +498,6 @@
     </footer>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
-    <script src="http://wet-boew.github.io/v4.0-ci/wet-boew/js/wet-boew.min.js"></script>
-    <script src="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
 
     <script>
         // credit: http://stackoverflow.com/a/21903119
@@ -585,6 +583,8 @@
             });
         }
     </script>
+    <script src="http://wet-boew.github.io/v4.0-ci/wet-boew/js/wet-boew.min.js"></script>
+    <script src="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
 
 </body>
 </html>

--- a/src/index-fgp-en.html
+++ b/src/index-fgp-en.html
@@ -521,7 +521,7 @@
             document.getElementById("fgpmap").setAttribute("rv-config", testConfig);
         }
     </script>
-    
+
     <script>
     const importScript = (function (oHead) {
         'use strict';
@@ -533,6 +533,7 @@
         return function (sSrc, fOnload) {
             var oScript = document.createElement("script");
             oScript.type = "text\/javascript";
+            oScript.async = false;
             oScript.onerror = loadError;
             if (fOnload) { oScript.onload = fOnload; }
             oHead.appendChild(oScript);

--- a/src/index-fgp-fr.html
+++ b/src/index-fgp-fr.html
@@ -532,6 +532,7 @@
         return function (sSrc, fOnload) {
             var oScript = document.createElement("script");
             oScript.type = "text\/javascript";
+            oScript.async = false;
             oScript.onerror = loadError;
             if (fOnload) { oScript.onload = fOnload; }
             oHead.appendChild(oScript);

--- a/src/index-fgp-fr.html
+++ b/src/index-fgp-fr.html
@@ -522,23 +522,6 @@
     </script>
 
     <script>
-    const importScript = (function (oHead) {
-        'use strict';
-
-        function loadError(oError) {
-            throw new URIError("The script " + oError.target.src + " is not accessible.");
-        }
-
-        return function (sSrc, fOnload) {
-            var oScript = document.createElement("script");
-            oScript.type = "text\/javascript";
-            oScript.async = false;
-            oScript.onerror = loadError;
-            if (fOnload) { oScript.onload = fOnload; }
-            oHead.appendChild(oScript);
-            oScript.src = sSrc;
-        };
-    })(document.head || document.getElementsByTagName("head")[0]);
     const needIePolyfills = [
         'Promise' in window,
         'TextDecoder' in window,
@@ -549,7 +532,7 @@
         'endsWith' in String.prototype
     ].some(function(x) { return !x; });
     if (needIePolyfills) {
-        importScript('../lib/ie-polyfills.js');
+        document.write('<script src="../lib/ie-polyfills.js"><\/script>');
     }
     </script>
 

--- a/src/index-fgp-fr.html
+++ b/src/index-fgp-fr.html
@@ -497,8 +497,6 @@
     </footer>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
-    <script src="http://wet-boew.github.io/v4.0-ci/wet-boew/js/wet-boew.min.js"></script>
-    <script src="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
 
     <script>
         // credit: http://stackoverflow.com/a/21903119
@@ -584,6 +582,8 @@
             });
         }
     </script>
+    <script src="http://wet-boew.github.io/v4.0-ci/wet-boew/js/wet-boew.min.js"></script>
+    <script src="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
 
 </body>
 </html>

--- a/src/index-jso.html
+++ b/src/index-jso.html
@@ -32,23 +32,6 @@
         ]
     };
 
-    const importScript = (function (oHead) {
-        'use strict';
-
-        function loadError(oError) {
-            throw new URIError("The script " + oError.target.src + " is not accessible.");
-        }
-
-        return function (sSrc, fOnload) {
-            var oScript = document.createElement("script");
-            oScript.type = "text\/javascript";
-            oScript.async = false;
-            oScript.onerror = loadError;
-            if (fOnload) { oScript.onload = fOnload; }
-            oHead.appendChild(oScript);
-            oScript.src = sSrc;
-        };
-    })(document.head || document.getElementsByTagName("head")[0]);
     const needIePolyfills = [
         'Promise' in window,
         'TextDecoder' in window,
@@ -59,7 +42,7 @@
         'endsWith' in String.prototype
     ].some(function(x) { return !x; });
     if (needIePolyfills) {
-        importScript('../lib/ie-polyfills.js');
+        document.write('<script src="../lib/ie-polyfills.js"><\/script>');
     }
     </script>
 

--- a/src/index-jso.html
+++ b/src/index-jso.html
@@ -42,6 +42,7 @@
         return function (sSrc, fOnload) {
             var oScript = document.createElement("script");
             oScript.type = "text\/javascript";
+            oScript.async = false;
             oScript.onerror = loadError;
             if (fOnload) { oScript.onload = fOnload; }
             oHead.appendChild(oScript);

--- a/src/index-many.html
+++ b/src/index-many.html
@@ -64,23 +64,6 @@
         </div>
 
         <script>
-        const importScript = (function (oHead) {
-            'use strict';
-
-            function loadError(oError) {
-                throw new URIError("The script " + oError.target.src + " is not accessible.");
-            }
-
-            return function (sSrc, fOnload) {
-                var oScript = document.createElement("script");
-                oScript.type = "text\/javascript";
-                oScript.async = false;
-                oScript.onerror = loadError;
-                if (fOnload) { oScript.onload = fOnload; }
-                oHead.appendChild(oScript);
-                oScript.src = sSrc;
-            };
-        })(document.head || document.getElementsByTagName("head")[0]);
         const needIePolyfills = [
             'Promise' in window,
             'TextDecoder' in window,
@@ -91,7 +74,7 @@
             'endsWith' in String.prototype
         ].some(function(x) { return !x; });
         if (needIePolyfills) {
-            importScript('../lib/ie-polyfills.js');
+            document.write('<script src="../lib/ie-polyfills.js"><\/script>');
         }
         </script>
 

--- a/src/index-many.html
+++ b/src/index-many.html
@@ -74,6 +74,7 @@
             return function (sSrc, fOnload) {
                 var oScript = document.createElement("script");
                 oScript.type = "text\/javascript";
+                oScript.async = false;
                 oScript.onerror = loadError;
                 if (fOnload) { oScript.onload = fOnload; }
                 oHead.appendChild(oScript);

--- a/src/index-one.html
+++ b/src/index-one.html
@@ -22,23 +22,6 @@
          rv-restore-bookmark="bookmark"/>
 
     <script>
-    const importScript = (function (oHead) {
-        'use strict';
-
-        function loadError(oError) {
-            throw new URIError("The script " + oError.target.src + " is not accessible.");
-        }
-
-        return function (sSrc, fOnload) {
-            var oScript = document.createElement("script");
-            oScript.type = "text\/javascript";
-            oScript.async = false;
-            oScript.onerror = loadError;
-            if (fOnload) { oScript.onload = fOnload; }
-            oHead.appendChild(oScript);
-            oScript.src = sSrc;
-        };
-    })(document.head || document.getElementsByTagName("head")[0]);
     const needIePolyfills = [
         'Promise' in window,
         'TextDecoder' in window,
@@ -49,7 +32,7 @@
         'endsWith' in String.prototype
     ].some(function(x) { return !x; });
     if (needIePolyfills) {
-        importScript('../lib/ie-polyfills.js');
+        document.write('<script src="../lib/ie-polyfills.js"><\/script>');
     }
     </script>
 

--- a/src/index-one.html
+++ b/src/index-one.html
@@ -32,6 +32,7 @@
         return function (sSrc, fOnload) {
             var oScript = document.createElement("script");
             oScript.type = "text\/javascript";
+            oScript.async = false;
             oScript.onerror = loadError;
             if (fOnload) { oScript.onload = fOnload; }
             oHead.appendChild(oScript);

--- a/src/index-wet.html
+++ b/src/index-wet.html
@@ -306,23 +306,6 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <![endif]-->
 
     <script>
-    const importScript = (function (oHead) {
-        'use strict';
-
-        function loadError(oError) {
-            throw new URIError("The script " + oError.target.src + " is not accessible.");
-        }
-
-        return function (sSrc, fOnload) {
-            var oScript = document.createElement("script");
-            oScript.type = "text\/javascript";
-            oScript.async = false;
-            oScript.onerror = loadError;
-            if (fOnload) { oScript.onload = fOnload; }
-            oHead.appendChild(oScript);
-            oScript.src = sSrc;
-        };
-    })(document.head || document.getElementsByTagName("head")[0]);
     const needIePolyfills = [
         'Promise' in window,
         'TextDecoder' in window,
@@ -333,7 +316,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
         'endsWith' in String.prototype
     ].some(function(x) { return !x; });
     if (needIePolyfills) {
-        importScript('../lib/ie-polyfills.js');
+        document.write('<script src="../lib/ie-polyfills.js"><\/script>');
     }
     </script>
 

--- a/src/index-wet.html
+++ b/src/index-wet.html
@@ -316,6 +316,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
         return function (sSrc, fOnload) {
             var oScript = document.createElement("script");
             oScript.type = "text\/javascript";
+            oScript.async = false;
             oScript.onerror = loadError;
             if (fOnload) { oScript.onload = fOnload; }
             oHead.appendChild(oScript);


### PR DESCRIPTION
`document.write` for script loading: JS best practices +1
For the moment this is the simplest reasonable fix, and it is only for sample pages

Should close #1042 and #1043 when merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1049)
<!-- Reviewable:end -->
