### PR TITLE
fix(ui): Bounding box is hidden when layer is hidden

### DIFF
--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -240,7 +240,7 @@
             // hide bounding box only when visibility is hidden
             // TODO: move to the LayerRecord class when LayerRecord is moved into geoapi
             if (!tocEntry.options.visibility.value) {
-                stateManager.display.settings.data.options.boundingBox.value = false;
+                tocEntry.options.boundingBox.value = false;
                 geoService.setBboxState(tocEntry, false);
             }
         }


### PR DESCRIPTION
Fixes an issue where the bounding box remains visible when the settings
panel is closed and the layer is hidden

Closes #675

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1065)
<!-- Reviewable:end -->
