### PR TITLE
fix(export): Safari open a new tab on save

### DIFF
--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -13,6 +13,12 @@
     // test user browser, true if IE false otherwise
     RV.isIE = /Edge\/|Trident\/|MSIE /.test(window.navigator.userAgent);
 
+    // Safari problem with file saver: https://github.com/eligrey/FileSaver.js/#supported-browsers
+    // test if it is Safari browser on desktop and it if is, show a message to let user know we can't automatically save the file
+    // they have to save it manually the same way as when the canvas is tainted.
+    RV.isSafari = /^((?!chrome|android|crios|fxios).)*safari/i.test(navigator.userAgent) &&
+        !/(iPhone|iPod|iPad)/i.test(navigator.platform);
+
     // set these outside of the initial creation in case the page defines RV for setting
     // properties like dojoURL
     Object.assign(RV, {

--- a/src/app/ui/export/export.service.js
+++ b/src/app/ui/export/export.service.js
@@ -1,4 +1,4 @@
-/* global saveAs */
+/* global saveAs, RV */
 (() => {
     'use strict';
 
@@ -145,6 +145,7 @@
              * Checks if anything is blocking the image download. The following things will block the download:
              *  - component graphics being generated
              *  - errors (tainted canvas is an error)
+             *  - Safari browser on desktop computer
              *  - if the custom size option was modified but not saved
              *  - if the graphics were generated for an size option different from the currently selected one
              *
@@ -155,6 +156,7 @@
             function isDownloadBlocked() {
                 return self.isGenerating() ||
                     self.isError ||
+                    self.isSafari ||
                     (self.exportSizes.isCustomOptionSelected() && !self.exportSizes.isCustomOptionUpdated()) ||
                     self.lastUsedSizeOption !== self.exportSizes.selectedOption;
             }
@@ -249,9 +251,14 @@
                 }
 
                 try {
-                    canvas.toBlob(blob => {
-                        saveAs(blob, `${fileName}.png`);
-                    });
+                    if (!RV.isSafari) {
+                        canvas.toBlob(blob => {
+                            saveAs(blob, `${fileName}.png`);
+                        });
+                    } else {
+                        showToast('error.safari');
+                        self.isSafari = true;
+                    }
                 } catch (error) {
                     // show error; nothing works
                     self.isError = true;

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -188,6 +188,7 @@ Geometry types,geometry.type.esriGeometryPolyline, line|lines, ligne|lignes
 ,export.error.minheight, Too small. {{min}} px minimum., Trop petit. {{min}} px minimum.
 ,export.error.maxwidth, Too large. {{max}} px maximum., Trop grand. {{max}} px maximum.
 ,export.error.maxheight, Too large. {{max}} px maximum., Trop grand. {{max}} px maximum.
+,export.error.safari,"We can't save the export image directly in Safari. You can right click the image and select ""Save Page As..."".","Nous ne pouvons pas enregistrer l’image directement dans Safari. Vous pouvez cliquez sur le bouton droit de la souris sur l’image et sélectionnez « Enregistrer la page sous... »."
 ,export.retry,Retry,Réessayez
 ,export.size.customwidth, Width (pixels), Largeur (pixels)
 ,export.size.customheight, Height (pixels), Hauteur (pixels)


### PR DESCRIPTION
## Description
Safari doesn't save the image when exported. It's open in a new tab. To solve this, we catch the save task and show a message on how to save the image like for tainted canvas error (#1398)

## Testing
Tested in Chrome and Safari IOS to make it behave as before. Test in Safari OSX to see the message

## Documentation
Inline

## Checklist

- [X] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1534)
<!-- Reviewable:end -->
