### PR TITLE
feat(ui): disable animations in IE

### DIFF
--- a/src/app/app.module.js
+++ b/src/app/app.module.js
@@ -1,3 +1,4 @@
+/* global RV */
 (() => {
     'use strict';
 
@@ -29,7 +30,13 @@
          * Feature areas
          */
         'app.layout'
-    ]);
+    ]).config(($compileProvider, $mdInkRippleProvider) => {
+        // to improve IE performance disable ripple effects globally and debug info
+        if (RV.isIE) {
+            $mdInkRippleProvider.disableInkRipple();
+            $compileProvider.debugInfoEnabled(false);
+        }
+    });
 
     // a separate templates module is needed to facilitate directive unit testing
     angular.module('app.templates', []);

--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -10,6 +10,9 @@
     // check if the global RV registry object already exists and store a reference
     const RV = window.RV = typeof window.RV === 'undefined' ? {} : window.RV;
 
+    // test user browser, true if IE false otherwise
+    RV.isIE = /Edge\/|Trident\/|MSIE /.test(window.navigator.userAgent);
+
     // set these outside of the initial creation in case the page defines RV for setting
     // properties like dojoURL
     Object.assign(RV, {


### PR DESCRIPTION
## Description
Disables angular material ripple effect and debugging information in IE to improve performance. See [this issue](https://github.com/angular/material/issues/8329#issuecomment-216816971) for some discussion on improving AM responsiveness.

I also tried disabling animations/transitions globally in IE, however this breaks map panning and the mini map toggle button. There was no noticeable improvement with global animations/transitions turned off.

Looking into this issue further, it seems IE 11 has a difficult/slow time with element CSS selectors. They should be avoided in favor of CSS classes. AM 1 is all element selectors, AM 2 is moving to classes. I suspect datatables is slow atm in part due to the potential for thousands of element CSS selectors such as md-icon. 

Closes #1274

## Testing
Eyeball tested in IE, chrome; no major changes to suspect anything else is broken

## Documentation
Inline comment

## Checklist

- [ ] commits messages follow the guidelines
- [ ] code passes unit tests
- [ ] release notes have been updated
- [ ] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1367)
<!-- Reviewable:end -->
