### PR TITLE
fix(ui): avoid IE11 scrollbar to overlap content in Full Screen Mode

### DIFF
--- a/src/content/styles/vendor/_special.scss
+++ b/src/content/styles/vendor/_special.scss
@@ -1,6 +1,12 @@
 // this overrides vendor classes of node created outside the main viewer container
 // this is why it's special :)
 
+// to avoid IE11 vertical scrollbar to overlapp content in full screen mode
+// reference: https://github.com/twbs/bootstrap/issues/18543
+html, body {
+    -ms-overflow-style: scrollbar;
+}
+
 .rv-hide {
     visibility: hidden !important;
     opacity: 0 !important;


### PR DESCRIPTION
Before: in IE11, vertical scrolling bar overlap content when the viewer
is in full screen mode
After: add -ms-overflow-style attribute (set to scrollbar) in body css
class
The content and the vertical scrollbar are now aside each other

Closes #1132

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1182)
<!-- Reviewable:end -->
