### PR TITLE
fix(ui): angular material dialogs no longer close unexpectedly

### DIFF
--- a/src/app/layout/focus.service.js
+++ b/src/app/layout/focus.service.js
@@ -47,7 +47,9 @@
 
         // detect if there has been a mousedown, if so disable focus management until re-activated
         $(document).on('mousedown', event => {
-            dlg.hide(); // always hide the dialog
+            if (currentStatus === statuses.WAITING) {
+                dlg.hide();
+            }
 
             // disable if clicking on the viewer until mouse support is implemented
             // TODO: this is temporary until epic #1213 is implemented to support simultaneous mouse/keyboard support


### PR DESCRIPTION
Currently $mdDialog does not support multiple dialogs at one time. Updated
focus manager to only close dialogs in WAITING state.

See [this angular material
issue](https://github.com/angular/material/issues/8630) for upcoming support

Closes #1215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1221)
<!-- Reviewable:end -->
