### PR TITLE
fix(ui): correct size of the loading spinner in details panel

### DIFF
--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -371,7 +371,8 @@
                         // TODO replace with existing function gapiService.gapi.proj.graphicsUtils.graphicsExtent()
                         // get the bbox extent if not defined
                         // it is calculated here to avoid calls when we enable bbox in settings
-                        if (lr._layer.fullExtent.xmax === undefined) {
+                        if (typeof lr._layer.fullExtent !== 'undefined' &&
+                            typeof lr._layer.fullExtent.xmax === 'undefined') {
                             lr._layer.fullExtent.spatialReference.wkid = lr._layer.graphics[0]
                                                                             ._extent.spatialReference.wkid;
                             lr._layer.fullExtent.xmax = Math.max(...lr._layer.graphics.map(o => o._extent.xmax));

--- a/src/app/ui/details/layer-list-slider.html
+++ b/src/app/ui/details/layer-list-slider.html
@@ -16,7 +16,7 @@
             symbology="item.requester.symbology"
             ng-class="{ 'rv-disabled' : item.data.length === 0 || item.isLoading }"></rv-toc-entry-symbology>
         <span class="rv-details-layer-badge" ng-if="item.data.length > 0">{{ item.data.length }}</span>
-        <md-progress-circular md-diameter="48" class="md-primary" md-mode="indeterminate" ng-if="item.isLoading"></md-progress-circular>
+        <md-progress-circular md-diameter="24" class="md-primary" md-mode="indeterminate" ng-if="item.isLoading"></md-progress-circular>
         <div class="rv-details-layer-name">
             <span class="">{{ item.requester.name }}</span>
             <span class="md-caption" ng-if="item.requester.caption">{{ item.requester.caption }}</span>

--- a/src/content/styles/modules/_details.scss
+++ b/src/content/styles/modules/_details.scss
@@ -119,8 +119,8 @@
 
                 md-progress-circular {
                     position: absolute;
-                    left: 0;
-                    top: 0;
+                    left: rem(4.8 - 2.4) / 2; // loading spinner is 24 x 24 pixels
+                    top: rem(4.8 - 2.4) / 2;
                     z-index: 0;
                 }
 


### PR DESCRIPTION
Closes #1125 

Also adds an undefined check for `fullExtent` on layer objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1288)
<!-- Reviewable:end -->
