### PR TITLE
fix(ui): help dialog properly opens in Firefox

### DIFF
--- a/src/app/ui/help/help.service.js
+++ b/src/app/ui/help/help.service.js
@@ -67,7 +67,6 @@
                 templateUrl: 'app/ui/help/help-summary.html',
                 parent: storageService.panels.shell,
                 disableParentScroll: false,
-                targetEvent: event,
                 clickOutsideToClose: true,
                 fullscreen: false
             });

--- a/src/app/ui/mapnav/mapnav-button.html
+++ b/src/app/ui/mapnav/mapnav-button.html
@@ -2,7 +2,7 @@
     aria-label="{{ self.control.label | translate }}"
     class="md-icon-button rv-button-32"
     ng-class="{ selected: self.control.selected() }"
-    ng-click="self.control.action()">
+    ng-click="self.control.action($event)">
 
     <md-tooltip md-direction="left">{{ self.control.tooltip | translate }}</md-tooltip>
     <md-icon md-svg-src="{{ self.control.icon }}"></md-icon>


### PR DESCRIPTION
## Description
Fixes the bug preventing the help dialog from opening in Firefox.

## Testing
Eyeballing.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Closes #1508

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1549)
<!-- Reviewable:end -->
