### PR TITLE
feat(ui): focus lost or changed on layer dropdown

### DIFF
--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -1,7 +1,7 @@
 /* global RV, jQuery */
 ((RV, jQuery) => {
     // delay in milliseconds from time focus is lost to when action is taken
-    const focusoutDelay = 800;
+    const focusoutDelay = 200;
     // all the possible states a viewer can be in - only one at any given time
     const statuses = {
         NONE: undefined,
@@ -294,6 +294,12 @@
         const evtTarget = $(event.target);
         const viewer = viewerGroup.contains(evtTarget);
 
+        // fixes issue where md-backdrop is briefly created outside the viewer, and on click makes the waiting dialog appear
+        // ignoring the click when it happens on an md-backdrop
+        if (evtTarget.is('md-backdrop')) {
+            return;
+        }
+
         if (viewer) {
             viewer.setStatus(statuses.ACTIVE);
             evtTarget
@@ -410,7 +416,12 @@
             // leaves unexpectedly, focus can be manually set and we don't need to be back through history
             // Animations often cause focus loss when, for example, one element is being hidden while the
             // element we want focus on is being shown.
-            focusoutTimerCancel = setTimeout(() => shiftFocus(false, true), focusoutDelay);
+            focusoutTimerCancel = setTimeout(() => {
+                // check if focus is still off the viewer after the delay - if so shift focus back
+                if (!viewer.contains($(document.activeElement))) {
+                    shiftFocus(false, true);
+                }
+            }, focusoutDelay);
         }
     }
 


### PR DESCRIPTION
## Description
Fixed issues with focus related to dropdown menus. Also reduced focus
recovery time from 800ms to 200ms since basemap selector moved to left
side which when on the right was the original cause for the focus recovery time increase.

Closes #1469

## Testing
👀 

## Documentation
inline where needed

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1500)
<!-- Reviewable:end -->
