### PR TITLE
fix(content): change expand menu labels

### DIFF
--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -168,9 +168,9 @@ Table of Content keyboard reoder tooltip,toc.tooltip.reorder,Reorder,Réorganise
 ,toc.menu.visibility.title,Toggle Visibility,Basculer la visibilité
 ,toc.menu.visibility.allon,Show All,Montre tout
 ,toc.menu.visibility.alloff,Hide All,Cacher tout
-,toc.menu.expand.title,Toggle Groups,Alternar grupos
-,toc.menu.expand.allon,Expand All,Expandir todo
-,toc.menu.expand.alloff,Collapse All,Desplegar todo
+,toc.menu.expand.title,Toggle Groups,Basculer les groupes
+,toc.menu.expand.allon,Expand Groups,Élargir les groupes
+,toc.menu.expand.alloff,Collapse Groups,Réduire les groupes
 ,toc.menu.reorder.title,Reorder Layers,Réorganiser les couches
 ,toc.menu.reorder.close,Stop Reordering,Arrêter de réorganiser
 While counting geometry,geometry.counting, ...counting, ...compte


### PR DESCRIPTION
## Description
Changes labels from "Expand/Collapse All" to "Expand/Collapse Groups".
If you know French, can you check if Google's translation is okay? Thanks.

## Testing
I just hope it works.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

Closes #1509

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1562)
<!-- Reviewable:end -->
