### PR TITLE
fix(ui): Zoom to location more uniform between projections

### DIFF
--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -518,7 +518,11 @@
                 const geoPt = gapiService.gapi.proj.localProjectPoint(4326, map.spatialReference.wkid,
                     [parseFloat(location.longitude), parseFloat(location.latitude)]);
                 const zoomPt = gapiService.gapi.proj.Point(geoPt[0], geoPt[1], map.spatialReference);
-                map.centerAndZoom(zoomPt, map.__tileInfo.lods[map.__tileInfo.lods.length - 3].level);
+
+                // give preference to the layer closest to a 50k scale ratio which is ideal for zoom
+                const diffs = map.__tileInfo.lods.map(lod => Math.abs(lod.scale - 50000));
+                const lodIdx = diffs.indexOf(Math.min(...diffs));
+                map.centerAndZoom(zoomPt, Math.max(map.__tileInfo.lods[lodIdx].level, 0));
             }
 
             /**


### PR DESCRIPTION
Previously we used the third last LOD as the zoom level. Now we give
preference to the layer closest to a 50K scale.

Closes #874

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1054)
<!-- Reviewable:end -->
