### PR TITLE
feat(geo): add bbox/layer extent calculations at file loading

### DIFF
--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -367,6 +367,19 @@
                         registerLayerRecord(lr);
                         const pos = createPlaceholder(lr);
                         console.log(`adding ${lr.config.name} to map at ${pos}`);
+
+                        // TODO replace with existing function gapiService.gapi.proj.graphicsUtils.graphicsExtent()
+                        // get the bbox extent if not defined
+                        // it is calculated here to avoid calls when we enable bbox in settings
+                        if (lr._layer.fullExtent.xmax === undefined) {
+                            lr._layer.fullExtent.spatialReference.wkid = lr._layer.graphics[0]
+                                                                            ._extent.spatialReference.wkid;
+                            lr._layer.fullExtent.xmax = Math.max(...lr._layer.graphics.map(o => o._extent.xmax));
+                            lr._layer.fullExtent.xmin = Math.min(...lr._layer.graphics.map(o => o._extent.xmin));
+                            lr._layer.fullExtent.ymax = Math.max(...lr._layer.graphics.map(o => o._extent.ymax));
+                            lr._layer.fullExtent.ymin = Math.min(...lr._layer.graphics.map(o => o._extent.ymin));
+                        }
+
                         lr.addStateListener(makeFirstLoadHandler(lr));
                         mapObject.addLayer(lr._layer, pos);
                         // HACK: for a file-based layer, call onLoad manually since such layers don't emmit events


### PR DESCRIPTION
Before: layer extent is not defined for loaded file (CSV,
GeoJSON,Shapefile) so the bbox cannot be displayed
After: add bbox/layer extent calculations when file is loaded. Bbox can
now be displayed. Test with CSV, GeoJSON and Shapefile in both
projections type

Closes #791

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1282)
<!-- Reviewable:end -->
