### PR TITLE
feat(ui): touch mode optimizations

### DIFF
--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -170,6 +170,11 @@
 
         node.setAttribute('rv-trap-focus', appId);
 
+        // basic touch device detection; if detected set rv-touch class so that touch mode is on by default
+        if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+            node.className += ' rv-touch';
+        }
+
         console.info('setting debug on', appId, node);
         // create debug object for each app instance
         RV.debug[appId] = {};

--- a/src/app/layout/shell.directive.js
+++ b/src/app/layout/shell.directive.js
@@ -29,7 +29,20 @@
         return directive;
 
         function link(scope, el) {
+            const self = scope.self;
+
             storageService.panels.shell = el;
+
+            // boolean used by touch mode toggle, true if touch mode is active
+            self.isTouch = $rootElement.hasClass('rv-touch');
+            self.toggleTouch = isActive => {
+                if (isActive) {
+                    $rootElement.removeClass('rv-touch');
+                } else {
+                    $rootElement.addClass('rv-touch');
+                }
+            };
+
             // fix for IE 11 where focus can move to esri generated svg elements
             $rootScope.$on(events.rvApiReady, () => {
                 $rootElement.find('.rv-esri-map svg').attr('focusable', false);

--- a/src/app/layout/tooltip.decorator.js
+++ b/src/app/layout/tooltip.decorator.js
@@ -1,0 +1,74 @@
+(() => {
+    'use strict';
+
+    /**
+     * @module mdTooltipDirective
+     * @memberof material.components.tooltip
+     * @requires $delegate
+     * @requires $rootElement
+     * @requires $timeout
+     * @description
+     *
+     * The `mdTooltipDirective` decorates the vanilla mdTooltip.
+     * Modifies display logic if touch mode is on.
+     */
+    angular
+        .module('material.components.tooltip')
+        .decorator('mdTooltipDirective', mdTooltipDirective);
+
+    function mdTooltipDirective($delegate, $rootElement, $timeout) {
+        'ngInject';
+
+        const mdTooltipDirective = $delegate[0]; // get the vanilla directive
+        const originalCompile = mdTooltipDirective.compile; // store reference to its compile function
+        mdTooltipDirective.compile = decorateCompile(originalCompile); // decorate compile function
+
+        return ([mdTooltipDirective]);
+
+        /**
+         * Decorates the original tooltip compile functions.
+         * @function decorateCompile
+         * @param  {Function} originalCompile original compile function
+         * @return {Function}                 enhances link function returned by the decorated compile function which modifies display logic if touch mode is on
+         */
+        function decorateCompile(originalCompile) {
+            return (...args) => {
+                const originalLink = originalCompile(...args);
+
+                // return a decorated link function
+                return (scope, el, attrs, ctrls) => {
+                    let showTooltipTimeout;
+
+                    // if touch mode is on - hide the tooltip on touchstart, then show it after 1 second if no touchend event is fired
+                    // did not use native md-delay since we don't want to change the delay for mouse hovers or on focus, just touch.
+                    // md-visible did/does not work for managing the visibility of the tooltip; this may be a bug or the documentation is misleading on its use.
+                    el.parent()
+                        .on('touchstart', () => {
+                            if (isTouch()) {
+                                showTooltipTimeout = $timeout(() => el.removeClass('rv-hide'), 1000);
+                            } else {
+                                el.removeClass('rv-hide');
+                            }
+                        }).on('touchend', () =>
+                            isTouch() ? $timeout.cancel(showTooltipTimeout) : undefined);
+
+                    /**
+                     * Returns whether touch mode is on, and if it is, ensures the tooltip is hidden.
+                     * @function isTouch
+                     * @private
+                     * @return {Boolean}    true iff touch mode is on, false otherwise
+                     */
+                    function isTouch() {
+                        if ($rootElement.hasClass('rv-touch')) {
+                            el.addClass('rv-hide');
+                            return true;
+                        }
+                        return false;
+                    }
+
+                    originalLink(scope, el, attrs, ctrls);
+                };
+            };
+        }
+    }
+})();

--- a/src/app/ui/sidenav/sidenav.html
+++ b/src/app/ui/sidenav/sidenav.html
@@ -25,6 +25,11 @@
             </li>
         </ul>
 
+        <div class="rv-touch menu-heading md-subhead">{{ 'sidenav.label.touch' | translate }}
+            <span flex></span>
+            <md-switch class="md-primary" ng-model="self.isTouch" ng-click="self.toggleTouch(self.isTouch)" translate-attr-aria-label="sidenav.label.touch"></md-switch>
+        </div>
+
         <md-divider></md-divider>
 
         <md-content role="language">

--- a/src/content/styles/common/_all.scss
+++ b/src/content/styles/common/_all.scss
@@ -38,3 +38,9 @@ $keyboard-only: '.rv-keyboard-only';
         }
     }
 }
+
+@mixin touch {
+    @at-root.rv-touch#{&} {
+        @content;
+    }
+}

--- a/src/content/styles/modules/_app-menu.scss
+++ b/src/content/styles/modules/_app-menu.scss
@@ -17,7 +17,7 @@
                 padding: rem(0.8) 0;
             }
 
