### PR TITLE
1281 manually saving tainted canvas

### DIFF
--- a/src/app/ui/export/export.html
+++ b/src/app/ui/export/export.html
@@ -33,12 +33,14 @@
                     ng-hide="self.isGenerationComplete || self.isError"
                     md-mode="indeterminate"></md-progress-linear>
 
-             <md-switch translate-attr-aria-label="export.includelegend" class="md-primary rv-switch"
-                        ng-model="self.isLegendIncluded"
-                        ng-change="self.includeLegend()"
-                        ng-disabled="self.isError">
+            <md-checkbox translate-attr-aria-label="export.includelegend"
+                ng-model="self.isLegendIncluded"
+                ng-change="self.includeLegend()"
+                ng-disabled="self.isError"
+                class="md-primary">
                 {{ 'export.includelegend' | translate }}
-            </md-switch>
+            </md-checkbox>
+
             <span flex></span>
 
             <md-button

--- a/src/app/ui/export/export.html
+++ b/src/app/ui/export/export.html
@@ -12,13 +12,16 @@
                     <rv-svg class="rv-export-local"
                             src="self.localGraphic"></rv-svg>
 
+                    <rv-svg class="rv-export-tainted" ng-if="self.isTainted"
+                            src="self.taintedGraphic"></rv-svg>
                 </div>
 
                 <rv-svg ng-if="self.isLegendIncluded"
                         class="rv-export-legend"
                         src="self.legendGraphic"></rv-svg>
 
-                <div class="rv-export-title">
+                <!-- need to hide the title input field when displaying the tainted canvas image for manual saving -->
+                <div class="rv-export-title" ng-hide="self.isTainted">
                     <md-input-container md-no-float class="md-headline" ng-disabled="self.isError">
                         <input placeholder="{{ 'export.title' | translate }}" ng-model="self.exportTitle">
                     </md-input-container>

--- a/src/app/ui/export/export.service.js
+++ b/src/app/ui/export/export.service.js
@@ -237,7 +237,13 @@
                     // draw parts of the export image on the canvas
                     context.drawImage(self.serviceGraphic, EXPORT_IMAGE_GUTTER, mapOffset);
                     context.drawImage(self.localGraphic, EXPORT_IMAGE_GUTTER, mapOffset);
-                    context.drawImage(self.legendGraphic || createCanvas(), EXPORT_IMAGE_GUTTER, legendOffset);
+
+                    // only render legend graphic on canvas if it's included;
+                    // the legend graphic could be cached, but not included - user first inlcuded then removes the legend, for example
+                    // a cached (but not included) legend graphic rendered this way to the canvas won't be visible (most likely), since it will be ouside the canvas boundary; however, if the legend graphic is tainted it will prevent the export image from saving directly
+                    if (self.isLegendIncluded) {
+                        context.drawImage(self.legendGraphic, EXPORT_IMAGE_GUTTER, legendOffset);
+                    }
                     context.drawImage(shellGraphic, 0, 0);
 
                     // file name is either the title provided by the user or app id + timestamp

--- a/src/app/ui/export/export.service.js
+++ b/src/app/ui/export/export.service.js
@@ -85,6 +85,7 @@
             self.dummyGraphic.height = mapHeight;
 
             self.isError = false;
+            self.isTainted = false; // indicates the canvas is tainted and cannot be directly saved
 
             self.isGenerationComplete = false;
 
@@ -252,8 +253,12 @@
 
                         // this one is likely a tainted canvas issue
                         if (error.name === 'SecurityError') {
-                            // TODO: seems browsers allow to right-click a canvas on the page and save it manually; we can output the final canvas on the page and instruct user how to save it manually
                             showToast('error.tainted');
+
+                            // some browsers (not IE) allow to right-click a canvas on the page and save it manually;
+                            // only when tainted, display resulting canvas inside the dialog, so users can save it manually, if the browser supports it
+                            self.isTainted = true;
+                            self.taintedGraphic = canvas;
                         } else {
                             // something else happened
                             showToast('error.somethingelseiswrong');

--- a/src/content/styles/layout/_main.scss
+++ b/src/content/styles/layout/_main.scss
@@ -26,14 +26,15 @@ md-toast {
     .md-toast-text {
         padding-top: rem(1.4);
         padding-bottom: rem(1.4);
+        flex-basis: auto;
     }
 
     .md-toast-content {
         pointer-events: auto;
-    }
 
-    .md-toast-content span {
-        flex-basis: auto;
+        > button {
+            flex-shrink: 0; // prevents the button from shrinking when the toast text is long
+        }
     }
 }
 

--- a/src/content/styles/modules/_export.scss
+++ b/src/content/styles/modules/_export.scss
@@ -42,32 +42,17 @@
             filter: blur(rem(0.5));
             transition: filter $swift-ease-in-duration * 2 $swift-ease-in-out-timing-function;
 
-            > canvas {
-                width: 100% !important;
-                height: auto !important;
-                display: block;
-            }
-
             &.rv-export-complete {
                 filter: none;
             }
-        }
 
