### PR TITLE
Legends for image and raster layers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
     "datatables.net-dt": "~1.10.10",
     "dotjem-angular-tree": "~0.2.1",
     "file-saver": "^1.3.3",
-    "geoapi": "https://github.com/fgpv-vpgf/geoApi/releases/download/v1.1.0/geoapi-1.1.0.tgz",
+    "geoapi": "http://fgpv.cloudapp.net/demo/gapi/geoapi-1.1.1-3.tgz",
     "gsap": "^1.18.0",
     "include-media": "^1.4.8",
     "jquery": "^2.1.4",

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -262,6 +262,7 @@
             }
 
             // FIXME: this should be done only on feature layers, nothing else!
+            //        NOTE: once fixed, revist legend.service, function imageGenerator, to remove the bandaid fix for this.
             // HACK: to get file based layers working; this will be solved by the layer record and legend entry hierarchy
             if (typeof initialState.url !== 'undefined') {
                 const urlParts = initialState.url.split('/');


### PR DESCRIPTION
## Description
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1487 and https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1525

## Testing
Unit tests should be added after move to geoApi and general legend refactor.
Tested against these two layers
`http://www.agr.gc.ca/atlas/rest/services/mapservices/aafc_crop_spatial_density_barley/MapServer/`
`http://www.agr.gc.ca/atlas/rest/services/imageservices/landuse_2010/ImageServer`

## Documentation
Function header docs

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1551)
<!-- Reviewable:end -->
