### PR TITLE
fix(loader): auto focus on open and close

### DIFF
--- a/src/app/ui/loader/loader-file.directive.js
+++ b/src/app/ui/loader/loader-file.directive.js
@@ -27,7 +27,7 @@
         return directive;
     }
 
-    function Controller($scope, $q, $timeout, stateManager, Stepper, geoService, LayerBlueprint, Geo) {
+    function Controller($scope, $q, $timeout, stateManager, Stepper, geoService, LayerBlueprint, Geo, $rootElement) {
         'ngInject';
         const self = this;
 
@@ -365,6 +365,11 @@
             // reset the loader after closing the panel
             stepper.reset().start();
             stateManager.setActive('mainToc');
+
+            // there is a bug with Firefox and Safari on a Mac. They don't focus back to add layer when close
+            $timeout(() => {
+                $rootElement.find('.rv-loader-add').first().focus(true);
+            }, 0);
         }
     }
 })();

--- a/src/app/ui/loader/loader-file.html
+++ b/src/app/ui/loader/loader-file.html
@@ -5,6 +5,7 @@
     flow-drag-leave="self.dropActive = false"
     flow-prevent-drop
     class="rv-file-drop"
+    rv-trap-focus="{{ ::self.appID }}"
     ng-class="{'rv-file-drop-active': self.dropActive}">
 
     <div

--- a/src/app/ui/loader/loader-menu.directive.js
+++ b/src/app/ui/loader/loader-menu.directive.js
@@ -28,7 +28,7 @@
         return directive;
     }
 
-    function Controller(stateManager, appInfo) {
+    function Controller(stateManager, appInfo, $timeout, $rootElement) {
         'ngInject';
         const self = this;
 
@@ -45,14 +45,27 @@
             // TODO: hack
             stateManager.setActive({
                 mainLoaderFile: true
-            });
+            }).then(() => { setFocus('rv-loader-file'); });
         }
 
         function openServiceLoader() {
             // TODO: hack
             stateManager.setActive({
                 mainLoaderService: true
-            });
+            }).then(() => { setFocus('rv-loader-service'); });
+        }
+
+        /**
+         * Sets focus on the close button when panel open.
+         *
+         * @function setFocus
+         * @private
+         * @param   {Object}    name     the class name to find button to focus on
+         */
+        function setFocus(name) {
+            $timeout(() => {
+                $rootElement.find(`${name} .rv-header-float button`).first().focus(true);
+            }, 0);
         }
     }
 })();

--- a/src/app/ui/loader/loader-menu.html
+++ b/src/app/ui/loader/loader-menu.html
@@ -4,7 +4,7 @@
 
     <md-button
         translate translate-attr-aria-label="import.title"
-        class="md-icon-button primary"
+        class="md-icon-button primary rv-loader-add"
         ng-click="$mdOpenMenu($event)">
         <md-tooltip>{{ 'import.title' | translate }}</md-tooltip>
         <md-icon md-svg-src="content:add"></md-icon>

--- a/src/app/ui/loader/loader-service.directive.js
+++ b/src/app/ui/loader/loader-service.directive.js
@@ -27,7 +27,7 @@
         return directive;
     }
 
-    function Controller($timeout, stateManager, geoService, Geo, Stepper, LayerBlueprint) {
+    function Controller($timeout, stateManager, geoService, Geo, Stepper, LayerBlueprint, $rootElement) {
         'ngInject';
         const self = this;
 
@@ -253,6 +253,11 @@
             // reset the loader after closing the panel
             stepper.reset().start();
             stateManager.setActive('mainToc');
+
+            // there is a bug with Firefox and Safari on a Mac. They don't focus back to add layer when close
+            $timeout(() => {
+                $rootElement.find('.rv-loader-add').first().focus(true);
+            }, 0);
         }
     }
 })();

--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -1,4 +1,4 @@
-<rv-content-pane rv-trap-focus close-panel="self.closeLoaderService()" floating-header="true">
+<rv-content-pane close-panel="self.closeLoaderService()" floating-header="true" rv-trap-focus="{{ ::self.appID }}">
 
     <div class="rv-loader-service">
         <rv-stepper-item

--- a/src/content/styles/modules/_content-pane.scss
+++ b/src/content/styles/modules/_content-pane.scss
@@ -48,7 +48,8 @@
                 /*background: linear-gradient(to bottom, rgba(255,255,255,1) 30%,rgba(255,255,255,0.62) 60%, rgba(255,255,255,0) 100%);*/
                 align-items: center;
 
-                .md-button {
+                // add not md-focused because if, it is overwritten and focus background-color is not applied
+                .md-button:not(.md-focused) {
                     background: radial-gradient(ellipse at center, rgba(255,255,255,1) 30%,rgba(255,255,255,0.32) 100%);
                 }
             }


### PR DESCRIPTION
Set focus to close button on open. Set focus to add button on close (bug for Firefox and Safari on Mac)

Close #1374

## Description
Issues #1374. Added auto focus on close because of a bug with Firefox and Safari on a Mac. When closed, the focus doesn't go to add button.

## Testing
Chrome, Firefox and Safari

## Documentation
Inline

## Checklist

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1535)
<!-- Reviewable:end -->
