### PR TITLE
IE11 toast error

### DIFF
--- a/src/content/styles/layout/_main.scss
+++ b/src/content/styles/layout/_main.scss
@@ -18,6 +18,10 @@ md-toast {
     .md-toast-content {
         pointer-events: auto;
     }
+
+    .md-toast-content span {
+        flex-basis: auto;
+    }
 }
 
 rv-panel md-toast.md-rv-flex {


### PR DESCRIPTION
Before: flex box is squashed in IE11
After: add css flex attribute to .md-toast-content CSS class and test
for Chrome, Firefox and IE11

Closes #604

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1178)
<!-- Reviewable:end -->
