### PR TITLE
feat(ui): add option to layer dropdown for datatable

### DIFF
--- a/src/app/geo/geo.constant.service.js
+++ b/src/app/geo/geo.constant.service.js
@@ -122,6 +122,11 @@
                         flags: angular.merge({},
                             flagDefaults, {
                                 // set type flag to the layer type
+                                data: {
+                                    // NOTE: this a temporary workaround for #1429; this should be removed after structured legend is implemented
+                                    // set `data` flag to visible if data option is enabled for this layer
+                                    visible: (({ data = {} }) => data.enabled || false)(LAYER_CONFIG_DEFAULTS[value])
+                                },
                                 type: {
                                     value: key
                                 }

--- a/src/app/geo/geo.constant.service.js
+++ b/src/app/geo/geo.constant.service.js
@@ -125,7 +125,8 @@
                                 data: {
                                     // NOTE: this a temporary workaround for #1429; this should be removed after structured legend is implemented
                                     // set `data` flag to visible if data option is enabled for this layer
-                                    visible: (({ data = {} }) => data.enabled || false)(LAYER_CONFIG_DEFAULTS[value])
+                                    visible: (({ data = {} } = {}) =>
+                                        data.enabled || false)(LAYER_CONFIG_DEFAULTS[value])
                                 },
                                 type: {
                                     value: key

--- a/src/app/ui/toc/templates/layer-entry.html
+++ b/src/app/ui/toc/templates/layer-entry.html
@@ -38,9 +38,9 @@
         <md-menu-content rv-trap-focus="{{::self.appID}}" class="rv-menu rv-dense" width="4">
             <rv-toc-entry-control type="menu-item" option="metadata"></rv-toc-entry-control>
             <rv-toc-entry-control type="menu-item" option="settings"></rv-toc-entry-control>
-            <rv-toc-entry-control type="menu-item" option="boundaryZoom"></rv-toc-entry-control>
             <rv-toc-entry-control type="menu-item" option="data"></rv-toc-entry-control>
             <md-menu-divider></md-menu-divider>
+            <rv-toc-entry-control type="menu-item" option="boundaryZoom"></rv-toc-entry-control>
             <rv-toc-entry-control type="menu-item" option="reload"></rv-toc-entry-control>
             <rv-toc-entry-control type="menu-item" option="remove"></rv-toc-entry-control>
         </md-menu-content>

--- a/src/app/ui/toc/templates/layer-entry.html
+++ b/src/app/ui/toc/templates/layer-entry.html
@@ -39,6 +39,7 @@
             <rv-toc-entry-control type="menu-item" option="metadata"></rv-toc-entry-control>
             <rv-toc-entry-control type="menu-item" option="settings"></rv-toc-entry-control>
             <rv-toc-entry-control type="menu-item" option="boundaryZoom"></rv-toc-entry-control>
+            <rv-toc-entry-control type="menu-item" option="data"></rv-toc-entry-control>
             <md-menu-divider></md-menu-divider>
             <rv-toc-entry-control type="menu-item" option="reload"></rv-toc-entry-control>
             <rv-toc-entry-control type="menu-item" option="remove"></rv-toc-entry-control>

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -149,18 +149,9 @@
                     tooltip: 'toc.tooltip.flag.scale'
                 },
                 data: {
-                    icon: {
-                        table: 'community:table-large',
-                        filter: 'community:filter'
-                    },
-                    label: {
-                        table: 'toc.label.flag.data.table',
-                        filter: 'toc.label.flag.data.filter'
-                    },
-                    tooltip: {
-                        table: 'toc.tooltip.flag.data.table',
-                        filter: 'toc.tooltip.flag.data.filter'
-                    }
+                    icon: 'community:table-large',
+                    label: 'toc.label.flag.data.table',
+                    tooltip: 'toc.tooltip.flag.data.table'
                 },
                 query: {
                     icon: 'community:map-marker-off',

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -84,6 +84,12 @@
                     tooltip: 'toc.tooltip.boundaryZoom',
                     action: zoomToBoundary
                 },
+                data: {
+                    icon: `community:table-large`,
+                    label: 'toc.label.dataTable',
+                    tooltip: 'toc.label.dataTable',
+                    action: service.actions.toggleLayerFiltersPanel
+                },
                 remove: {
                     icon: 'action:delete',
                     label: 'toc.label.remove',

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -160,6 +160,7 @@ Table of Content loading state tootlip,toc.tooltip.state.loading,Updating,Mise �
 Table of Content templates placeholder loading label,toc.tmp.label.state.loading,Loading layer...,Chargement de la couche...
 Table of Content templates placeholder loading error label,toc.tmp.label.error.loading,Can't load layer,Impossible de charger la couche
 Table of Content zoom to boundary label,toc.label.boundaryZoom,Zoom to Layer Boundary,Zoomer à la limite
+Table of Content open datatable label,toc.label.dataTable,Datatable,Datatable
 Table of Content zoom to boundary tooltip,toc.tooltip.boundaryZoom,Zoom to Layer Boundary,Zoomer à la limite
 Table of Content keyboard reoder tooltip,toc.tooltip.reorder,Reorder,Réorganiser
 While counting geometry,geometry.counting, ...counting, ...compte


### PR DESCRIPTION
## Description
Adds an option to layer dropdown menu to open the datatable. I have not been able to identify why the datatable icon fails to show, since the icon is defined in `toc.service.js` and is added in `layer-entry.html`. Most likely the flag is not being activated for layers with data. The icon was displayed in `v0.7.0`, and my guess is that the flag activating logic was removed sometime after this. Input would be appreciated.

## Testing
:eyes: 

## Documentation
None

## Checklist

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [ ] PR targets the correct release version

Closes #1429

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1455)
<!-- Reviewable:end -->