-            .rv-language {
+            .rv-language, .rv-touch {
                 display: flex!important;
                 align-items: center;
             }

--- a/src/content/styles/modules/_buttons.scss
+++ b/src/content/styles/modules/_buttons.scss
@@ -113,26 +113,74 @@
 @mixin icon-sizes {
     .rv-icon-40 {
         @include icon-size(rem(4));
+
+        @include touch {
+            @include icon-size(rem(6));
+        }
+
+        @include media($rv-sm) {
+            @include icon-size(rem(6));
+        }
     }
 
     .rv-icon-32 {
         @include icon-size(rem(3.2));
+
+        @include touch {
+            @include icon-size(rem(4.8));
+        }
+
+        @include media($rv-sm) {
+            @include icon-size(rem(4.8));
+        }
     }
 
     .rv-icon-24 {
         @include icon-size(rem(2.4));
+
+        @include touch {
+            @include icon-size(rem(3.6));
+        }
+
+        @include media($rv-sm) {
+            @include icon-size(rem(3.6));
+        }
     }
 
     .rv-icon-20 {
         @include icon-size(rem(2));
+
+        @include touch {
+            @include icon-size(rem(3));
+        }
+
+        @include media($rv-sm) {
+            @include icon-size(rem(3));
+        }
     }
 
     .rv-icon-16 {
         @include icon-size(rem(1.6));
+
+        @include touch {
+            @include icon-size(rem(2.4));
+        }
+
+        @include media($rv-sm) {
+            @include icon-size(rem(2.4));
+        }
     }
 
     .rv-icon-14 {
         @include icon-size(rem(1.4));
+
+        @include touch {
+            @include icon-size(rem(2.1));
+        }
+
+        @include media($rv-sm) {
+            @include icon-size(rem(2.1));
+        }
     }
 }
 

--- a/src/content/styles/modules/_mapnav.scss
+++ b/src/content/styles/modules/_mapnav.scss
@@ -51,6 +51,10 @@
             &:not([disabled]).md-focused {
                 background-color: rgba(255, 255, 255, $opacity-to);
             }
+
+            @include touch {
+                background-color: rgba(255, 255, 255, 1);
+            }
         }
 
         rv-mapnav-button {

--- a/src/content/styles/modules/_toc.scss
+++ b/src/content/styles/modules/_toc.scss
@@ -33,6 +33,10 @@ $layer-item-height: rem(6.0);
     @include keyboard {
         @include entry-controls-keyboard;
     };
+
+    @include touch {
+        @include entry-controls-touch;
+    };
 }
 
 @mixin layer-list {
@@ -339,6 +343,12 @@ absolutely position a button underneath an item so it acts like a button body fo
 
 @mixin entry-controls-keyboard() {
     .rv-toc-entry-controls > * {
+        display: inline !important;
+    }
+}
+
+@mixin entry-controls-touch() {
+    .rv-toc-entry-controls > :first-child {
         display: inline !important;
     }
 }

--- a/src/content/styles/vendor/_all.scss
+++ b/src/content/styles/vendor/_all.scss
@@ -3,14 +3,6 @@ jQuery UI and a color picker override styles are examples of CSS that you might 
 This should make it easy to update my third-party stylesheets to more current versions in the future. */
 
 // import all vendor override files
-
-// overriding default icon color with a darker hue
-
-// Angular Material
-md-icon {
-    color: #666666;
-}
-
 @import "_datatable.scss";
 @import "_esri.scss";
 @import "_dragula.scss";

--- a/src/content/styles/vendor/_angularmaterial.scss
+++ b/src/content/styles/vendor/_angularmaterial.scss
@@ -1,5 +1,26 @@
 @mixin angularmaterial {
+
     md-dialog {
         @include keyboard-focus;
+    }
+
+    md-icon {
+        color: #666666;
+
+        @include touch {
+            width: rem(3.6);
+            height: rem(3.6);
+        }
+
+        @include media($rv-sm) {
+            width: rem(3.6);
+            height: rem(3.6);
+        }
+    }
+
+    md-tooltip {
+        .rv-hide {
+            display: none;
+        }
     }
 }

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -99,6 +99,7 @@ Bookmark short link,sidenav.label.shortlink,Short Link,Lien court
 Bookmark link copied feedback,sidenav.label.copysuccess,Link copied to clipboard,Lien copié dans le presse-papiers
 Bookmark link click to copy hint,sidenav.label.clicktocopy,Click to copy,Cliquez pour copier
 Side Navigation help,sidenav.label.help,HELP,AIDE
+Side Navigation touch mode,sidenav.label.touch,Touch Mode,Mode Tactile
 Side Navigation language,sidenav.label.language,Language,Langage
 Table of Content Unnamed service,toc.layer.unnamed,Unnamed Service #{{count}},Service sans nom #{{count}}
 Table of Content Layer open data panel aria label,toc.layer.aria.openData,Open data panel menu,Menu du panneau des données ouvertes


### PR DESCRIPTION
## Description
Adds an option in the left side menu to enable touch mode. For some devices this is turned on by default. While on:
    - icon size increases by 1.5x
    - navbar controls become fully opaque
    - legend entry settings ellipses is shown for easier access
    - tooltips are shown on touch long presses (unchanged for mouseover/focusin)

## Testing
Eyeball testing done in chrome

## Documentation
jsdoc

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Closes #1241

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1347)
<!-- Reviewable:end -->
