### PR TITLE
fix(filters): Datatables column jumping when sorting

### DIFF
--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -166,6 +166,31 @@
                         .filter(idx => idx > -1);
                 };
 
+                // set width from field length if it is a string field type. If it is the oid field,
+                // set width to 100px because we have the oid, the details and zoom to button. If it is
+                // another type of field, set width to be the title.
+                displayData.columns.forEach(column => {
+                    const field = displayData.fields.find(field => field.name === column.data);
+
+                    if (typeof field !== 'undefined') {
+                        if (field.type === 'esriFieldTypeString') {
+                            const width = getColumnWidth(column.title, field.length);
+                            column.width = `${width}px`;
+                            column.render = renderEllipsis(width);
+                        } else if (field.type === 'esriFieldTypeOID') {
+                            // set column to be 100px width because of details and zoom to buttons
+                            column.width = '100px';
+                        } else {
+                            const width = getColumnWidth(column.title);
+                            column.width = `${width}px`;
+                            column.render = renderEllipsis(width);
+                        }
+                    } else {
+                        // set symbol column width
+                        column.width = '30px';
+                    }
+                });
+
                 // ~~I hate DataTables~~ Datatables are cool!
                 self.table = tableNode
                     .on('init.dt', callbacks.onTableInit)
@@ -200,6 +225,91 @@
                         ],
                         oLanguage: oLang
                     });
+
+                /**
+                 * Get column width from column title and field length.
+                 * @function getColumnWidth
+                 * @private
+                 * @param {Object} title    column title
+                 * @param {Object} length   optional column length (characters)
+                 * @param {Object}  maxLength   optional maximum column length (pixels)
+                 * @return {Number} width    width of the column
+                 */
+                function getColumnWidth(title, length = 0, maxLength = 200) {
+                    // get title length (minimum 50px)
+                    let metricsTitle = getTextWidth(title);
+                    metricsTitle = metricsTitle < 50 ? 50 : metricsTitle;
+
+                    // get column length (only type string have length)
+                    if (length) {
+                        // generate a string with that much characters and get width
+                        let metricsContent = getTextWidth(Array(length).join('x'));
+
+                        // set the column length from field length (maximum will be maxLength)
+                        metricsContent = metricsContent <= maxLength ? metricsContent : maxLength;
+
+                        // check if it is lower then title length. If so, use title length
+                        metricsTitle = metricsContent < metricsTitle ? metricsTitle : metricsContent;
+                    }
+
+                    return metricsTitle;
+                }
+
+                /**
+                 * Render long text width ellipsis (https://datatables.net/blog/2016-02-26)
+                 * @function RenderEllipsis
+                 * @private
+                 * @param {Object} width    column width
+                 * @return {String} text    text for td element or string who contain html element
+                 */
+                function renderEllipsis(width) {
+                    const esc = (text) => {
+                        return text
+                            .replace(/&/g, '&amp;')
+                            .replace(/</g, '&lt;')
+                            .replace(/>/g, '&gt;')
+                            .replace(/"/g, '&quot;');
+                    };
+
+                    return (text, type) => {
+                        // order, search and type get the original data
+                        if (type !== 'display') {
+                            return text;
+                        }
+
+                        if (typeof text !== 'number' && typeof text !== 'string') {
+                            return text;
+                        }
+
+                        text = text.toString(); // cast numbers
+
+                        // if text width smaller then column width, return text
+                        if (getTextWidth(text) < width) {
+                            return text;
+                        }
+
+                        // for wcag we add a text input read only. This element is focusable so we can have tooltips.
+                        return `<input type="text" readonly title="${esc(text)}" value="${esc(text)}"
+                                    class="rv-render-ellipsis"></input>
+                                <span class="rv-render-tooltip">${esc(text)}</span>`;
+                    };
+                }
+
+                /**
+                 * Get text width (http://stackoverflow.com/questions/118241/calculate-text-width-with-javascript)
+                 * @function getTextWidth
+                 * @private
+                 * @param {String} input    text ot calculate width from
+                 * @return {Number} width    text width
+                 */
+                function getTextWidth(input) {
+                    // re-use canvas object for better performance
+                    const canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement('canvas'));
+                    const context = canvas.getContext('2d');
+                    context.font = '14px Roboto';
+
+                    return context.measureText(input).width;
+                }
 
                 /**
                  * Table initialization callback. This will hide the loading indicator.

--- a/src/content/styles/modules/_filters.scss
+++ b/src/content/styles/modules/_filters.scss
@@ -16,6 +16,10 @@
             height: 100%;
             min-height: 0; // Firefox fix; otherwise div won't shrink: http://stackoverflow.com/questions/27424831/firefox-flexbox-overflow
 
+            table {
+                table-layout: fixed; // make autowidth: false works for datatable https://datatables.net/forums/discussion/30530/set-fixed-column-width
+            }
+
             .dataTables_wrapper {
                 height: 100%;
                 display: flex !important; // there was an update in datatables styles that was overriding `flex` with `block`
@@ -35,6 +39,34 @@
                         background: lighten($divider-color, 20%);
 
                         tbody {
+
+                            // ellipsis renderer when text is longer then field width
+                            .rv-render-ellipsis {
+                                width: 100%;
+                                border: none;
+                                background: none;
+                                padding: 0;
+                                font-size: 14px;
+                                cursor: text;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                            }
+
+                            .rv-render-tooltip {
+                                display: none;
+                            }
+
+                            // on keyboard focus show tooltip to be wcag compliant
+                            .rv-render-ellipsis:focus + .rv-render-tooltip {
+                                display: block;
+                                position: absolute;
+                                border: 1px solid #D3D3D3;
+                                background-color: #F2F2F2;
+                                padding: 2px 5px;
+                                box-shadow: 1px 1px 2px #CCC;
+                                max-width: 250px;
+                                white-space: normal;
+                            }
 
                             .rv-data {
                                 // flex: flex-grow flex-shrink flex-basis; IE sets flex-basis as 0px which collapses the span instead of 0% as Chrome does;


### PR DESCRIPTION
## Description

Datatable jump when sorting field. To solve this, we must set column width. For long text, we render it with ellipsis. If you hover it you will have the value. For wcah keyboard user can tab to the ellipsis to get the value. TEsted with http://geoappext.nrcan.gc.ca/arcgis/rest/services/GSCC/Geochronology/MapServer/ who has a lot of long fields. Issue #1482

## Testing
Chrome, FF and Safari

## Documentation
Inline>

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version
