### PR TITLE
fix(ui): point info panel toggles not closes

### DIFF
--- a/src/app/ui/details/details.directive.js
+++ b/src/app/ui/details/details.directive.js
@@ -37,8 +37,6 @@
 
         self.getSectionNode = () => $element.find('.rv-details');
 
-        stateManager.setCloseCallback('mainDetails', closeDetails);
-
         /**
         * Set the selected item from the array of items if previously set.
         * @private


### PR DESCRIPTION
## Description
The point information panel should not be closed by clicking on its icon in the appbar. See here https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1431 and here https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1399 for more information.

## Testing
Eyeballing.

## Documentation
Not needed.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] ~~release notes have been updated~~ not needed as the bug was introduced after v1.3.1 release
- [x] PR targets the correct release version

The point information panel can only be closed by the close button located
inside the panel itself.

Closes #1399

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1466)
<!-- Reviewable:end -->
