### PR TITLE
feat(ui): remove hardcoded WKIDs in basemap service

### DIFF
--- a/src/app/ui/basemap/basemap.service.js
+++ b/src/app/ui/basemap/basemap.service.js
@@ -1,10 +1,5 @@
 (() => {
     'use strict';
-    const wkidTypes = {
-        3978: 'Lambert',
-        102100: 'Mercator'
-    };
-    const wkidNames = wkid => wkid in wkidTypes ? wkidTypes[wkid] : 'Other';
 
     /**
      * @module basemapService
@@ -79,6 +74,21 @@
         }
 
         /**
+         * Returns the projection name given a basemap wkID as defined in translations,
+         * or 'Other' if not found
+         * @function wkidToName
+         * @private
+         * @param   {Number}    wkID    the basemap wkID from which to derive a name
+         * @return  {String}    the translated basemap projection name
+         */
+        function wkidToName(wkID) {
+            const translationID = `wkids.${wkID}`;
+            const translationStr = $translate.instant(translationID);
+
+            return translationID !== translationStr ? translationStr : $translate.instant('wkids.other');
+        }
+
+        /**
          * Sets a callback function that is called whenever basemaps changes.
          *
          * @function setOnChangeCallback
@@ -141,7 +151,7 @@
 
             basemapList.forEach(bm => {
                 const basemap = _normalizeBasemap(bm);
-                const projName = wkidNames(basemap.wkid);
+                const projName = wkidToName(basemap.wkid);
                 let projection = projections.find(proj => proj.name === projName);
                 // make first basemap selected by default
                 bmSelected = typeof bmSelected === 'undefined' ? basemap : bmSelected;

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -59,6 +59,9 @@ Basemap projection title,basemap.projection.title,{{name}} Maps,Cartes {{name}}
 ,basemap.select,Select basemap,Sélectionnez le fond de carte
 ,basemap.showdescription,Show basemap description,Voir la carte de base description
 ,basemap.hidedescription,Hide basemap description,Masquer la description de la carte de base
+WKIDs to name 3978 -> lambert,wkids.3978,Lambert,Lambert
+WKIDs to name 102100 -> Mercator,wkids.102100,Mercator,Mercator
+WKIDs to name other,wkids.other,Other,Autre
 Map Navigation slider only text,nav.sliderOnly,slider only,Curseur seulement
 Map Navigation slider text,nav.slider,slider,Curseur
 Map Navigation zoom in label,nav.label.zoomIn,Zoom in,Zoom avant


### PR DESCRIPTION
## Description
Projection name is now derived from translations, and if no translation is
found outputs a default "other" name. 

Closes #1190

## Testing
Eyeball tested on FF, IE, and chrome given valid and invalid wkID's including language switching.

## Documentation
jsdoc

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1354)
<!-- Reviewable:end -->
