### PR TITLE
feat(core): use config for mannav cluster

### DIFF
--- a/schemas/fgpv_schema_v1_4.json
+++ b/schemas/fgpv_schema_v1_4.json
@@ -310,10 +310,6 @@
                 },
                 "boundingBox": {
                     "$ref": "#/definitions/boundingBoxOptionNode"
-                },
-                "symbologyStack": {
-                    "$ref": "#/definitions/option",
-                    "description": "Allows symbology stack to be opened from menu"
                 }
             },
             "additionalProperties": false
@@ -366,10 +362,6 @@
                 "data": {
                     "$ref": "#/definitions/option",
                     "description": "Enables data panel"
-                },
-                "symbologyStack": {
-                    "$ref": "#/definitions/option",
-                    "description": "Allows symbology stack to be opened from menu"
                 }
             },
             "additionalProperties": false
@@ -419,10 +411,6 @@
                 "data": {
                     "$ref": "#/definitions/option",
                     "description": "Enables data panel"
-                },
-                "symbologyStack": {
-                    "$ref": "#/definitions/option",
-                    "description": "Allows symbology stack to be opened from menu"
                 }
             },
             "additionalProperties": false
@@ -468,10 +456,6 @@
                 },
                 "query": {
                     "$ref": "#/definitions/queryOptionNode"
-                },
-                "symbologyStack": {
-                    "$ref": "#/definitions/option",
-                    "description": "Allows symbology stack to be opened from menu"
                 }
             },
             "additionalProperties": false
@@ -497,10 +481,6 @@
                 },
                 "query": {
                     "$ref": "#/definitions/queryOptionNode"
-                },
-                "symbologyStack": {
-                    "$ref": "#/definitions/option",
-                    "description": "Allows symbology stack to be opened from menu"
                 }
             },
             "required": ["id"],
@@ -518,10 +498,6 @@
                 },
                 "query": {
                     "$ref": "#/definitions/queryOptionNode"
-                },
-                "symbologyStack": {
-                    "$ref": "#/definitions/option",
-                    "description": "Allows symbology stack to be opened from menu"
                 }
             },
             "required": ["index"],
@@ -559,11 +535,7 @@
                     "$ref": "#/definitions/option",
                     "description": "Enables data panel"
                 },
-                "outfields": { "type": "string", "default": "*", "description": "A comma separated list of attribute names that should be requested on query." },
-                "symbologyStack": {
-                    "$ref": "#/definitions/option",
-                    "description": "Allows symbology stack to be opened from menu"
-                }
+                "outfields": { "type": "string", "default": "*", "description": "A comma separated list of attribute names that should be requested on query." }
             },
             "required": ["index"],
             "additionalProperties": false
@@ -746,7 +718,7 @@
 
         "navBarButtons": {
             "type": "string",
-            "enum": ["geoLocator", "marquee", "home", "history", "basemap", "help"]
+            "enum": ["geoLocator", "marquee", "home", "history", "basemap"]
         },
 
         "mapComponentsNode": {
@@ -763,7 +735,7 @@
     },
 
     "properties": {
-        "version": { "type": "string", "enum": [ "1.6", "1.5", "1.4", "1.3","1.2","1.1.0","1.0" ], "description": "The schema version used to validate the configuration file.  The schema should enumerate the list of versions accepted by this version of the viewer." },
+        "version": { "type": "string", "enum": [ "1.4", "1.3","1.2","1.1.0","1.0" ], "description": "The schema version used to validate the configuration file.  The schema should enumerate the list of versions accepted by this version of the viewer." },
         "language": { "type": "string", "enum": [ "en", "fr", "es" ], "description": "ISO 639-1 code indicating the language of strings in the schema file" },
         "theme": { "type": "string", "enum": [ "default" ], "default": "default", "description": "UI theme of the viewer" },
         "logoUrl": { "type": "string", "description": "An optional image to be used in the place of the default viewer logo" },
@@ -846,11 +818,6 @@
                 "initialBasemapId": {
                     "type": "string",
                     "description": "Initial basemap to load. If not supplied viewer will select any basemap."
-                },
-                "restrictNavigation": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Will restrict the user from panning beyond the maximum extent."
                 }
             },
             "required": ["lods"]

--- a/src/app/ui/appbar/appbar.html
+++ b/src/app/ui/appbar/appbar.html
@@ -14,7 +14,7 @@
     <div class="rv-appbar-title">
         <h2 class="md-headline" translate ng-if="self.stateManager.state.mainToc.active">appbar.headline.layers</h2>
         <h2 class="md-headline" translate ng-if="self.stateManager.state.mainLoaderFile.active">import.file.title</h2>
