### PR TITLE
Exclude symbol column in grid CSV

### DIFF
--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -156,6 +156,16 @@
                     column.data !== 'rvSymbol');
                 addColumnInteractivity(interactiveColumn, ROW_BUTTONS);
 
+                // returns array of column indexes we want in the CSV export
+                const exportColumns = (columns) => {
+                    // map columns to their ordinal indexes. but mark the symbol column as -1.
+                    // then filter out the -1. result is an array of column indexes that
+                    // are not the symbol column.
+                    return columns.map((column, i) =>
+                        column.data === 'rvSymbol' ? -1 : i
+                    ).filter(idx => idx > -1);
+                };
+
                 // ~~I hate DataTables~~ Datatables are cool!
                 self.table = tableNode
                     .on('init.dt', callbacks.onTableInit)
@@ -182,7 +192,10 @@
                             },
                             {
                                 extend: 'csvHtml5',
-                                title: self.display.requester.name
+                                title: self.display.requester.name,
+                                exportOptions: {
+                                    columns: exportColumns(displayData.columns)
+                                }
                             }
                         ],
                         oLanguage: oLang
@@ -527,6 +540,7 @@
          * @param  {Number|String} index button selector: https://datatables.net/reference/api/button()
          */
         function triggerTableButton(index) {
+            // see `buttons` array in the DataTable constructor object in the directive above
             const button = self.table.button(index);
             if (button) {
                 button.trigger();

--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -161,9 +161,9 @@
                     // map columns to their ordinal indexes. but mark the symbol column as -1.
                     // then filter out the -1. result is an array of column indexes that
                     // are not the symbol column.
-                    return columns.map((column, i) =>
-                        column.data === 'rvSymbol' ? -1 : i
-                    ).filter(idx => idx > -1);
+                    return columns
+                        .map((column, i) => column.data === 'rvSymbol' ? -1 : i)
+                        .filter(idx => idx > -1);
                 };
 
                 // ~~I hate DataTables~~ Datatables are cool!


### PR DESCRIPTION
## Description
Omits blank `symbol` column from grid CSV export.
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1394

## Testing
Small fix, no existing unit tests for datagrids.

## Documentation
None

## Checklist

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1408)
<!-- Reviewable:end -->
