### PR TITLE
chore(build): deploy dev and prod demo builds to cloud

### DIFF
--- a/devdeploy.sh
+++ b/devdeploy.sh
@@ -24,7 +24,8 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
 
     echo "Destintation: $DESTDIR"
     ssh "$SSHSRV" mkdir -p "$DESTDIR/dist"
-    rsync -av --delete "build/" "$SSHSRV:$DESTDIR"
+    rsync -av --delete "build/" "$SSHSRV:$DESTDIR/prod"
     rsync -av "dist/" "$SSHSRV:$DESTDIR/dist"
+    ssh "$SSHSRV" unzip "$DESTDIR/dist/*-samples.zip" -d "$DESTDIR/dev"
 
 fi

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -353,12 +353,12 @@ gulp.task('samples', 'Generate sample archives for distribution', ['remove-apike
     merge(
         gulp
             .src([config.build + '/**'])
-            .pipe($.tar('fgpv-' + pkg.version + '-samples.tgz'))
+            .pipe($.tar('fgpv-' + pkg.version + '-dev-samples.tgz'))
             .pipe($.gzip({ append: false }))
             .pipe(gulp.dest('dist')),
         gulp
             .src([config.build + '/**'])
-            .pipe($.zip('fgpv-' + pkg.version + '-samples.zip'))
+            .pipe($.zip('fgpv-' + pkg.version + '-dev-samples.zip'))
             .pipe(gulp.dest('dist')))
 );
 


### PR DESCRIPTION
## Description
Modifies the deployment script to publish both dev and prod build to cloud. Dev build is much easier to test. Also renames samples archives to make clear they contain dev builds.

## Testing
No unit tests necessary.

## Documentation
Nothing added.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

Closes #1302

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1335)
<!-- Reviewable:end -->
