### PR TITLE
fix(filters): display filters between maximize and split view in Safari

### DIFF
--- a/src/content/styles/modules/_filters.scss
+++ b/src/content/styles/modules/_filters.scss
@@ -1,4 +1,10 @@
 @mixin filters {
+    .filters-panel {
+        .rv-content {
+            height: 50%; // in Safari, content panel does not update to the right height when switch from maximized to split view
+        }
+    }
+
     .rv-filters {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Closes #1404

## Description
<!-- Link to an issue or include a description -->
Content panel doesn't update height properly in Safari from maximize to split view for filters (related to #1404).

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Visual in Chrome, FF and Safari

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1558)
<!-- Reviewable:end -->
