### PR TITLE
fix(ui): sidenav styles are no longer broken

### DIFF
--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -10,8 +10,9 @@
         ACTIVE: 'ACTIVE'
     };
     // jQuery selectors for elements that are likely focusable
-    const focusSelector = `a[href], area[href], input:not([disabled]), select:not([disabled]),
-            textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex], [contenteditable]`;
+    // since we don't want focus on md-sidenav (focus instead on close button) we omit this with [tabindex]:not(md-sidenav)
+    const focusSelector = `a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]),
+        button:not([disabled]), iframe, object, embed, [tabindex]:not(md-sidenav), [contenteditable]`;
     // object containing all currently depressed keyboard keys
     const keys = {};
     // ordered list of elements which has received focus

--- a/src/app/ui/sidenav/sidenav.html
+++ b/src/app/ui/sidenav/sidenav.html
@@ -1,5 +1,4 @@
-<md-sidenav class="site-sidenav md-sidenav-left md-whiteframe-z2" md-component-id="left">
-    <div rv-trap-focus>
+<md-sidenav rv-trap-focus class="site-sidenav md-sidenav-left md-whiteframe-z2" md-component-id="left">
     <header class="nav-header">
         <a class="app-logo" href="#">
             <div>
@@ -48,5 +47,4 @@
         </div>
 
     </md-content>
-    </div>
 </md-sidenav>


### PR DESCRIPTION
## Description
Fixes issue where added `div` element in `md-sidenav` broke css styling. Removed the div, instead focus manager will not target `md-sidenav` even if `tabindex` is set.

## Testing
:eyes: 

## Documentation
None needed

## Checklist

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Closes #1383

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1398)
<!-- Reviewable:end -->
