### PR TITLE
fix(ui): remove unsused buttons from the mapnav

### DIFF
--- a/src/config-all.en.json
+++ b/src/config-all.en.json
@@ -386,10 +386,8 @@
     "zoom": "buttons",
     "extra": [
       "geoLocator",
-      "marquee",
       "home",
-      "history",
-      "basemap"
+      "help"
     ]
   }
 }

--- a/src/config-demo.json
+++ b/src/config-demo.json
@@ -318,10 +318,8 @@
     "zoom": "buttons",
     "extra": [
       "geoLocator",
-      "marquee",
       "home",
-      "history",
-      "basemap"
+      "help"
     ]
   }
 }

--- a/src/config.fr-CA.json
+++ b/src/config.fr-CA.json
@@ -356,10 +356,7 @@
     "zoom": "buttons",
     "extra": [
       "geoLocator",
-      "marquee",
       "home",
-      "history",
-      "basemap",
       "help"
     ]
   }

--- a/src/config.rcs.en-CA.json
+++ b/src/config.rcs.en-CA.json
@@ -367,10 +367,8 @@
     "zoom": "buttons",
     "extra": [
       "geoLocator",
-      "marquee",
       "home",
-      "history",
-      "basemap"
+      "help"
     ]
   }
 }

--- a/src/config.rcs.fr-CA.json
+++ b/src/config.rcs.fr-CA.json
@@ -313,10 +313,8 @@
     "zoom": "buttons",
     "extra": [
       "geoLocator",
-      "marquee",
       "home",
-      "history",
-      "basemap"
+      "help"
     ]
   }
 }


### PR DESCRIPTION
## Description
Remove unused buttons from the mapnav cluster (basemap selector, history, and marquee).

## Testing
Nope.

## Documentation
None needed.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

Closes #1517

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1518)
<!-- Reviewable:end -->
