### PR TITLE
fix(ui): share dialog opens

### DIFF
--- a/src/app/ui/sidenav/sidenav.service.js
+++ b/src/app/ui/sidenav/sidenav.service.js
@@ -35,6 +35,7 @@
         return service;
 
         function ShareController($mdDialog, $rootElement, $http, configService) {
+            'ngInject';
             const self = this;
 
             // url cache to avoid unneeded API calls


### PR DESCRIPTION
## Description
Share dialog would not open as 'ngInject' was missing.

## Testing
Eyeballing.

## Documentation
Not needed.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version (current v1.4)

Restored missing 'ngInject' from the share controller.

Closes #1478

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1479)
<!-- Reviewable:end -->
