### PR TITLE
feat(datagrid): add ui for datagrid filters for large layout

### DIFF
--- a/src/app/geo/layer-record.class.js
+++ b/src/app/geo/layer-record.class.js
@@ -214,7 +214,7 @@
                 const fieldNameArray = [];
                 const columns = layerData.fields
                     .filter(field =>
-                        // assuming there is at least one attribute - empty attribute budnle promises should be rejected, so it never even gets this far
+                        // assuming there is at least one attribute - empty attribute bundle promises should be rejected, so it never even gets this far
                         // filter out fields where there is no corresponding attribute data
                         attributes.features[0].attributes.hasOwnProperty(field.name))
                     .map(field => {
@@ -224,6 +224,7 @@
                         }
                         return {
                             data: field.name,
+                            name: field.name, // add name so we can easely get column from datatables
                             title: field.alias || field.name
                         };
                     });

--- a/src/app/ui/filters/filters-number-only.directire.js
+++ b/src/app/ui/filters/filters-number-only.directire.js
@@ -1,0 +1,40 @@
+(() => {
+    'use strict';
+
+    /**
+     * @module rvFiltersNumberOnly
+     * @memberof app.ui
+     * @restrict E
+     * @description
+     *
+     * The `rvFiltersNumberOnly` directive is use to enforce numbers input tag (http://codepen.io/apuchkov/pen/ILjFr).
+     */
+    angular
+        .module('app.ui.filters')
+        .directive('rvFiltersNumberOnly', rvFiltersNumberOnly);
+
+    function rvFiltersNumberOnly() {
+        return {
+            require: 'ngModel',
+            link: (scope, element, attr, ngModelCtrl) => {
+                function fromUser(text) {
+                    if (text) {
+                        const numRegex = /-?(\d+)?(\.)?(\d+)?/g;
+                        const transformedInput = text.match(numRegex);
+
+                        if (transformedInput !== null) {
+                            ngModelCtrl.$setViewValue(transformedInput[0]);
+                        } else {
+                            ngModelCtrl.$setViewValue(text.slice(0, -1));
+                        }
+                        ngModelCtrl.$render();
+
+                        return transformedInput;
+                    }
+                    return undefined;
+                }
+                ngModelCtrl.$parsers.push(fromUser);
+            }
+        };
+    }
+})();

--- a/src/app/ui/filters/filters.service.js
+++ b/src/app/ui/filters/filters.service.js
@@ -34,7 +34,11 @@
             filterTimeStamps,
             filter: {
                 isActive: false
-            }
+            },
+            onFilterStringChange: debounceService.registerDebounce(onFilterStringChange, 700, false),
+            onFilterNumberChange: debounceService.registerDebounce(onFilterNumberChange, 700, false),
+            onFilterDateChange: onFilterDateChange,
+            preventSorting: preventSorting
         };
 
         init();
@@ -55,6 +59,53 @@
                 filteredState().then(() => {
                     filterTimeStamps.onChanged = Date.now();
                 });
+            }
+        }
+
+        /**
+         * Apply on string filter change callback
+         *
+         * @function onFilterStringChange
+         * @param   {String}   column   column name
+         * @param   {String}   value   search filter
+         */
+        function onFilterStringChange(column, value) {
+            console.log(`string - ${column}: ${value}`);
+        }
+
+        /**
+         * Apply on number filter change callback
+         *
+         * @function onFilterNumberChange
+         * @param   {String}   column   column name
+         * @param   {Number}   min   minimum number search filter
+         * @param   {Number}   max   maximum number search filter
+         */
+        function onFilterNumberChange(column, min, max) {
+            console.log(`number - ${column}: ${min} - ${max}`);
+        }
+
+        /**
+         * Apply on date filter change callback
+         *
+         * @function onFilterDateChange
+         * @param   {String} column   column name
+         * @param   {Date}   min   minimum date search filter
+         * @param   {Date}   max   maximum date search filter
+         */
+        function onFilterDateChange(column, min, max) {
+            console.log(`date - ${column}: ${min} - ${max}`);
+        }
+
+        /**
+         * Prevent column sort when filter is clicked
+         *
+         * @function preventSorting
+         */
+        function preventSorting(event) {
+            if (event.type === 'click' || (event.type === 'keypress' && event.which === 13)) {
+                event.stopPropagation(true);
+                event.preventDefault(true);
             }
         }
 

--- a/src/config.en-CA.json
+++ b/src/config.en-CA.json
@@ -131,6 +131,12 @@
   },
   "layers": [
     {
+      "id":"DateLayer",
+      "name":"Date layer field",
+      "layerType":"esriFeature",
+      "url":"http://geoappext.nrcan.gc.ca/arcgis/rest/services/NEB/Incident/MapServer/0"
+    },
+    {
       "id":"scaleDep",
       "name":"Air Ozone Scale Dep",
       "layerType":"esriFeature",

--- a/src/content/styles/modules/_filters.scss
+++ b/src/content/styles/modules/_filters.scss
@@ -28,7 +28,17 @@
                     flex-direction: column;
                     min-height: 0; // Firefox fix; otherwise div won't shrink: http://stackoverflow.com/questions/27424831/firefox-flexbox-overflow
 
-                    .dataTables_scrollHead {}
+                    // for filters in the header for large layout
+                    .dataTables_scrollHead {
+
+                        @include largeFilters;
+
+                        @include media($rv-lg) {
+                            .rv-filter-string, .rv-filter-number, .rv-filter-date {
+                                display: flex;
+                            }
+                        }
+                    }
 
                     .dataTables_scrollBody {
                         flex: 1; // this needed for the body to fill available space
@@ -65,6 +75,26 @@
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@mixin largeFilters {
+
+    .rv-filter-string, .rv-filter-number, .rv-filter-date {
+        display: none;
+        height: 35px;
+    }
+
+    md-input-container {
+        margin: 0;
+
+        input {
+            &[placeholder] {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
             }
         }
     }

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -19,6 +19,11 @@ rv-truncate directive show less,rv-truncate.showLess,Hide,Masquer
 Tooltip text for Zoom To Feature,filter.tooltip.zoom,Zoom To Feature,Zoom à l'élément
 Tooltip text for Details,filter.tooltip.description,Details,Détails
 Tooltip text for No Zoom Projection,filter.tooltip.nozoom,Data in custom projection. Cannot zoom to feature.,La donnée utilise une projection personnalisée. Le zoom à l'entité n'est pas supporté.
+DataTable string filter placeholder,filter.placeholder.string,text,texte
+DataTable min filter placeholder,filter.placeholder.min,min,min
+DataTable max filter placeholder,filter.placeholder.max,max,max
+DataTable date min filter placeholder,filter.placeholder.datemin, date min,date min
+DataTable date max filter placeholder,filter.placeholder.datemax,date max,date max
 DataTable text for Processing,filter.default.label.processing,Processing...,Traitement en cours...
 DataTable text for Search,filter.default.label.search,Search: ,"Rechercher : "
 DataTable text for Length Menu,filter.default.label.length.menu,Show _MENU_ entries,Afficher _MENU_ éléments


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Create filters for large view viewer (Filters are on the table and they are removed for small display). Tu use with catalog layers, filter of type string, number range and date range have been added. For selection filter it should be added when we will have thematic map.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Tested it in Chrome, Firefox and Safari

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->
Added a layer "Date layer field" where all type of filter can be test. In the console, when value change, the value and the name of the field on trigger the change should be logged.

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Closes #1417

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1477)
<!-- Reviewable:end -->
