### PR TITLE
feat(ui): updates to export dialog UI

### DIFF
--- a/src/app/ui/export/export.html
+++ b/src/app/ui/export/export.html
@@ -7,7 +7,7 @@
                     ng-if="self.exportSizes.isCustomOptionSelected()">
 
                     <h4 class="md-title">{{ 'export.size.custom' | translate }}</h4>
-
+                    <p class="md-caption">{{ 'export.custom.note1' | translate }}</p>
                     <div class="rv-container" layout="column">
                         <div layout="row" layout-wrap>
                             <md-input-container ng-disabled="self.isError">
@@ -54,11 +54,11 @@
                         </div>
                         <div layout="row">
                             <span flex></span>
-
                             <md-button
+                                ng-disabled="self.exportSizes.isCustomOptionUpdated() || (!exportForm.customSizeWidth.$viewValue && !exportForm.customSizeHeight.$viewValue && !self.exportSizes.customOption.height)"
                                 ng-click="self.exportSizes.resetTemporaryOption()"
                                 class="rv-button-square">
-                                {{ 'export.cancel' | translate }}
+                                {{ 'export.undo' | translate }}
                             </md-button>
 
                             <md-button
@@ -174,12 +174,18 @@
                 {{ 'export.close' | translate }}
             </md-button>
 
-            <md-button
-                class="rv-button-square md-raised md-primary"
-                ng-click="self.saveImage()"
-                ng-disabled="self.isDownloadBlocked()">
-                {{ 'export.download' | translate }}
-            </md-button>
+            <!-- div needed to shop tooltip when button is disabled, see
+            https://github.com/angular/material/issues/1667#issuecomment-224651024
+            -->
+            <div>
+                <md-button
+                    class="rv-button-square md-raised md-primary"
+                    ng-click="self.saveImage()"
+                    ng-disabled="self.isDownloadBlocked()">
+                    {{ 'export.download' | translate }}
+                </md-button>
+                <md-tooltip ng-if="self.exportSizes.isCustomOptionSelected() && self.isDownloadBlocked()">{{ 'export.custom.note2' | translate }}</md-tooltip>
+            </div>
         </md-dialog-actions>
     </form>
 </md-dialog>

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -179,7 +179,7 @@ Geometry types,geometry.type.esriGeometryPolyline, line|lines, ligne|lignes
 ,export.close,Close,Fermer
 ,export.save,Save,Sauver
 ,export.download,Download,Télécharger
-,export.cancel,Cancel,Annuler
+,export.undo,Undo,Annuler
 ,export.title,Enter Title,Titre
 ,export.error.timeout,"Connection timed out. Stopping export task.","Connexion a expiré. Tâche d’exportation arrêt."
 ,export.error.tainted,"We can't save the export image directly (same-origin policy exception). You can right click the image and select ""Save As..."" if supported by your browser.","Nous ne pouvons pas enregistrer l’image directement (exception de politique de même origine). Vous pouvez cliquez sur le bouton droit de la souris sur l’image et sélectionnez « Enregistrer sous... » si cela est pris en charge par votre navigateur."
@@ -205,6 +205,8 @@ Geometry types,geometry.type.esriGeometryPolyline, line|lines, ligne|lignes
 ,export.size.small, Small, Petit
 ,export.size.medium, Medium, Médium
 ,export.size.custom, Custom size, Format personnalisé
+,export.custom.note1,Custom sizes apply to the map image - the actual exported image size will vary based on the export options selected.,Les tailles personnalisées s'appliquent à l'image cartographique - la taille réelle de l'image exportée varie en fonction des options d'exportation sélectionnées.
+,export.custom.note2,You must first click on the Generate button below to create your custom size before downloading is enabled.,Vous devez d'abord cliquer sur le bouton Générer ci-dessous pour créer votre taille personnalisée avant que le téléchargement ne soit activé.
 ,import.title,Add Layer,Ajouter une couche
 ,import.file.title,Import File,Importer un fichier
 ,import.file.upload.title,Upload data,Charger des données


### PR DESCRIPTION
## Description
- [x] Change the "Cancel" label to "Undo" when selecting a custom size option.
- [x] Disable the "Undo" button until the user makes a modification to the custom size option.
- [x] Add an explanation that the selected size is for the map image only; it's not the size of the resulting image.
- [x] Add an explanation in the form of a tooltip on the "download" button that when selecting a custom size, the export image needs to be generated anew and that the user must trigger it (by clicking on the "generate" button).

Closes #1471

## Testing
A lot of :eye: balling

## Documentation
Inline where needed

## Checklist

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1529)
<!-- Reviewable:end -->
