### PR TITLE
fix(ui): cancel stale print jobs when exporting map image

### DIFF
--- a/src/app/ui/export/export.service.js
+++ b/src/app/ui/export/export.service.js
@@ -159,11 +159,11 @@
                  * @function checkRequest
                  * @private
                  * @param {Promise} promise print promise which resolves when its canvas is ready
-                 * @param {Object} graphic target graphic the canvas needs to be assigned ot
+                 * @param {String} graphicName name of the target graphic the canvas needs to be assigned to
                  */
-                function checkRequest(promise, graphic) {
+                function checkRequest(promise, graphicName) {
                     promise.then(canvas =>
-                        requestId === requestCount ? (self[graphic] = canvas) : angular.noop());
+                        requestId === requestCount ? (self[graphicName] = canvas) : angular.noop());
                 }
             }
 


### PR DESCRIPTION
## Description
Stale print jobs might override the current export image in some cases.

## Testing
Eyeball testing has been performed. No unit tests.

## Documentation
Added comments in the code.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Stale print requests might override the current export image.

Closes #1285

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1336)
<!-- Reviewable:end -->
