### PR TITLE
Bookmark version B

### DIFF
--- a/src/app/core/bookmark.service.js
+++ b/src/app/core/bookmark.service.js
@@ -180,14 +180,17 @@
         function encodeProperty(obj, propChain) {
             let pointer = obj;
 
-            propChain.forEach(p => {
+            // since we want to break the loop, use for instead of .forEach
+            for (let i = 0; i < propChain.length; i++) {
+                const p = propChain[i];
                 if (pointer[p]) { // falsy ok here, as it still ends up encoding false
                     pointer = pointer[p];
                 } else {
                     // property doesn't exist.  default to false
-                    return encodeBoolean(false);
+                    pointer = false;
+                    break;
                 }
-            });
+            }
 
             // if we've made it here, our property exists and has a value.  encode it
             return encodeBoolean(pointer);

--- a/src/app/core/bookmark.service.js
+++ b/src/app/core/bookmark.service.js
@@ -12,8 +12,8 @@
         .module('app.core')
         .factory('bookmarkService', bookmarkService);
 
-    function bookmarkService($rootElement, $q, legendService, geoService, LayerBlueprint,
-            LayerRecordFactory, configService, gapiService, bmVer, Geo) {
+    function bookmarkService($rootElement, $q, geoService, LayerBlueprint,
+            LayerRecordFactory, configService, gapiService, bookmarkVersions, Geo) {
 
         const blankPrefix = 'blank_basemap_';
 
@@ -57,8 +57,8 @@
                 return encode64(makeLayerBookmark(legendEntry));
             });
 
-            // bmVer.? is the version. update this accordingly whenever the structure of the bookmark changes
-            const bookmark = `${bmVer.B},${basemap},${extent.x},${extent.y},${extent.scale}` +
+            // bookmarkVersions.? is the version. update this accordingly whenever the structure of the bookmark changes
+            const bookmark = `${bookmarkVersions.B},${basemap},${extent.x},${extent.y},${extent.scale}` +
                 (layerBookmarks.length > 0 ? `,${layerBookmarks.toString()}` : '');
             console.log(bookmark);
             return bookmark;
@@ -81,7 +81,7 @@
         }
 
         /**
-         * Converts an boolean to a 1 or 0 character.
+         * Converts a boolean to a 1 or 0 character.
          *
          * @function encodeBoolean
          * @private
@@ -106,7 +106,7 @@
         }
 
         /**
-         * Converts an string in binary to a string in hexadecimal
+         * Converts a string in binary to a string in hexadecimal
          * Length of binary input should be a multiple of 4
          *
          * @function binaryToHex
@@ -119,13 +119,11 @@
             // return parseInt(value, 2).toString(16);
 
             const fourBits = value.match(/.{1,4}/g);
-            return fourBits.map(b4 => {
-                return parseInt(b4, 2).toString(16);
-            }).join('');
+            return fourBits.map(b4 => parseInt(b4, 2).toString(16)).join('');
         }
 
         /**
-         * Converts an string in hexadecimal to a string in binary
+         * Converts a string in hexadecimal to a string in binary
          *
          * @function hexToBinary
          * @private
@@ -156,7 +154,7 @@
         }
 
         /**
-         * Converts an binary encoding of opacity to an actual opacity number
+         * Converts a binary encoding of opacity to an actual opacity number
          * Values are mapped from range 0000000 - 1100100 (0 - 100 in decimal) to 0 - 1.
          *
          * @function decodeOpacity
@@ -170,6 +168,7 @@
 
         /**
          * Encode an object property (possibly nested), or handle the case that the property does not exist.
+         * Target property should be a boolean. All values will be converted to boolean result (encoded).
          *
          * @function encodeProperty
          * @private
@@ -183,7 +182,7 @@
             // since we want to break the loop, use for instead of .forEach
             for (let i = 0; i < propChain.length; i++) {
                 const p = propChain[i];
-                if (pointer[p]) { // falsy ok here, as it still ends up encoding false
+                if (pointer.hasOwnProperty(p)) {
                     pointer = pointer[p];
                 } else {
                     // property doesn't exist.  default to false
@@ -341,7 +340,7 @@
                 // also store any layer info
                 layers = info[6];
 
-                if (version !== bmVer.A) {
+                if (version !== bookmarkVersions.A) {
                     blankBaseMap = basemap.substr(basemap.length - 1, 1) === '1';
                     basemap = basemap.substring(0, basemap.length - 1);
                 }
@@ -535,7 +534,7 @@
         }
 
         /**
-         * Generates a layer config snippet with options initialzed
+         * Generates a layer config snippet with options initialized
          * based on the layer type and contents of the bookmark settings
          *
          * @function makeLayerConfig
@@ -578,7 +577,7 @@
             // fancier integration / code sharing can be considered after the
             // state snapshot refactor, which will likely change the whole situation.
 
-            if (version === bmVer.A) {
+            if (version === bookmarkVersions.A) {
                 const layerPatterns = [
                     /^(.+?)(\d{7})$/, // feature
                     /^(.+?)(\d{6})$/, // wms

--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -32,6 +32,10 @@
             rvDataPrint: 'rvDataPrint', // these data events should be removed after switching to angular 1.5 or 2 or React
             rvDataExportCSV: 'rvDataExportCSV'
         })
+        .constant('bmVer', { // Bookmark versions https://github.com/fgpv-vpgf/fgpv-vpgf/wiki/Bookmark-Formats
+            A: 'A',
+            B: 'B'
+        })
         .constant('translations', AUTOFILLED_TRANSLATIONS)
         .value('appInfo', {
             id: null

--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -32,7 +32,7 @@
             rvDataPrint: 'rvDataPrint', // these data events should be removed after switching to angular 1.5 or 2 or React
             rvDataExportCSV: 'rvDataExportCSV'
         })
-        .constant('bmVer', { // Bookmark versions https://github.com/fgpv-vpgf/fgpv-vpgf/wiki/Bookmark-Formats
+        .constant('bookmarkVersions', { // Bookmark versions https://github.com/fgpv-vpgf/fgpv-vpgf/wiki/Bookmark-Formats
             A: 'A',
             B: 'B'
         })

--- a/src/app/geo/layer-record.class.js
+++ b/src/app/geo/layer-record.class.js
@@ -130,7 +130,7 @@
              *
              * @param {Array} props     The property names
              * @param {Array} info      The values for the properties
-             * @param {String} version  Version of the bookmark data
+             * @param {String} version  Version of the bookmark data. See core/constant.service for valid versions
              * @returns {Object}        config snippet for the layer
              */
             static parseData (props, info, version) {
@@ -309,7 +309,7 @@
              * Creates a config snippet (containing options) given the dataString portion of the layer bookmark.
              *
              * @param {String} dataString   a partial layer bookmark (everything after the id)
-             * @param {String} version      version of the bookmark
+             * @param {String} version      version of the bookmark. See core/constant.service for valid versions
              * @returns {Object}            config snippet for the layer
              */
             static parseData (dataString, version) {
@@ -361,7 +361,7 @@
                 };
 
                 // grab stuff on children.  we can't use walkItems because it returns a flat list.
-                // we need to preserve heirarchy here.
+                // we need to preserve hierarchy here.
                 // loop over top-level children of the layer. these are the ones that have
                 // entries defined in .layerEntries in the config.
                 // these get serialized, and delimited by a ;
@@ -389,7 +389,7 @@
              * Creates a config snippet (containing options) given the dataString portion of the layer bookmark.
              *
              * @param {String} dataString   a partial layer bookmark (everything after the id)
-             * @param {String} version      version of the bookmark
+             * @param {String} version      version of the bookmark. See core/constant.service for valid versions
              * @returns {Object}            config snippet for the layer
              */
             static parseData (dataString, version) {
@@ -472,7 +472,7 @@
              * Creates a config snippet (containing options) given the dataString portion of the layer bookmark.
              *
              * @param {String} dataString   a partial layer bookmark (everything after the id)
-             * @param {String} version      version of the bookmark
+             * @param {String} version      version of the bookmark. See core/constant.service for valid versions
              * @returns {Object}            config snippet for the layer
              */
             static parseData (dataString, version) {
@@ -521,7 +521,7 @@
              * Creates a config snippet (containing options) given the dataString portion of the layer bookmark.
              *
              * @param {String} dataString   a partial layer bookmark (everything after the id)
-             * @param {String} version      version of the bookmark
+             * @param {String} version      version of the bookmark. See core/constant.service for valid versions
              * @returns {Object}            config snippet for the layer
              */
             static parseData (dataString, version) {
@@ -573,7 +573,7 @@
              * Creates a config snippet (containing options) given the dataString portion of the layer bookmark.
              *
              * @param {String} dataString   a partial layer bookmark (everything after the id)
-             * @param {String} version      version of the bookmark
+             * @param {String} version      version of the bookmark. See core/constant.service for valid versions
              * @returns {Object}            config snippet for the layer
              */
             static parseData (dataString, version) {
@@ -630,7 +630,7 @@
          * @function parseLayerData
          * @param {String} dataString   a partial layer bookmark (everything after the id)
          * @param {Number} layerType    Layer type taken from the layer bookmark
-         * @param {String} version      Version of the bookmark format
+         * @param {String} version      Version of the bookmark format. See core/constant.service for valid versions
          * @returns {Object}            config snippet for the layer
          */
         function parseLayerData(dataString, layerType, version) {
@@ -645,6 +645,15 @@
             return classes[layerType].parseData(dataString, version);
         }
 
+        /**
+         * Converts an opacity number to a fixed-length character representation.
+         * Values are mapped from range 0 - 1  to 0 - 99, 99 representing 100 to save space.
+         * Single digits are zero-padded (i.e. 2 -> 02).
+         *
+         * @function padOpacity
+         * @param {Number} value        Opacity value of a layer. A Decimal between 0 and 1
+         * @returns {String}            Two digit string representation of value, mapped to between 0 and 99, 99 representing 100. Single digits are zero-padded.
+         */
         function padOpacity(value) {
             // sometimes we get weird decimal numbers coming in, like 0.5599999999999 instead of 0.56
             value = String(Math.round(value * 100));

--- a/src/app/geo/layer-record.class.js
+++ b/src/app/geo/layer-record.class.js
@@ -120,27 +120,20 @@
 
             /**
              * Creates a config snippet (containing options) given a list of properties and values.
+             * Only used for bookmark version A
              *
              * @param {Array} props     The property names
              * @param {Array} info      The values for the properties
-             * @param {String} version  Version of the bookmark data. See core/constant.service for valid versions
              * @returns {Object}        config snippet for the layer
              */
-            static parseData (props, info, version) {
+            static parseData (props, info) {
 
                 const lookup = {
                     opacity: value => {
-                        if (version !== 'A' && value === '99') {
-                            value = 100;
-                        }
                         return parseInt(value) / 100;
                     },
                     visibility: value => {
-                        if (version === 'A') {
-                            return value === '1' ? true : null;
-                        } else {
-                            return value === '1';
-                        }
+                        return value === '1' ? true : null;
                     },
                     boundingBox: value => value === '1',
                     snapshot: value => value === '1',
@@ -290,20 +283,15 @@
              * Creates a config snippet (containing options) given the dataString portion of the layer bookmark.
              *
              * @param {String} dataString   a partial layer bookmark (everything after the id)
-             * @param {String} version      version of the bookmark. See core/constant.service for valid versions
              * @returns {Object}            config snippet for the layer
              */
-            static parseData (dataString, version) {
-
+            static parseData (dataString) {
+                // Only used for bookmark version A
                 // ( opacity )( viz )( boundingBox )( query )
-                // vA uses 3-char opacity
 
-                const format = {
-                    A: /^(\d{3})(\d{1})(\d{1})$/,
-                    B: /^(\d{2})(\d{1})(\d{1})$/
-                };
+                const format = /^(\d{3})(\d{1})(\d{1})$/;
 
-                const info = dataString.match(format[version]);
+                const info = dataString.match(format);
 
                 if (info) {
                     return super.parseData([, 'opacity', 'visibility', 'boundingBox'], info); // jshint ignore:line
@@ -327,66 +315,17 @@
              * Creates a config snippet (containing options) given the dataString portion of the layer bookmark.
              *
              * @param {String} dataString   a partial layer bookmark (everything after the id)
-             * @param {String} version      version of the bookmark. See core/constant.service for valid versions
              * @returns {Object}            config snippet for the layer
              */
-            static parseData (dataString, version) {
-                // vA: ( opacity )( viz )( boundingBox )( query )
-                // vB: ( sublayer info )( opacity )( viz )( boundingBox )( query )
-                const format = {
-                    A: /^(\d{3})(\d{1})(\d{1})(\d{1})$/,
-                    B: /^(.+?)(\d{2})(\d{1})(\d{1})(\d{1})$/
-                };
+            static parseData (dataString) {
+                // Only used for bookmark version A
+                // ( opacity )( viz )( boundingBox )( query )
 
-                const info = dataString.match(format[version]);
+                const format = /^(\d{3})(\d{1})(\d{1})(\d{1})$/;
+                const info = dataString.match(format);
 
                 if (info) {
-
-                    const snippet = {
-                        layerEntries: [],
-                        childOptions: []
-                    };
-
-                    if (version !== 'A') {
-                        // process info for child layers
-                        // ( opacity ) ( viz ) ( query ) ( sublayer index )
-                        const cFormat = /^(\d{2})(\d{1})(\d{1})(.+?)$/;
-                        const childData = info[1].substr(1); // drop leading ;
-                        info.splice(1, 1); // remove child info from array, normalizing it with version A
-
-                        const makeEntryNode = bmData => {
-                            // we make use of super.parseData, but need to pull the data up out of the
-                            // .options subobject in this case.
-                            const cInfo = bmData.match(cFormat);
-                            const result = super.parseData([, 'opacity', 'visibility', 'query'], cInfo, version); // jshint ignore:line
-                            result.options.index = cInfo[4];
-                            return result.options;
-                        };
-
-                        // splitting on ; gives us chunks of data for each top-level index in the layer.
-                        // i.e. each chunk defines an object that goes in .layerEntries
-                        childData.split(';').forEach(cData => {
-                            // for a single top level index, we can also have auto-generated child settings along with it.
-                            // these values are separated by ` chars. The first one is always the parent.
-                            const subChildData = cData.split('`');
-
-                            // make parent entry, then remove it from source array
-                            const lEntry = makeEntryNode(subChildData[0]);
-                            subChildData.splice(0, 1);
-
-                            // if any child data remains, add it to the children property of the parent.
-                            if (subChildData.length > 0) {
-                                snippet.childOptions.push(...subChildData.map(scd => makeEntryNode(scd)));
-                            }
-
-                            snippet.layerEntires.push(lEntry);
-                        });
-                    }
-
-                    // merge child config data with top level config data
-                    const topDat = super.parseData([, 'opacity', 'visibility', 'boundingBox', 'query'], info, version); // jshint ignore:line
-                    angular.merge(snippet, topDat);
-                    return snippet;
+                    return super.parseData([, 'opacity', 'visibility', 'boundingBox', 'query'], info); // jshint ignore:line
                 }
             }
         }
@@ -401,19 +340,14 @@
              * Creates a config snippet (containing options) given the dataString portion of the layer bookmark.
              *
              * @param {String} dataString   a partial layer bookmark (everything after the id)
-             * @param {String} version      version of the bookmark. See core/constant.service for valid versions
              * @returns {Object}            config snippet for the layer
              */
-            static parseData (dataString, version) {
+            static parseData (dataString) {
+                // Only used for bookmark version A
                 // ( opacity )( viz )( boundingBox )
-                // vA uses 3-char opacity
 
-                const format = {
-                    A: /^(\d{3})(\d{1})(\d{1})$/,
-                    B: /^(\d{2})(\d{1})(\d{1})$/
-                };
-
-                const info = dataString.match(format[version]);
+                const format = /^(\d{3})(\d{1})(\d{1})$/;
+                const info = dataString.match(format);
 
                 if (info) {
                     return super.parseData([, 'opacity', 'visibility', 'boundingBox'], info); // jshint ignore:line
@@ -437,19 +371,14 @@
              * Creates a config snippet (containing options) given the dataString portion of the layer bookmark.
              *
              * @param {String} dataString   a partial layer bookmark (everything after the id)
-             * @param {String} version      version of the bookmark. See core/constant.service for valid versions
              * @returns {Object}            config snippet for the layer
              */
-            static parseData (dataString, version) {
+            static parseData (dataString) {
+                // Only used for bookmark version A
                 // ( opacity )( viz )( boundingBox )( query )
-                // vA uses 3-char opacity
 
-                const format = {
-                    A: /^(\d{3})(\d{1})(\d{1})(\d{1})$/,
-                    B: /^(\d{2})(\d{1})(\d{1})(\d{1})$/
-                };
-
-                const info = dataString.match(format[version]);
+                const format = /^(\d{3})(\d{1})(\d{1})(\d{1})$/;
+                const info = dataString.match(format);
 
                 if (info) {
                     return super.parseData([, 'opacity', 'visibility', 'boundingBox', 'query'], info); // jshint ignore:line
@@ -475,19 +404,14 @@
              * Creates a config snippet (containing options) given the dataString portion of the layer bookmark.
              *
              * @param {String} dataString   a partial layer bookmark (everything after the id)
-             * @param {String} version      version of the bookmark. See core/constant.service for valid versions
              * @returns {Object}            config snippet for the layer
              */
-            static parseData (dataString, version) {
+            static parseData (dataString) {
+                // Only used for bookmark version A
                 // ( opacity )( viz )( boundingBox )( snapshot )( query )
-                // vA uses 3-char opacity
 
-                const format = {
-                    A: /^(\d{3})(\d{1})(\d{1})(\d{1})(\d{1})$/,
-                    B: /^(\d{2})(\d{1})(\d{1})(\d{1})(\d{1})$/
-                };
-
-                const info = dataString.match(format[version]);
+                const format =  /^(\d{3})(\d{1})(\d{1})(\d{1})(\d{1})$/;
+                const info = dataString.match(format);
 
                 if (info) {
                     return super.parseData([, 'opacity', 'visibility', 'boundingBox', 'snapshot', 'query'], info); // jshint ignore:line
@@ -532,10 +456,9 @@
          * @function parseLayerData
          * @param {String} dataString   a partial layer bookmark (everything after the id)
          * @param {Number} layerType    Layer type taken from the layer bookmark
-         * @param {String} version      Version of the bookmark format. See core/constant.service for valid versions
          * @returns {Object}            config snippet for the layer
          */
-        function parseLayerData(dataString, layerType, version) {
+        function parseLayerData(dataString, layerType) {
             const classes = [
                 FeatureRecord,
                 WmsRecord,
@@ -544,7 +467,7 @@
                 ImageRecord
             ];
 
-            return classes[layerType].parseData(dataString, version);
+            return classes[layerType].parseData(dataString);
         }
 
         return { makeServiceRecord, makeFileRecord, parseLayerData };

--- a/src/app/geo/layer-record.class.js
+++ b/src/app/geo/layer-record.class.js
@@ -404,7 +404,10 @@
 
                 if (info) {
 
-                    const snippet = {};
+                    const snippet = {
+                        layerEntries: [],
+                        childOptions: []
+                    };
 
                     if (version !== 'A') {
                         // process info for child layers
@@ -424,7 +427,7 @@
 
                         // splitting on ; gives us chunks of data for each top-level index in the layer.
                         // i.e. each chunk defines an object that goes in .layerEntries
-                        snippet.layerEntries = childData.split(';').map(cData => {
+                        childData.split(';').forEach(cData => {
                             // for a single top level index, we can also have auto-generated child settings along with it.
                             // these values are separated by ` chars. The first one is always the parent.
                             const subChildData = cData.split('`');
@@ -435,10 +438,10 @@
 
                             // if any child data remains, add it to the children property of the parent.
                             if (subChildData.length > 0) {
-                                lEntry.children = subChildData.map(scd => makeEntryNode(scd));
+                                snippet.childOptions.push(...subChildData.map(scd => makeEntryNode(scd)));
                             }
 
-                            return lEntry;
+                            snippet.layerEntires.push(lEntry);
                         });
                     }
 

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -509,18 +509,14 @@
             console.info(this);
             this.bindListeners();
 
-            // morph layerEntries array into an object where keys are indexes of sublayers:
+            // morph layerEntries array and childOptions into an object where keys are indexes of sublayers:
             // { 1: {index: 1, ...}, 4: { index: 4, ...} }
+            // TODO should we implement a data integrity check? The same index should never exist in both
+            //      layerEntries and childOptions
             const layerEntriesOptions = {};
-            this.layerEntries.forEach(layerEntry => {
+            const configEntries = this.layerEntries.concat(this.childOptions);
+            configEntries.forEach(layerEntry => {
                 layerEntriesOptions[layerEntry.index] = layerEntry;
-                if (layerEntry.children) {
-                    layerEntry.children.forEach(childEntry => {
-                        // TODO add check for bad configs? we should never be overwriting anything in
-                        //      layerEntriesOptions. not sure who should be responsible for quality.
-                        layerEntriesOptions[childEntry.index] = childEntry;
-                    });
-                }
             });
 
             // we need to mark entries that have explicit settings from the config file.

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -517,7 +517,7 @@
                 if (layerEntry.children) {
                     layerEntry.children.forEach(childEntry => {
                         // TODO add check for bad configs? we should never be overwriting anything in
-                        //      layerEntriesOptions. not sure who should be responsibile for quality.
+                        //      layerEntriesOptions. not sure who should be responsible for quality.
                         layerEntriesOptions[childEntry.index] = childEntry;
                     });
                 }

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -514,7 +514,7 @@
             // TODO should we implement a data integrity check? The same index should never exist in both
             //      layerEntries and childOptions
             const layerEntriesOptions = {};
-            const configEntries = this.layerEntries.concat(this.childOptions);
+            const configEntries = this.layerEntries.concat(this.childOptions || []);
             configEntries.forEach(layerEntry => {
                 layerEntriesOptions[layerEntry.index] = layerEntry;
             });

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -57,7 +57,6 @@
                 clearHilight,
                 dropMapPin,
                 geolocate,
-                findClosestLOD,
                 getFullExtent
             };
 
@@ -550,22 +549,8 @@
                 const zoomPt = gapiService.gapi.proj.Point(geoPt[0], geoPt[1], map.spatialReference);
 
                 // give preference to the layer closest to a 50k scale ratio which is ideal for zoom
-                const sweetLod = findClosestLOD(map.__tileInfo.lods, 50000);
+                const sweetLod = gapiService.gapi.mapManager.findClosestLOD(map.__tileInfo.lods, 50000);
                 map.centerAndZoom(zoomPt, Math.max(sweetLod.level, 0));
-            }
-
-            /**
-             * Finds the level of detail closest to the provided scale.
-             *
-             * @function findClosestLOD
-             * @param  {Array} lods     list of levels of detail objects
-             * @param  {Number} scale   scale value to search for in the levels of detail
-             * @return {Object} the level of detail object closest to the scale
-             */
-            function findClosestLOD(lods, scale) {
-                const diffs = lods.map(lod => Math.abs(lod.scale - scale));
-                const lodIdx = diffs.indexOf(Math.min(...diffs));
-                return lods[lodIdx];
             }
 
             /**

--- a/src/bookmark-decode.html
+++ b/src/bookmark-decode.html
@@ -191,7 +191,7 @@
     }
 
     function encodeInteger(value, bitSize) {
-        const binary = value.toString(2);
+        var binary = value.toString(2);
         return '0'.repeat(bitSize - binary.length) + binary;
     }
 
@@ -202,7 +202,7 @@
 
     function hexToBinary(value) {
         var hexes = value.match(/./g); // split into single chars
-        return hexes.map(h => {
+        return hexes.map(function(h) {
             return encodeInteger(parseInt(h, 16), 4); // 4-digit padded binary
         }).join('');
     }

--- a/src/bookmark-decode.html
+++ b/src/bookmark-decode.html
@@ -180,15 +180,71 @@
         }
     }
 
-    function decodeVerB(bookmark) {
+    function dataToTextB (props, info) {
+
+        var result = '';
+
+        props.forEach(function(prop) {
+            result += (prop + ': ' + info[prop].toString() + ', ' );
+        });
+        return result;
+    }
+
+	function encodeInteger(value, bitSize) {
+		const binary = value.toString(2);
+		return '0'.repeat(bitSize - binary.length) + binary;
+	}
+
+	function decodeBoolean(value) {
+		// very complex
+		return value === '1';
+	}
+
+	function hexToBinary(value) {
+		var hexes = value.match(/./g); // split into single chars
+		return hexes.map(h => {
+			return encodeInteger(parseInt(h, 16), 4); // 4-digit padded binary
+		}).join('');
+	}
+
+	function decodeOpacity(value) {
+		return parseInt(value, 2) / 100;
+	}
+
+	function extractLayerSettings(layerSettingsHex) {
+	    var splitty = hexToBinary(layerSettingsHex).match(/^(.{7})(.)(.)(.)(.)(.{9})/);
+
+		return {
+			opacity: decodeOpacity(splitty[1]),
+			visibility: decodeBoolean(splitty[2]),
+			boundingBox: decodeBoolean(splitty[3]),
+			snapshot: decodeBoolean(splitty[4]),
+			query: decodeBoolean(splitty[5]),
+			childCount: parseInt(splitty[6], 2)
+		};
+	}
+
+	function extractChildSettings(childSettingsHex) {
+		var splitty = hexToBinary(childSettingsHex).match(/^(.{7})(.)(.)(.)(.{12})/);
+
+		return {
+			opacity: decodeOpacity(splitty[1]),
+			visibility: decodeBoolean(splitty[2]),
+			query: decodeBoolean(splitty[3]),
+			index: parseInt(splitty[5], 2),
+			root: decodeBoolean(splitty[4])
+		};
+	}
+
+	function decodeVerB(bookmark) {
         var pattern = /^([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)(?:$|,(.*)$)/i;
-        // things for specific layers:[ layer type name, regex to strip data from id, regex to parse data, property names in data ]
+        // things for specific layers:[ layer type name,  property names in data ]
         var layerSpec = [
-            ['Feature', /^(.+?)(\d{6})$/, /^(\d{2})(\d{1})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'snapshot', 'query']],
-            ['Wms', /^(.+?)(\d{5})$/, /^(\d{2})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'query']],
-            ['Tile', /^(.+?)(\d{4})$/, /^(\d{2})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox']],
-            ['Dynamic', /^(.+?)([;].*\d{5})$/, /^(.+?)(\d{2})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'query']],
-            ['Image', /^(.+?)(\d{4})$/, /^(\d{2})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox']]
+            ['Feature', ['opacity', 'visibility', 'boundingBox', 'snapshot', 'query']],
+            ['Wms', ['opacity', 'visibility', 'boundingBox', 'query']],
+            ['Tile', ['opacity', 'visibility', 'boundingBox']],
+            ['Dynamic', ['opacity', 'visibility', 'boundingBox', 'query', 'childCount']],
+            ['Image', ['opacity', 'visibility', 'boundingBox']]
         ];
 
         var info = bookmark.match(pattern);
@@ -218,48 +274,39 @@
             layers.forEach((layer, i) => {
                 layer = decode64(layer);
 
-                // strip out integer that defines the layer type
-                var layerType = parseInt(layer.substring(0, 2));
+                // strip out hex char that defines the layer type
+                var layerCode = parseInt(layer.substr(0, 1));
+
                 // split the remaining data into layer id and layer data
-                var layerGuts = layer.substring(2).match(layerSpec[layerType][1]);
-                var layerId = layerGuts[1];
-                // parse the data into discrete parts, specific to the layer type
-                var layerData = layerGuts[2].match(layerSpec[layerType][2]);
+                var layerSettings = extractLayerSettings(layer.substr(1, 5));
+                var layerId = layer.substr(6 + (layerSettings.childCount * 6));
 
                 // rip off child data if we are dynamic
-                if (layerType === 3) {
+                if (layerSettings.childCount > 0) {
 
                     var textArray = [];
-                    var childData = layerData[1].substr(1); // drop leading ;
-                    layerData.splice(1, 1); // remove child info from array, normalizing it with the other layer types
+                    var childrenInfo = layer.substr(6, layerSettings.childCount * 6);
+					var childItems = childrenInfo.match(/.{6}/g);
 
-                    // process the children and store them in our persistant var, so it can be accessed if someone clicks on the parent
+                    // process the children and store them in our persistant var, so it can be accessed if
+					// someone clicks on the parent
 
-                    // splitting on ; gives us chunks of data for each top-level index in the layer.
-                    // i.e. each chunk defines an object that goes in .layerEntries
-                    childData.split(';').forEach(function (cData) {
-                        // for a single top level index, we can also have auto-generated child settings along with it.
-                        // these values are separated by ` chars. The first one is always the parent.
-                        var subChildData = cData.split('`');
+                    childItems.forEach(function (cData) {
+						var childSettings = extractChildSettings(cData);
+						var prefix = childSettings.root ? 'Root Child: ' : 'Non Root Child: ';
 
-                        // make parent entry, then remove it from source array
-                        textArray.push( 'Parent: ' + childDataToText(subChildData[0], 'B'));
-                        subChildData.splice(0, 1);
-
-                        // if any child data remains, add it to the text array
-                        subChildData.forEach(function (scd) {
-                            textArray.push( '--Child: ' + childDataToText(scd, 'B'));
-                        });
+                        textArray.push( prefix  +
+							dataToTextB(['index', 'opacity', 'visibility', 'query' ], childSettings));
                     });
 
                     childDataStore[i.toString()] = textArray;
 
                 }
 
-                // show the raw data, and then a human friendly version of it
+                // show data
                 var opt = document.createElement("option");
-                opt.text = layerSpec[layerType][0] + ' Layer, id: ' + layerId + ', ' +
-                        dataToText(layerSpec[layerType][3], layerData, 'B');
+                opt.text = layerSpec[layerCode][0] + ' Layer, id: ' + layerId + ', ' +
+                        dataToTextB(layerSpec[layerCode][1], layerSettings);
                 opt.value = i;
                 layerList.add(opt);
 

--- a/src/bookmark-decode.html
+++ b/src/bookmark-decode.html
@@ -190,53 +190,53 @@
         return result;
     }
 
-	function encodeInteger(value, bitSize) {
-		const binary = value.toString(2);
-		return '0'.repeat(bitSize - binary.length) + binary;
-	}
+    function encodeInteger(value, bitSize) {
+        const binary = value.toString(2);
+        return '0'.repeat(bitSize - binary.length) + binary;
+    }
 
-	function decodeBoolean(value) {
-		// very complex
-		return value === '1';
-	}
+    function decodeBoolean(value) {
+        // very complex
+        return value === '1';
+    }
 
-	function hexToBinary(value) {
-		var hexes = value.match(/./g); // split into single chars
-		return hexes.map(h => {
-			return encodeInteger(parseInt(h, 16), 4); // 4-digit padded binary
-		}).join('');
-	}
+    function hexToBinary(value) {
+        var hexes = value.match(/./g); // split into single chars
+        return hexes.map(h => {
+            return encodeInteger(parseInt(h, 16), 4); // 4-digit padded binary
+        }).join('');
+    }
 
-	function decodeOpacity(value) {
-		return parseInt(value, 2) / 100;
-	}
+    function decodeOpacity(value) {
+        return parseInt(value, 2) / 100;
+    }
 
-	function extractLayerSettings(layerSettingsHex) {
-	    var splitty = hexToBinary(layerSettingsHex).match(/^(.{7})(.)(.)(.)(.)(.{9})/);
+    function extractLayerSettings(layerSettingsHex) {
+        var splitty = hexToBinary(layerSettingsHex).match(/^(.{7})(.)(.)(.)(.)(.{9})/);
 
-		return {
-			opacity: decodeOpacity(splitty[1]),
-			visibility: decodeBoolean(splitty[2]),
-			boundingBox: decodeBoolean(splitty[3]),
-			snapshot: decodeBoolean(splitty[4]),
-			query: decodeBoolean(splitty[5]),
-			childCount: parseInt(splitty[6], 2)
-		};
-	}
+        return {
+            opacity: decodeOpacity(splitty[1]),
+            visibility: decodeBoolean(splitty[2]),
+            boundingBox: decodeBoolean(splitty[3]),
+            snapshot: decodeBoolean(splitty[4]),
+            query: decodeBoolean(splitty[5]),
+            childCount: parseInt(splitty[6], 2)
+        };
+    }
 
-	function extractChildSettings(childSettingsHex) {
-		var splitty = hexToBinary(childSettingsHex).match(/^(.{7})(.)(.)(.)(.{12})/);
+    function extractChildSettings(childSettingsHex) {
+        var splitty = hexToBinary(childSettingsHex).match(/^(.{7})(.)(.)(.)(.{12})/);
 
-		return {
-			opacity: decodeOpacity(splitty[1]),
-			visibility: decodeBoolean(splitty[2]),
-			query: decodeBoolean(splitty[3]),
-			index: parseInt(splitty[5], 2),
-			root: decodeBoolean(splitty[4])
-		};
-	}
+        return {
+            opacity: decodeOpacity(splitty[1]),
+            visibility: decodeBoolean(splitty[2]),
+            query: decodeBoolean(splitty[3]),
+            index: parseInt(splitty[5], 2),
+            root: decodeBoolean(splitty[4])
+        };
+    }
 
-	function decodeVerB(bookmark) {
+    function decodeVerB(bookmark) {
         var pattern = /^([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)(?:$|,(.*)$)/i;
         // things for specific layers:[ layer type name,  property names in data ]
         var layerSpec = [
@@ -286,17 +286,17 @@
 
                     var textArray = [];
                     var childrenInfo = layer.substr(6, layerSettings.childCount * 6);
-					var childItems = childrenInfo.match(/.{6}/g);
+                    var childItems = childrenInfo.match(/.{6}/g);
 
                     // process the children and store them in our persistant var, so it can be accessed if
-					// someone clicks on the parent
+                    // someone clicks on the parent
 
                     childItems.forEach(function (cData) {
-						var childSettings = extractChildSettings(cData);
-						var prefix = childSettings.root ? 'Root Child: ' : 'Non Root Child: ';
+                        var childSettings = extractChildSettings(cData);
+                        var prefix = childSettings.root ? 'Root Child: ' : 'Non Root Child: ';
 
                         textArray.push( prefix  +
-							dataToTextB(['index', 'opacity', 'visibility', 'query' ], childSettings));
+                            dataToTextB(['index', 'opacity', 'visibility', 'query' ], childSettings));
                     });
 
                     childDataStore[i.toString()] = textArray;

--- a/src/bookmark-decode.html
+++ b/src/bookmark-decode.html
@@ -12,7 +12,7 @@
         <div class="form-group col-md-12">
             <label>Encoded Bookmark (paste it in the box!)</label>
             <input class="form-control" type="text" id="encodebook" value="" />
-            <button class="btn btn-default" id='dtenhance'>Enhance</button>
+            <button class="btn btn-default" id='cmdEnhance'>Enhance</button><button class="btn" id='cmdRaw'>Raw Decode</button>
         </div>
 
     </div>
@@ -54,11 +54,25 @@
 
     <div class="row"><div class="form-group col-md-12">
         <label>Layers</label>
-        <textarea id="layers" rows=10 class="form-control"></textarea>
+        <select id="layers" size="10" class="form-control"></select>
+    </div></div>
+
+    <div class="row"><div class="form-group col-md-12">
+        <label>Child Layers</label>
+        <select id="childs" size="10" class="form-control"></select>
     </div></div>
 
     <div class="row"><div id="log" class="form-group col-md-12">
     </div></div>
+
+    <!-- Input field for the bookmark -->
+    <div class="row">
+        <div class="form-group col-md-12">
+            <label>Raw Decode</label>
+            <input class="form-control" type="text" id="rawout" value="" />
+        </div>
+
+    </div>
 
 </div>
 
@@ -67,16 +81,23 @@
 
 <script>
     
+    var childDataStore = {};
+
     // decode from the customized base64 format
     function decode64(string) {
         return atob(string.replace(/_/g, '/').replace(/-/g, '+'));
     }
 
-    // takes an array of properties, plus the property settings in bookmark encoding. 
+    // takes an array of properties, plus the property settings in bookmark encoding.
     // returns a human readable string of the properties
-    function dataToText (props, info) {
+    function dataToText (props, info, version) {
         var lookup = {
-            opacity: value => parseInt(value) / 100,
+            opacity: value => {
+                if (version !== 'A' && value === '99') {
+                    value = '100';
+                }
+                return parseInt(value) / 100
+            },
             visibility: value => value === '1',
             boundingBox: value => value === '1',
             snapshot: value => value === '1',
@@ -91,9 +112,165 @@
         return result;
     }
 
+    // returns a human readable string of properties for a child layer fragment of a bookmark
+    function childDataToText(childData, version) {
+        var cFormat = /^(\d{2})(\d{1})(\d{1})(.+?)$/;
+        var cInfo = childData.match(cFormat);
+        return 'service index: ' + cInfo[4] + ', ' + dataToText([, 'opacity', 'visibility', 'query'], cInfo, version);
+    };
+
+    // keeping things totally separate to avoid piles of IF statements
+
+    function decodeVerA(bookmark) {
+
+        var pattern = /^([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)(?:$|,(.*)$)/i;
+        // things for specific layers:[ layer type name, regex to strip data from id, regex to parse data, property names in data ]
+        var layerSpec = [
+            ['Feature', /^(.+?)(\d{7})$/, /^(\d{3})(\d{1})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'snapshot', 'query']],
+            ['Wms', /^(.+?)(\d{6})$/, /^(\d{3})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'query']],
+            ['Tile', /^(.+?)(\d{5})$/, /^(\d{3})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox']],
+            ['Dynamic', /^(.+?)(\d{6})$/, /^(\d{3})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'query']],
+            ['Image', /^(.+?)(\d{5})$/, /^(\d{3})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox']]
+        ];
+        
+        var info = bookmark.match(pattern);
+        var version = info[1];
+        var decoded = [2, 3, 4, 5].map(i => decode64(info[i]));
+
+        $('#version').val( 'A' );
+        $('#scale').val( decoded[3] );
+        $('#basemap').val( decoded[0] );
+        $('#x').val( decoded[1] );
+        $('#y').val( decoded[2] );
+
+        var layerList = $('#layers')[0];
+        clearList(layerList);
+        childDataStore = {};
+
+        if (info[6]) {
+            var layers = info[6].split(',');
+
+            // Generate text for all layers
+            layers.forEach((layer, i) => {
+                layer = decode64(layer);
+
+                // strip out integer that defines the layer type
+                var layerType = parseInt(layer.substring(0, 2));
+                // split the remaining data into layer id and layer data
+                var layerGuts = layer.substring(2).match(layerSpec[layerType][1]);
+                var layerId = layerGuts[1];
+                // parse the data into discrete parts, specific to the layer type
+                var layerData = layerGuts[2].match(layerSpec[layerType][2]);
+
+                // show the raw data, and then a human friendly version of it
+                var opt = document.createElement("option");
+                opt.text = layerSpec[layerType][0] + ' Layer, id: ' + layerId + ', ' +
+                        dataToText(layerSpec[layerType][3], layerData, 'A');
+                opt.value = i;
+                layerList.add(opt);
+
+            });
+
+        }
+    }
+
+    function clearList(listControl) {
+        while (listControl.firstChild) {
+            listControl.removeChild(listControl.firstChild);
+        }
+    }
+
+    function decodeVerB(bookmark) {
+        var pattern = /^([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)(?:$|,(.*)$)/i;
+        // things for specific layers:[ layer type name, regex to strip data from id, regex to parse data, property names in data ]
+        var layerSpec = [
+            ['Feature', /^(.+?)(\d{6})$/, /^(\d{2})(\d{1})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'snapshot', 'query']],
+            ['Wms', /^(.+?)(\d{5})$/, /^(\d{2})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'query']],
+            ['Tile', /^(.+?)(\d{4})$/, /^(\d{2})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox']],
+            ['Dynamic', /^(.+?)([;].*\d{5})$/, /^(.+?)(\d{2})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'query']],
+            ['Image', /^(.+?)(\d{4})$/, /^(\d{2})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox']]
+        ];
+
+        var info = bookmark.match(pattern);
+        var version = info[1];
+        var decoded = [2, 3, 4, 5].map(i => decode64(info[i]));
+
+        // if we have the blank flag set, format it nicely
+        var basemap = decoded[0].substring(0, decoded[0].length - 1);
+        if (decoded[0].substr(decoded[0].length - 1, 1) === '1') {
+            basemap = `blank basemap [${basemap}]`;
+        }
+
+        $('#version').val( 'B' );
+        $('#scale').val( decoded[3] );
+        $('#basemap').val( basemap );
+        $('#x').val( decoded[1] );
+        $('#y').val( decoded[2] );
+
+        var layerList = $('#layers')[0];
+        clearList(layerList);
+        childDataStore = {};
+
+        if (info[6]) {
+            var layers = info[6].split(',');
+
+            // Generate text for all layers
+            layers.forEach((layer, i) => {
+                layer = decode64(layer);
+
+                // strip out integer that defines the layer type
+                var layerType = parseInt(layer.substring(0, 2));
+                // split the remaining data into layer id and layer data
+                var layerGuts = layer.substring(2).match(layerSpec[layerType][1]);
+                var layerId = layerGuts[1];
+                // parse the data into discrete parts, specific to the layer type
+                var layerData = layerGuts[2].match(layerSpec[layerType][2]);
+                
+                // rip off child data if we are dynamic
+                if (layerType === 3) {
+
+                    var textArray = [];
+                    var childData = layerData[1].substr(1); // drop leading ;
+                    layerData.splice(1, 1); // remove child info from array, normalizing it with the other layer types
+
+                    // process the children and store them in our persistant var, so it can be accessed if someone clicks on the parent
+
+                    // splitting on ; gives us chunks of data for each top-level index in the layer.
+                    // i.e. each chunk defines an object that goes in .layerEntries
+                    childData.split(';').forEach(function (cData) {
+                        // for a single top level index, we can also have auto-generated child settings along with it.
+                        // these values are separated by ` chars. The first one is always the parent.
+                        var subChildData = cData.split('`');
+
+                        // make parent entry, then remove it from source array
+                        textArray.push( 'Parent: ' + childDataToText(subChildData[0], 'B'));
+                        subChildData.splice(0, 1);
+
+                        // if any child data remains, add it to the text array
+                        subChildData.forEach(function (scd) {
+                            textArray.push( '--Child: ' + childDataToText(scd, 'B'));
+                        });
+                    });
+
+                    childDataStore[i.toString()] = textArray;
+
+                }
+
+                // show the raw data, and then a human friendly version of it
+                var opt = document.createElement("option");
+                opt.text = layerSpec[layerType][0] + ' Layer, id: ' + layerId + ', ' +
+                        dataToText(layerSpec[layerType][3], layerData, 'B');
+                opt.value = i;
+                layerList.add(opt);
+
+            });
+           
+        }
+    }
+
     $(document).ready(function () {
 
-        $('#dtenhance').click( function() {
+        $('#cmdEnhance').click( function() {
             // enhance the bookmark into human readable form
 
             var bookmark = $('#encodebook').val();
@@ -109,54 +286,67 @@
                 bookmark = bookmark.substring(keyStart + 3, nextAnd);
             } 
 
-            // TODO update when version gets added to bookmark
-
-            var pattern = /^([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)(?:$|,(.*)$)/i;
-            // things for specific layers:[ layer type name, regex to strip data from id, regex to parse data, property names in data ]
-            var layerSpec = [
-                ['Feature', /^(.+?)(\d{7})$/, /^(\d{3})(\d{1})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'snapshot', 'query']],
-                ['Wms', /^(.+?)(\d{6})$/, /^(\d{3})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'query']],
-                ['Tile', /^(.+?)(\d{5})$/, /^(\d{3})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox']],
-                ['Dynamic', /^(.+?)(\d{6})$/, /^(\d{3})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'query']],
-                ['Image', /^(.+?)(\d{5})$/, /^(\d{3})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox']]
-            ];
-           
-            var info = bookmark.match(pattern);
-            var version = info[1];
-            var decoded = [2, 3, 4, 5].map(i => decode64(info[i]));
-
-            $('#version').val( version );
-            $('#scale').val( decoded[3] );
-            $('#basemap').val( decoded[0] );
-            $('#x').val( decoded[1] );
-            $('#y').val( decoded[2] );
-
-            if (info[6]) {
-                var layers = info[6].split(',');
-                var texty = '';
-                
-                // Generate text for all layers
-                layers.forEach(layer => {
-                    layer = decode64(layer);
-
-                    // strip out integer that defines the layer type
-                    var layerType = parseInt(layer.substring(0, 2));
-                    // split the remaining data into layer id and layer data
-                    var layerGuts = layer.substring(2).match(layerSpec[layerType][1]);
-                    var layerId = layerGuts[1];
-                    // parse the data into discrete parts, specific to the layer type
-                    var layerData = layerGuts[2].match(layerSpec[layerType][2]);
-                    
-                    // show the raw data, and then a human friendly version of it
-                    texty += (layer + ' -- ' + layerSpec[layerType][0] + ' Layer, id: ' + layerId + ', ' + 
-                            dataToText(layerSpec[layerType][3], layerData) + '\n');
-
-                });
-                $('#layers').val( texty );
+            var version = bookmark.match(/^([^,]+)/)[0];
+             
+            switch (version) {
+                case 'A':
+                    decodeVerA(bookmark);
+                    break;
+                case 'B':
+                    decodeVerB(bookmark);
+                    break;
             }
 
         });
        
+        $('#cmdRaw').click( function() {
+            // enhance the bookmark into human readable form
+
+            var bookmark = $('#encodebook').val();
+
+            // if full URL is supplied, only take the rv param
+            var keyStart = bookmark.indexOf('rv=');
+            if (keyStart > -1) {
+                var nextAnd = bookmark.indexOf('&', keyStart + 3);
+                if (nextAnd === -1) {
+                    // no more url params after the bookmark, so set it up to read to the end of the string
+                    nextAnd = bookmark.length;
+                }
+                bookmark = bookmark.substring(keyStart + 3, nextAnd);
+            } 
+
+            var rawOut = bookmark.split(',').map(function(nugget, idx) {
+                if (idx === 0) {
+                    return nugget;
+                } else {
+                    return decode64(nugget);
+                }
+            }).join(',');
+           
+            $('#rawout').val( rawOut );
+            
+        });
+
+        $('#layers').click( function(e) {
+            var idx = e.currentTarget.value;
+            var childList = $('#childs')[0];
+
+            clearList(childList);
+
+            if (childDataStore[idx]) {
+                // add some child stuff
+                var textArray = childDataStore[idx];
+                textArray.forEach(function(t, i) {
+
+                    var opt = document.createElement("option");
+                    opt.text = t;
+                    opt.value = i;
+                    childList.add(opt);
+
+                });
+            }
+        });
+
     });
 </script>
 

--- a/src/bookmark-decode.html
+++ b/src/bookmark-decode.html
@@ -225,7 +225,7 @@
                 var layerId = layerGuts[1];
                 // parse the data into discrete parts, specific to the layer type
                 var layerData = layerGuts[2].match(layerSpec[layerType][2]);
-                
+
                 // rip off child data if we are dynamic
                 if (layerType === 3) {
 
@@ -264,7 +264,7 @@
                 layerList.add(opt);
 
             });
-           
+
         }
     }
 
@@ -287,7 +287,7 @@
             } 
 
             var version = bookmark.match(/^([^,]+)/)[0];
-             
+
             switch (version) {
                 case 'A':
                     decodeVerA(bookmark);
@@ -298,7 +298,7 @@
             }
 
         });
-       
+
         $('#cmdRaw').click( function() {
             // enhance the bookmark into human readable form
 
@@ -322,9 +322,9 @@
                     return decode64(nugget);
                 }
             }).join(',');
-           
+
             $('#rawout').val( rawOut );
-            
+
         });
 
         $('#layers').click( function(e) {

--- a/src/bookmark-decode.html
+++ b/src/bookmark-decode.html
@@ -80,7 +80,7 @@
 <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
 
 <script>
-    
+
     var childDataStore = {};
 
     // decode from the customized base64 format
@@ -92,21 +92,29 @@
     // returns a human readable string of the properties
     function dataToText (props, info, version) {
         var lookup = {
-            opacity: value => {
+            opacity: function (value) {
                 if (version !== 'A' && value === '99') {
                     value = '100';
                 }
-                return parseInt(value) / 100
+                return parseInt(value) / 100;
             },
-            visibility: value => value === '1',
-            boundingBox: value => value === '1',
-            snapshot: value => value === '1',
-            query: value => value === '1'
+            visibility: function (value) {
+                return value === '1';
+            },
+            boundingBox: function (value) {
+                return value === '1';
+            },
+            snapshot: function (value) {
+                return value === '1';
+            },
+            query: function (value) {
+                return value === '1';
+            }
         };
 
         var result = '';
 
-        props.forEach((prop, index) => {
+        props.forEach(function(prop, index) {
             result += (prop + ': ' + lookup[prop](info[index]) + ', ' );
         });
         return result;
@@ -132,10 +140,10 @@
             ['Dynamic', /^(.+?)(\d{6})$/, /^(\d{3})(\d{1})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox', 'query']],
             ['Image', /^(.+?)(\d{5})$/, /^(\d{3})(\d{1})(\d{1})$/, [, 'opacity', 'visibility', 'boundingBox']]
         ];
-        
+
         var info = bookmark.match(pattern);
         var version = info[1];
-        var decoded = [2, 3, 4, 5].map(i => decode64(info[i]));
+        var decoded = [2, 3, 4, 5].map(function (i) { return decode64(info[i]); });
 
         $('#version').val( 'A' );
         $('#scale').val( decoded[3] );
@@ -151,7 +159,7 @@
             var layers = info[6].split(',');
 
             // Generate text for all layers
-            layers.forEach((layer, i) => {
+            layers.forEach(function (layer, i) {
                 layer = decode64(layer);
 
                 // strip out integer that defines the layer type
@@ -249,7 +257,7 @@
 
         var info = bookmark.match(pattern);
         var version = info[1];
-        var decoded = [2, 3, 4, 5].map(i => decode64(info[i]));
+        var decoded = [2, 3, 4, 5].map(function (i) { return decode64(info[i]); });
 
         // if we have the blank flag set, format it nicely
         var basemap = decoded[0].substring(0, decoded[0].length - 1);
@@ -271,7 +279,7 @@
             var layers = info[6].split(',');
 
             // Generate text for all layers
-            layers.forEach((layer, i) => {
+            layers.forEach(function (layer, i) {
                 layer = decode64(layer);
 
                 // strip out hex char that defines the layer type

--- a/src/schema.json
+++ b/src/schema.json
@@ -606,7 +606,7 @@
                 "childOptions": {
                     "type": "array",
                     "items": { "$ref": "#/definitions/dynamicChildOptionNode" },
-                    "minItems": 0,
+                    "default": [],
                     "description": "Settings for child layers not defined in layerEntries. I.e. sub layers that are not at the root level of the legend"
                 },
                 "tolerance": { "type": "number", "default": 5, "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer" },

--- a/src/schema.json
+++ b/src/schema.json
@@ -444,13 +444,13 @@
                 "index": { "type": "number", "description": "The index of the layer in the map service." },
                 "visibility": {
                     "$ref": "#/definitions/visibilityOptionNode"
-                },                
+                },
                 "opacity": {
                     "$ref": "#/definitions/opacityOptionNode"
-                },               
+                },
                 "query": {
                     "$ref": "#/definitions/queryOptionNode"
-                }                
+                }
             },
             "required": ["index"],
             "additionalProperties": false

--- a/src/schema.json
+++ b/src/schema.json
@@ -487,11 +487,6 @@
                     "$ref": "#/definitions/option",
                     "description": "Enables data panel"
                 },
-                "children": {
-                    "type": "array",
-                    "items": { "$ref": "#/definitions/dynamicChildOptionNode" },
-                    "minItems": 0
-                },
                 "outfields": { "type": "string", "default": "*", "description": "A comma separated list of attribute names that should be requested on query." }
             },
             "required": ["index"],
@@ -607,6 +602,12 @@
                     "type": "array",
                     "items": { "$ref": "#/definitions/dynamicLayerEntryNode" },
                     "minItems": 1
+                },
+                "childOptions": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/dynamicChildOptionNode" },
+                    "minItems": 0,
+                    "description": "Settings for child layers not defined in layerEntries. I.e. sub layers that are not at the root level of the legend"
                 },
                 "tolerance": { "type": "number", "default": 5, "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer" },
                 "extent": { "$ref": "#/definitions/extentWithReferenceNode" },

--- a/src/schema.json
+++ b/src/schema.json
@@ -438,7 +438,23 @@
             "required": ["id"],
             "additionalProperties": false
         },
-
+        "dynamicChildOptionNode": {
+            "type": "object",
+            "properties": {
+                "index": { "type": "number", "description": "The index of the layer in the map service." },
+                "visibility": {
+                    "$ref": "#/definitions/visibilityOptionNode"
+                },                
+                "opacity": {
+                    "$ref": "#/definitions/opacityOptionNode"
+                },               
+                "query": {
+                    "$ref": "#/definitions/queryOptionNode"
+                }                
+            },
+            "required": ["index"],
+            "additionalProperties": false
+        },
         "dynamicLayerEntryNode": {
             "type": "object",
             "properties": {
@@ -470,6 +486,11 @@
                 "data": {
                     "$ref": "#/definitions/option",
                     "description": "Enables data panel"
+                },
+                "children": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/dynamicChildOptionNode" },
+                    "minItems": 0
                 },
                 "outfields": { "type": "string", "default": "*", "description": "A comma separated list of attribute names that should be requested on query." }
             },
@@ -664,7 +685,7 @@
     },
 
     "properties": {
-        "version": { "type": "string", "enum": [ "1.3","1.2","1.1.0","1.0" ], "description": "The schema version used to validate the configuration file.  The schema should enumerate the list of versions accepted by this version of the viewer." },
+        "version": { "type": "string", "enum": [ "1.4", "1.3","1.2","1.1.0","1.0" ], "description": "The schema version used to validate the configuration file.  The schema should enumerate the list of versions accepted by this version of the viewer." },
         "language": { "type": "string", "enum": [ "en", "fr", "es" ], "description": "ISO 639-1 code indicating the language of strings in the schema file" },
         "theme": { "type": "string", "enum": [ "default" ], "default": "default", "description": "UI theme of the viewer" },
         "logoUrl": { "type": "string", "description": "An optional image to be used in the place of the default viewer logo" },


### PR DESCRIPTION
* version B of the bookmark -- supports child structures of dynamic layers
* config schema change to allow definition of dynamic child layer settings
* fixed issue with initial query flag setting
* support blank map state in bookmark
* fixed basemap schema change to blank basemap
* reduce bookmark opacity to 2 digits
* update bookmark decoder page with child support
* raw decode function on decoder page

See https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1265 for discussion on bookmark version management -- some comments may be better suited there than in the code review.

Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/926 and https://github.com/fgpv-vpgf/fgpv-vpgf/issues/824

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1266)
<!-- Reviewable:end -->
