### PR TITLE
Separate startup paths for fpg demo

### DIFF
--- a/src/index-fgp-en.html
+++ b/src/index-fgp-en.html
@@ -558,10 +558,12 @@
             // turn keys into an array, pass them to the map
             var keysArr = keys.split(',');
             RV.getMap('fgpmap').restoreSession(keysArr);
+        } else {
+            var bookmark = queryStr.rv;
+            console.log(bookmark);
+            RV.getMap('fgpmap').initialBookmark(bookmark);
         }
-        var bookmark = queryStr.rv;
-        console.log(bookmark);
-        RV.getMap('fgpmap').initialBookmark(bookmark);
+
         function getBookmark(){
             RV.getMap('fgpmap').getBookmark().then(function (bookmark) {
                 document.getElementById("bookmarkDisplay").value = window.location.href.split('?')[0] + '?rv=' + String(bookmark);

--- a/src/index-fgp-fr.html
+++ b/src/index-fgp-fr.html
@@ -557,10 +557,12 @@
             // turn keys into an array, pass them to the map
             var keysArr = keys.split(',');
             RV.getMap('fgpmap').restoreSession(keysArr);
+        } else {
+            var bookmark = queryStr.rv;
+            console.log(bookmark);
+            RV.getMap('fgpmap').initialBookmark(bookmark);
         }
-        var bookmark = queryStr.rv;
-        console.log(bookmark);
-        RV.getMap('fgpmap').initialBookmark(bookmark);
+
         function getBookmark(){
             RV.getMap('fgpmap').getBookmark().then(function (bookmark) {
                 document.getElementById("bookmarkDisplay").value = window.location.href.split('?')[0] + '?rv=' + String(bookmark);


### PR DESCRIPTION
Prevents both the initial page load code and back-to-cart page load code from running when the back-to-cart demo is triggered. 

Related to https://github.com/fgpv-vpgf/fgpv-vpgf/issues/415

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1143)
<!-- Reviewable:end -->
