### PR TITLE
fix(core): stop appInfo service from being shared

### DIFF
--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -37,8 +37,16 @@
             B: 'B'
         })
         .constant('translations', AUTOFILLED_TRANSLATIONS)
-        .value('appInfo', {
+        .factory('appInfo', appInfo);
+
+    // Angular services that have no constructors (services that are just plain objects) are __shared__ across app instances
+    // to have it per instance, the appInfo service needs to have some initialization logic
+    function appInfo() {
+        const service = {
             id: null
             // something else ?
-        });
+        };
+
+        return service;
+    }
 })();


### PR DESCRIPTION
## Description
Angular services (value and constant services) and not initialized with something like `Object.create` and remain shared between app instances.

Relates #1363 

## Testing
Eyeball testing. Cannot be tested with Karma; needs Protractor tests.

## Documentation
Source comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1364)
<!-- Reviewable:end -->
