### PR TITLE
fix(ui): focus manager correctly responds to mouse activity

### DIFF
--- a/src/index-one.html
+++ b/src/index-one.html
@@ -16,9 +16,10 @@
 </head>
 
 <body>
+    <!-- TODO: remove rv-fullpage-app with resolution of issue #834 (when there is a config property)-->
     <div class="fgpv" rv-config="config.${lang}.json" rv-langs='["en-CA", "fr-CA"]'
          rv-service-endpoint="http://section917.cloudapp.net:8000/" rv-keys='["Airports"]'
-         rv-restore-bookmark="bookmark">
+         rv-restore-bookmark="bookmark" rv-fullpage-app="true" >
          <noscript>
             <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
 


### PR DESCRIPTION
Clicking inside the viewer with a mouse completely disables focus
management until focus leaves the viewer.

Closes #1192

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1199)
<!-- Reviewable:end -->
