### PR TITLE
feat(core): update schema with export options

### DIFF
--- a/src/config.en-CA.json
+++ b/src/config.en-CA.json
@@ -16,7 +16,9 @@
     }
   },
   "export": {
-      "footnote": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+    "footnote": {
+      "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+    }
   },
   "map": {
     "components": {

--- a/src/config.fr-CA.json
+++ b/src/config.fr-CA.json
@@ -15,6 +15,11 @@
           "types": "http://geogratis.gc.ca/services/geoname/fr/codes/concise.json"
       }
   },
+  "export": {
+    "footnote": {
+      "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+    }
+  },
   "map": {
     "components": {
       "geoSearch": {

--- a/src/config.rcs.en-CA.json
+++ b/src/config.rcs.en-CA.json
@@ -8,7 +8,9 @@
     "exportMapUrl": "http://webservices-staging.maps.canada.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task"
   },
   "export": {
-      "footnote": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size."
+    "footnote": {
+      "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+    }
   },
   "map": {
     "components": {

--- a/src/config.rcs.fr-CA.json
+++ b/src/config.rcs.fr-CA.json
@@ -7,6 +7,11 @@
     "proxyUrl": "http://cp.zz9.ca/index",
     "exportMapUrl": "http://webservices-staging.maps.canada.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task"
   },
+  "export": {
+    "footnote": {
+      "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+    }
+  },
   "map": {
     "components": {
       "geoSearch": {

--- a/src/schema.json
+++ b/src/schema.json
@@ -119,22 +119,18 @@
         "exportComponent": {
             "type": "object",
             "properties": {
-                "isIncluded": {
+                "isSelected": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Indicates if the component is included in the export graphic."
+                    "description": "Indicates if the component is selected and included in the export graphic."
                 },
-                "isEditable": {
+                "isSelectable": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Indicates if the component can be included or excluded by the user."
-                },
-                "isVisible": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Indicates if the component graphic is visible in the export dialog."
+                    "description": "Indicates if the component can be included or excluded from the export graphic by the user."
                 },
                 "value": {
+                    "type": "string",
                     "description": "Value to be passed to the generation function of this export component."
                 }
             },
@@ -765,11 +761,12 @@
              "properties": {
                  "title": { "$ref": "#/definitions/exportComponent", "description": "Title of the export graphic." },
                  "map": { "$ref": "#/definitions/exportComponent", "description": "Map component." },
-                 "mapelements": { "$ref": "#/definitions/exportComponent", "description": "North arrow and scalebar component." },
+                 "mapElements": { "$ref": "#/definitions/exportComponent", "description": "North arrow and scalebar component." },
                  "legend": { "$ref": "#/definitions/exportComponent", "description": "Legend component." },
                  "footnote": { "$ref": "#/definitions/exportComponent", "description": "Foot notice to add to exported map" },
                  "timestamp":  { "$ref": "#/definitions/exportComponent", "description": "Timestamp component." }
-             }
+             },
+             "additionalProperties": false
          },
 
         "map": {

--- a/src/schema.json
+++ b/src/schema.json
@@ -116,6 +116,31 @@
             "additionalProperties": false
         },
 
+        "exportComponent": {
+            "type": "object",
+            "properties": {
+                "isIncluded": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Indicates if the component is included in the export graphic."
+                },
+                "isEditable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Indicates if the component can be included or excluded by the user."
+                },
+                "isVisible": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Indicates if the component graphic is visible in the export dialog."
+                },
+                "value": {
+                    "description": "Value to be passed to the generation function of this export component."
+                }
+            },
+            "description": "This is the initial configuration for an export component.",
+            "additionalProperties": false
+        },
 
         "option": {
             "type": "object",
@@ -735,12 +760,17 @@
         },
 
         "export": {
-            "type": "object",
-            "description": "Export properties",
-            "properties": {
-                "footnote": { "type": "string", "description": "Foot notice to add to exported map" }
-            }
-        },
+             "type": "object",
+             "description": "Export properties",
+             "properties": {
+                 "title": { "$ref": "#/definitions/exportComponent", "description": "Title of the export graphic." },
+                 "map": { "$ref": "#/definitions/exportComponent", "description": "Map component." },
+                 "mapelements": { "$ref": "#/definitions/exportComponent", "description": "North arrow and scalebar component." },
+                 "legend": { "$ref": "#/definitions/exportComponent", "description": "Legend component." },
+                 "footnote": { "$ref": "#/definitions/exportComponent", "description": "Foot notice to add to exported map" },
+                 "timestamp":  { "$ref": "#/definitions/exportComponent", "description": "Timestamp component." }
+             }
+         },
 
         "map": {
             "type": "object",


### PR DESCRIPTION
## Description
Adds export options to the config schema. All export components (map, title, legend, map elements (north arrow and scalebar), footnote and timestamp) will be configurable through the config including:
- allowing the user to select if a component should be included in the output graphic
- displaying the component graphic in the export dialog (as a preview)
- including the component graphic in the resulting image

NOTE: This breaks the current footnote implementation. 

## Testing
Schema validates.

## Documentation
Comments included.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated (do we need separate release notes for this?)
- [x] PR targets the correct release version

In support of #1258;

Relates #1258

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1436)
<!-- Reviewable:end -->
