### PR TITLE
feat(ui): enhance zoom to feature on small/medium viewports

### DIFF
--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -62,7 +62,7 @@
      * @return {object} directive body
      */
     function rvFiltersDefault($timeout, $q, stateManager, $compile, geoService, $translate,
-        layoutService, detailService) {
+        layoutService, detailService, $rootElement) {
 
         const directive = {
             restrict: 'E',
@@ -243,8 +243,30 @@
                     const objId = data[displayData.oidField];
                     const layer = geoService.layers[requester.layerId];
                     const zoomLayer = requester.legendEntry;
+                    const filterPanel = $rootElement.find('rv-panel[type="filters"]');
+                    const otherPanels = $rootElement.find('rv-appbar, rv-mapnav, rv-panel:not([type="filters"])');
+                    let ignoreClick = true;
 
                     geoService.zoomToGraphic(layer, zoomLayer, requester.legendEntry.featureIdx, objId);
+
+                    const removeZoomtoTransparency = () => {
+                        otherPanels.removeClass('rv-lt-lg-hide');
+                        filterPanel.removeClass('zoomto-transparent');
+                        filterPanel.off('.zoomTO');
+                        $(window).off('.zoomTo');
+                    };
+
+                    otherPanels.addClass('rv-lt-lg-hide');
+                    filterPanel.addClass('zoomto-transparent');
+
+                    filterPanel.on('click.zoomTO mousedown.zoomTO touchstart.zoomTO', () =>
+                        ignoreClick ? ignoreClick = false : removeZoomtoTransparency()
+                    );
+
+                    // ensures that resizing from sm/md to lg and back does not persist transparency
+                    $(window).on('resize.zoomTO', () =>
+                        layoutService.currentLayout() === 'large' ? removeZoomtoTransparency() : undefined
+                    );
                 }
 
                 /**

--- a/src/content/styles/common/_breakpoints.scss
+++ b/src/content/styles/common/_breakpoints.scss
@@ -18,6 +18,15 @@ $rv-lt-lg: "<=medium";
     }
 }
 
+@mixin hide-element($class, $query) {
+    .#{$class} {
+        @include media($query...) {
+            display: none !important;
+        }
+    }
+}
+
 @include show-element("rv-gt-sm", $rv-gt-sm);
 @include show-element("rv-lt-lg", $rv-lt-lg);
 @include show-element("rv-lg", $rv-lg);
+@include hide-element("rv-lt-lg-hide", $rv-lt-lg);

--- a/src/content/styles/layout/_main.scss
+++ b/src/content/styles/layout/_main.scss
@@ -50,6 +50,12 @@ rv-panel {
             bottom: 0;
         }
     }
+
+    @include media($rv-lt-lg) {
+        &.zoomto-transparent {
+            opacity: 0.14;
+        }
+    }
 }
 
 // reduces the size of buttons to conform better with the inline text around them,


### PR DESCRIPTION
## Description
When clicking on zoom to feature in small/medium sized viewports the data table is made almost transparent so that the changes to the map are visible. Clicking anywhere restores the data table.

## Testing
:eyes: chrome 

## Documentation
jsdoc

## Checklist

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Closes #1344

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1402)
<!-- Reviewable:end -->