-        .rv-export-dummy {
-            display: block;
-
-            > canvas {
-                width: 100% !important;
-                height: auto !important;
-                display: block;
+            > rv-svg {
+                @extend %export-component;
             }
         }
 
-        .rv-export-server,
-        .rv-export-local {
+        %export-component {
             display: block;
-            position: absolute;
-            top: 0;
 
             > canvas {
                 width: 100% !important;
@@ -77,13 +62,14 @@
         }
 
         .rv-export-legend {
-            display: block;
+            @extend %export-component;
+        }
 
-            canvas {
-                width: 100% !important;
-                height: auto !important;
-                display: block;
-            }
+        .rv-export-server,
+        .rv-export-local,
+        .rv-export-tainted {
+            position: absolute;
+            top: 0;
         }
 
         .rv-export-progress-indicator {

--- a/src/content/styles/modules/_export.scss
+++ b/src/content/styles/modules/_export.scss
@@ -12,6 +12,12 @@
             padding: 0 rem(1.6);
             flex: 1 0 0%;
             border-bottom: 1px solid $divider-color-light;
+            align-items: center;
+
+            md-checkbox {
+                margin-top: 0;
+                margin-bottom: 0;
+            }
         }
 
         md-dialog-content {

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -166,7 +166,7 @@ Geometry types,geometry.type.esriGeometryPolygon, polygon|polygons, polygone|pol
 Geometry types,geometry.type.esriGeometryPolyline, line|lines, ligne|lignes
 ,export.close,Close,Fermer
 ,export.save,Save,Sauver
-,export.includelegend,Include legend,Inclure la légende
+,export.includelegend,Legend,Légende
 ,export.title,Enter Title,Titre
 ,export.error.timeout,"Connection timed out. Stopping export task.","Connexion a expiré. Tâche d’exportation arrêt."
 ,export.error.tainted,"Ops, we can't save the export image directly. You can right click the image and select ""Save As..."" if supported by your browser.","OPS, nous ne pouvons pas enregistrer l’image d’exportation directement. Vous pouvez cliquez droit sur l’image et sélectionnez « Enregistrer sous... » si pris en charge par votre navigateur."

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -169,7 +169,7 @@ Geometry types,geometry.type.esriGeometryPolyline, line|lines, ligne|lignes
 ,export.includelegend,Legend,Légende
 ,export.title,Enter Title,Titre
 ,export.error.timeout,"Connection timed out. Stopping export task.","Connexion a expiré. Tâche d’exportation arrêt."
-,export.error.tainted,"Ops, we can't save the export image directly. You can right click the image and select ""Save As..."" if supported by your browser.","OPS, nous ne pouvons pas enregistrer l’image d’exportation directement. Vous pouvez cliquez droit sur l’image et sélectionnez « Enregistrer sous... » si pris en charge par votre navigateur."
+,export.error.tainted,"Oops, we can't save the export image directly. You can right click the image and select ""Save As..."" if supported by your browser.","Nous ne pouvons pas enregistrer l’image directement. Vous pouvez cliquez sur le bouton droit de la souris sur l’image et sélectionnez « Enregistrer sous... » si cela est pris en charge par votre navigateur."
 ,export.error.somethingelseiswrong,"Ouch. Something went wrong. We cannot save the export image.","Aïe. Quelque chose n’allait pas. Nous ne pouvons pas enregistrer l’image de l’exportation."
 ,export.retry,Retry,Réessayez
 ,import.title,Import Layers,Importer des couches

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -169,7 +169,7 @@ Geometry types,geometry.type.esriGeometryPolyline, line|lines, ligne|lignes
 ,export.includelegend,Include legend,Inclure la légende
 ,export.title,Enter Title,Titre
 ,export.error.timeout,"Connection timed out. Stopping export task.","Connexion a expiré. Tâche d’exportation arrêt."
-,export.error.tainted,"Ops, we can't save the export image directly.","OPS, nous ne pouvons pas enregistrer l’image d’exportation directement."
+,export.error.tainted,"Ops, we can't save the export image directly. You can right click the image and select ""Save As..."" if supported by your browser.","OPS, nous ne pouvons pas enregistrer l’image d’exportation directement. Vous pouvez cliquez droit sur l’image et sélectionnez « Enregistrer sous... » si pris en charge par votre navigateur."
 ,export.error.somethingelseiswrong,"Ouch. Something went wrong. We cannot save the export image.","Aïe. Quelque chose n’allait pas. Nous ne pouvons pas enregistrer l’image de l’exportation."
 ,export.retry,Retry,Réessayez
 ,import.title,Import Layers,Importer des couches


### PR DESCRIPTION
## Description
If the export map canvas is tainted, instructs the user via the error toast message that the image can be saved manually in some browsers.

## Testing
Cannot unit test DOM elements with Karma. Protractor is broken.

## Documentation
Code comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1351)
<!-- Reviewable:end -->
