### PR TITLE
1532 export locks browser

### DIFF
--- a/src/app/layout/shell.html
+++ b/src/app/layout/shell.html
@@ -39,7 +39,7 @@
 <!--div ng-class="{ active: self.active }" ui-view="geoSearchPlug"></div-->
 
 <md-progress-linear
-    class="rv-shell-progress-indicator"
+    class="rv-progress-bottom"
     md-mode="indeterminate"
     ng-show="self.geoService.mapObject.isMapLoading"></md-progress-linear>
 

--- a/src/app/ui/common/stepper/stepper-item.html
+++ b/src/app/ui/common/stepper/stepper-item.html
@@ -44,7 +44,7 @@
                     ng-if="self.onContinue || self.step.onContinue"
                     ng-click="(self.onContinue || self.step.onContinue)()">
                     {{ 'stepper.continue' | translate }}
-                    <md-progress-linear class="rv-toc-progress-indicator" md-mode="indeterminate" ng-show="self.step.isThinking"></md-progress-linear>
+                    <md-progress-linear class="rv-progress-bottom" md-mode="indeterminate" ng-show="self.step.isThinking"></md-progress-linear>
                 </md-button>
 
             </div>

--- a/src/app/ui/export/export-size.class.js
+++ b/src/app/ui/export/export-size.class.js
@@ -68,11 +68,21 @@
 
         get dimensions() {
             // returns a text description of the size in the form of `(width x height)`
-            if (this._height === null || this._width === null) {
+            if (!this.isValid()) {
                 return '';
             } else {
                 return `(${this._width} x ${this._height})`;
             }
+        }
+
+        /**
+         * Checks if this export size is valid (dimensions are defined)
+         *
+         * @function isValid
+         * @return {Boolean} true if width and height are defined; false otherwise
+         */
+        isValid() {
+            return this._height !== null && this._width !== null;
         }
     }
     // jscs:enable requireSpacesInAnonymousFunctionExpression

--- a/src/app/ui/export/export-sizes.service.js
+++ b/src/app/ui/export/export-sizes.service.js
@@ -29,12 +29,10 @@
             customOption
         ];
 
-        const selectedOption = defaultOption;
-
         const service = {
             options,
             customOption,
-            selectedOption,
+            selectedOption: defaultOption,
             tempOption,
             exportSizeRatio: 1,
 
@@ -77,6 +75,13 @@
             service.tempOption.widthHeightRatio = service.exportSizeRatio;
 
             defaultOption.height = mapHeight;
+
+            // in cases when the custom option was selected, but no valid width/height entered, the selected option become invalid
+            // need to reset selected option to default; otherwise the browser will lock trying to divide by null or somethings
+            // https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1532
+            if (!service.selectedOption.isValid()) {
+                service.selectedOption = defaultOption;
+            }
 
             service.width = {
                 min: Math.round(service.height.min * service.exportSizeRatio),

--- a/src/app/ui/export/export.html
+++ b/src/app/ui/export/export.html
@@ -61,11 +61,14 @@
                                 {{ 'export.undo' | translate }}
                             </md-button>
 
+                            <!-- disable the custom size generate button when the image is being generated; make the button available if the custom size is changed, so the user can trigger generation of a differently sized image not waiting until the previous generation completes -->
                             <md-button
-                                ng-disabled="!exportForm.$valid"
+                                ng-disabled="!exportForm.$valid || (self.isGenerating() && self.exportSizes.tempOption.height === self.exportSizes.selectedOption.height)"
                                 ng-click="self.exportSizes.updateCustomOption(); self.updateComponents();"
                                 class="rv-button-square md-raised md-primary">
                                 {{ 'export.generate' | translate }}
+                                <!-- show a progress indicator on the generate button when picking a custom export size -->
+                                <md-progress-linear class="rv-progress-bottom" md-mode="indeterminate" ng-show="self.isGenerating()"></md-progress-linear>
                             </md-button>
                         </div>
                     </div>
@@ -138,7 +141,7 @@
 
         <md-dialog-actions layout="row">
              <md-progress-linear
-                    class="rv-export-progress-indicator"
+                    class="rv-progress-bottom"
                     ng-hide="!self.isGenerating() || self.isError"
                     md-mode="indeterminate"></md-progress-linear>
 

--- a/src/app/ui/panels/content-pane.html
+++ b/src/app/ui/panels/content-pane.html
@@ -61,5 +61,5 @@
 
     <div class="rv-footer" ng-show="self.footer"></div>
 
-    <md-progress-linear class="rv-content-pane-progress-indicator" md-mode="indeterminate" ng-show="self.isLoading"></md-progress-linear>
+    <md-progress-linear class="rv-progress-top" md-mode="indeterminate" ng-show="self.isLoading"></md-progress-linear>
 </div>

--- a/src/app/ui/toc/toc.html
+++ b/src/app/ui/toc/toc.html
@@ -35,7 +35,7 @@
 
                 <div class="rv-shadow" ng-if-end></div>
 
-                <md-progress-linear class="rv-toc-progress-indicator" md-mode="indeterminate" ng-show="item.isLoading"></md-progress-linear>
+                <md-progress-linear class="rv-progress-bottom" md-mode="indeterminate" ng-show="item.isLoading"></md-progress-linear>
 
             </li>
         </ul>

--- a/src/content/styles/modules/_content-pane.scss
+++ b/src/content/styles/modules/_content-pane.scss
@@ -66,13 +66,8 @@
             border-top: 1px solid $divider-color-light;
         }
 
-        &-progress-indicator {
-            position: absolute;
-            top: 0;
+        .rv-progress-top {
             height: 3px;
-            overflow: hidden;
-            padding: 0;
-            z-index: 10;
         }
     }
 

--- a/src/content/styles/modules/_export.scss
+++ b/src/content/styles/modules/_export.scss
@@ -159,15 +159,6 @@
             }
         }
 
