### PR TITLE
Fix bookmark visibility and snapshot

### DIFF
--- a/src/app/core/bookmark.service.js
+++ b/src/app/core/bookmark.service.js
@@ -186,13 +186,6 @@
                 const id = layer.id;
                 const bookmarkLayer = layerObjs[id];
                 if (bookmarkLayer) {
-                    // set visibility to null instead of false to distinguish a layer
-                    // actually set to false in the config or set to false in a bookmark.
-                    // If null, sublayer visibility will be forced off
-                    if (!bookmarkLayer.options.visibility.value) {
-                        bookmarkLayer.options.visibility.value = null;
-                    }
-
                     // apply bookmark layer info to config
                     angular.merge(config.layers[config.layers.indexOf(layer)], bookmarkLayer);
 

--- a/src/app/geo/layer-record.class.js
+++ b/src/app/geo/layer-record.class.js
@@ -441,6 +441,7 @@
                 const cfg = super.makeLayerConfig();
                 cfg.mode = this.config.options.snapshot.value ? this.layerClass.MODE_SNAPSHOT
                                                               : this.layerClass.MODE_ONDEMAND;
+                this.config.options.snapshot.enabled = !this.config.options.snapshot.value;
                 return cfg;
             }
 

--- a/src/app/geo/layer-record.class.js
+++ b/src/app/geo/layer-record.class.js
@@ -133,9 +133,13 @@
              * @returns {Object}        config snippet for the layer
              */
             static parseData (props, info) {
+                // set visibility to null instead of false to distinguish a layer
+                // actually set to false in the config or set to false in a bookmark.
+                // If null, sublayer visibility will be forced off (since we dont track
+                // sublayer state in bookmarks)
                 const lookup = {
                     opacity: value => parseInt(value) / 100,
-                    visibility: value => value === '1',
+                    visibility: value => value === '1' ? true : null,
                     boundingBox: value => value === '1',
                     snapshot: value => value === '1',
                     query: value => value === '1'

--- a/src/app/ui/settings/settings.directive.js
+++ b/src/app/ui/settings/settings.directive.js
@@ -114,6 +114,7 @@
         function loadSnapshot(legendEntry) {
             geoService.snapshotLayer(legendEntry);
             self.tocEntry.options.snapshot.enabled = false;
+            self.tocEntry.options.snapshot.value = true;
         }
 
         activateOpacitySetting();


### PR DESCRIPTION
Update Legend snapshot value when snapshot is enabled.
Disable Legend snapshot when starting state is snapshot.
Move bookmark group visibility trick logic to LayerRecord, so it will be applied to RCS layers as well.
					
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/847

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1139)
<!-- Reviewable:end -->