-        <h2 class="md-headline" translate ng-if="self.stateManager.state.mainLoaderService.active">Import Service</h2>
+        <h2 class="md-headline" translate ng-if="self.stateManager.state.mainLoaderService.active">import.service.title</h2>
         <h2 class="md-headline" translate ng-if="self.stateManager.state.mainDetails.active">appbar.tooltip.pointInfo</h2>
     </div>
 

--- a/src/app/ui/mapnav/mapnav.service.js
+++ b/src/app/ui/mapnav/mapnav.service.js
@@ -1,6 +1,20 @@
 (() => {
     'use strict';
 
+    const MAPNAV_CONFIG_DEFAULT = {
+        zoom: 'buttons', // 'all', 'slider', 'buttons'
+        extra: [
+            // NOTE: marquee and history buttons kept as options for future functionality
+            // possible values
+            // 'geoLocation',
+            // 'marquee',
+            // 'home',
+            // 'history',
+            // 'basemap'
+            // 'help'
+        ]
+    };
+
     /**
      * @module mapNavigationService
      * @memberof app.ui
@@ -20,24 +34,15 @@
      * @private
      * @return {object} service object
      */
-    function mapNavigationService($rootElement, stateManager, geoService, $rootScope,
-        locateService, helpService, basemapService) {
+    function mapNavigationService(stateManager, geoService, $rootScope,
+        locateService, helpService, basemapService, events, configService) {
+
         const service = {
-            // FIXME: this config snippet should obvisouly come from config service
-            config: {
-                zoom: 'buttons', // 'all', 'slider', 'buttons'
-                extra: [
-                    // NOTE: marquee and history buttons kept as options for future functionality
-                    'geoLocation',
-                    // 'marquee',
-                    'home',
-                    // 'history',
-                    // 'basemap'
-                    'help'
-                ]
-            },
+            config: {},
             controls: {}
         };
+
+        init();
 
         // navigation controls presets
         service.controls = {
@@ -56,7 +61,7 @@
                 tooltip: 'nav.tooltip.zoomOut',
                 action: () => geoService.shiftZoom(-1)
             },
-            geoLocation: {
+            geoLocator: {
                 label: 'nav.label.geoLocation',
                 icon: 'maps:my_location',
                 tooltip: 'nav.tooltip.geoLocation',
@@ -111,5 +116,30 @@
         return service;
 
         /*************/
+
+        /**
+         * Set up initial mapnav cluster buttons.
+         * Set up language change listener to update the buttons when a new config is loaded.
+         *
+         * @function init
+         * @private
+         */
+        function init() {
+            setupMapnavButton();
+
+            // if language change, reset menu item
+            $rootScope.$on(events.rvLangSwitch, setupMapnavButton);
+        }
+
+        /**
+         *
+         *
+         * @function setupMapnavButton
+         * @function private
+         */
+        function setupMapnavButton() {
+            configService.getCurrent().then(data =>
+                    angular.extend(service.config, MAPNAV_CONFIG_DEFAULT, data.navBar));
+        }
     }
 })();

--- a/src/app/ui/mapnav/mapnav.service.js
+++ b/src/app/ui/mapnav/mapnav.service.js
@@ -132,7 +132,7 @@
         }
 
         /**
-         *
+         * Merges a mapnav snippet from the config file with the default configuration. This is a shallow extend and the top-level properties (`extra` and `button` will be overwritten). Supplying an empty array as `extra` will remove all the extra buttons from the cluster.
          *
          * @function setupMapnavButton
          * @function private

--- a/src/config.en-CA.json
+++ b/src/config.en-CA.json
@@ -419,10 +419,8 @@
     "zoom": "buttons",
     "extra": [
       "geoLocator",
-      "marquee",
       "home",
-      "history",
-      "basemap"
+      "help"
     ]
   }
 }

--- a/src/config.fr-CA.json
+++ b/src/config.fr-CA.json
@@ -359,7 +359,8 @@
       "marquee",
       "home",
       "history",
-      "basemap"
+      "basemap",
+      "help"
     ]
   }
 }


### PR DESCRIPTION
## Description
Mapnav cluster buttons now configured by the config file (default English config has geoLocation, home and help; default French has geoLocation, home, help, basemap, history, and marquee buttons).

## Testing
Eyeballing.

## Documentation
Source code comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

Closes #1481

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1503)
<!-- Reviewable:end -->
