### PR TITLE
feat(ui): viewer displacement after projection change corrected

### DIFF
--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -1,7 +1,7 @@
 /* global RV, jQuery */
 ((RV, jQuery) => {
     // delay in milliseconds from time focus is lost to when action is taken
-    const focusoutDelay = 200;
+    const focusoutDelay = 800;
     // all the possible states a viewer can be in - only one at any given time
     const statuses = {
         NONE: undefined,


### PR DESCRIPTION
## Description
- Only occurs with Chrome (FF, IE are OK) when clicking on the map. Using the close button or pressing escape does not cause issue.
- The cause seems to be focus related, but it's not immediately clear why this fix works. 

Closes #1376

## Testing
Tested in Chrome, FF, and IE

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1395)
<!-- Reviewable:end -->