-        .rv-export-progress-indicator {
-            bottom: 0;
-            left: 0;
-            right: 0;
-            height: 2px;
-            overflow: hidden;
-            position: absolute;
-        }
-
         .rv-export-title {
             display: flex;
             justify-content: center;

--- a/src/content/styles/modules/_progress-indicator.scss
+++ b/src/content/styles/modules/_progress-indicator.scss
@@ -12,4 +12,27 @@
             opacity: 0;
         }
     }
+
+    %progress {
+        position: absolute;
+        padding: 0;
+        left: 0;
+        right: 0;
+        height: 2px;
+        overflow: hidden;
+
+        // This prevents layer loading indicators from showing when another panel overlays the toc (in small medium layouts only)
+        @include media($rv-lg) {
+            z-index: 10;
+        }
+    }
+
+    $progress-positions: top, bottom;
+
+    @each $item in $progress-positions {
+        .rv-progress-#{$item} {
+            @extend %progress;
+            #{$item}: 0;
+        }
+    }
 }

--- a/src/content/styles/modules/_shell.scss
+++ b/src/content/styles/modules/_shell.scss
@@ -19,13 +19,6 @@
             z-index: -2;
         }
 
-        .rv-shell-progress-indicator {
-            bottom: 0;
-            position: absolute;
-            height: 2px;
-            overflow: hidden;
-        }
-
         .rv-focus-dialog-content {
             display: none;
         }

--- a/src/content/styles/modules/_toc.scss
+++ b/src/content/styles/modules/_toc.scss
@@ -19,19 +19,6 @@ $layer-item-height-touch: rem(7.2);
     .rv-toc {
         padding: rem(0.8) 0;
         @include layer-list;
-
-        &-progress-indicator {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            height: 2px;
-            overflow: hidden;
-
-            // This prevents layer loading indicators from showing when another panel overlays the toc (in small medium layouts only)
-            @include media($rv-lg) {
-                z-index: 10;
-            }
-        }
     }
 
     @include toc-tools;


### PR DESCRIPTION
## Description
Fixes a condition when a browser locks up trying to apply an invalid export size. If the selected export size is invalid when the export dialog is opened, the export size resets to a default size.

## Testing
Eyeballing and lots of page reloading.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Closes #1532

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1547)
<!-- Reviewable:end -->
