### PR TITLE
fix(geo): define featureInfoMimeType in legendEntry for user added service

### DIFF
--- a/src/app/geo/layer-blueprint.class.js
+++ b/src/app/geo/layer-blueprint.class.js
@@ -160,6 +160,15 @@
                         if (data.layers.length > 0) { // if there are layers, it's a wms layer
                             console.log(`${this.config.url} is a WMS, yak!`);
 
+                            // it is mandatory to set featureInfoMimeType attribute to get fct identifyOgcWmsLayer to work.
+                            // get the first supported format available in the GetFeatureInfo section of the Capabilities XML.
+                            const formatType = Object.values(data.queryTypes)
+                                                    .filter(format => typeof format === 'string')
+                                                    .find(format => format in Geo.Layer.Ogc.INFO_FORMAT_MAP);
+
+                            const featInfoMimeType = { featureInfoMimeType: formatType };
+                            Object.assign(this.config, featInfoMimeType);
+
                             // return an object resembling fileInfo object returned by GeoApi
                             return {
                                 serviceType: Geo.Service.Types.WMS,


### PR DESCRIPTION
Before: clicking on a feature coming from a user added service give no
result because the featureInfoMimeType is no defined at
identifyOgcWmsLayer call
After: get the available info_format values from the Capabilities XML
and pick the first one supported by the viewer

Closes #1010

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1300)

<!-- Reviewable:end -->
