### PR TITLE
fix(ui): prevents rvReady from being fired multiple times

### DIFF
--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -24,7 +24,7 @@
     angular
         .module('app.core')
         .constant('events', {
-            rvReady: 'rvReady', // Fired when map should be created the first time
+            rvReady: 'rvReady', // Fired when map should be created the first time; should not be broadcasted more then once
             rvApiHalt: 'rvApiHalt', // Fired when API should be put back into 'queue' mode
             rvApiReady: 'rvApiReady', // Fired when API should let calls through
             rvBookmarkInit: 'rvBookmarkInit', // Fired after the bookmark has modified the config

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -52,10 +52,11 @@
 
             preLoadApiBlock();
 
-            if (waitAttr !== undefined) {
+            if (typeof waitAttr !== 'undefined') {
                 reloadService.bookmarkBlocking = true;
-                $rootScope.$on(events.rvBookmarkInit, () => {
+                const deRegister = $rootScope.$on(events.rvBookmarkInit, () => {
                     $rootScope.$broadcast(events.rvReady);
+                    deRegister(); // de-register `rvBookmarkInit` listener to prevent broadcasting `rvReady` in the future
                 });
             } else {
                 $rootScope.$broadcast(events.rvReady);


### PR DESCRIPTION
Related to bug #1131. The bug itself was accidentally prevented by PR #1117, but the underlying cause remained. 

`rvReady` event should not be broadcasted twice, and nothing should listen to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1135)
<!-- Reviewable:end -->
