### PR TITLE
fix(ui): scrolling now possible in legend for touch devices

### DIFF
--- a/src/app/ui/common/dragula.directive.js
+++ b/src/app/ui/common/dragula.directive.js
@@ -19,7 +19,7 @@
         .module('app.ui.common')
         .directive('rvDragula', rvDragula);
 
-    function rvDragula($compile, dragulaService, keyNames) {
+    function rvDragula($compile, dragulaService, keyNames, $timeout) {
         const directive = {
             restrict: 'A',
             link: link,
@@ -51,6 +51,31 @@
             // get dragula instance of dragula
             const drake = dragulaService.find(dragulaScope, attr.rvDragula)
                 .drake;
+
+            // make dragula more touch friendly - only start drag after 1 second if y movement is less than 10 pixels
+            let touchTimeout;
+            let draggable = false;
+            let initYOffset;
+
+            el.on('touchmove', e => {
+                if (Math.abs(initYOffset - e.originalEvent.touches[0].pageY) > 10) {
+                    $timeout.cancel(touchTimeout);
+                }
+
+                if (!draggable) {
+                    e.stopPropagation(true);
+                }
+            });
+
+            el.on('touchstart', e => {
+                initYOffset = e.originalEvent.touches[0].pageY;
+                touchTimeout = $timeout(() => draggable = true, 1000);
+            });
+
+            el.on('touchend touchcancel', () => {
+                $timeout.cancel(touchTimeout);
+                draggable = false;
+            });
 
             keyboardDragula(el, scope, drake, dragulaOptions);
         }


### PR DESCRIPTION
## Description
Adds a one second delay to dragula start which is canceled if there is vertical movement of more than 10 pixels. 

## Testing
:eyes: on IE, FF, and chrome. Does not change IE functionality. 

## Documentation
jsdoc

## Checklist

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Closes #1343

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1410)
<!-- Reviewable:end -->
