### PR TITLE
feat(ui): add autolinking to details panel

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,9 +37,16 @@
     "jquery-hoverintent": "~1.8.1",
     "ng-flow": "~2.7.1",
     "RandomColor": "https://github.com/sterlingwes/RandomColor.git",
-    "svg.textflow.js": "https://github.com/fgpv-vpgf/svg.textflow.js.git"
+    "svg.textflow.js": "https://github.com/fgpv-vpgf/svg.textflow.js.git",
+    "linkifyjs": "^2.1.4"
   },
   "overrides": {
+    "linkifyjs": {
+      "main": [
+        "linkify.js",
+        "linkify-string.js"
+      ]
+    },
     "canvas-toBlob.js": {
       "main": "canvas-toBlob.js"
     },

--- a/src/app/common/formatters.filter.js
+++ b/src/app/common/formatters.filter.js
@@ -20,17 +20,32 @@
         return autolink;
 
         /**
+         * Autolinks strings; doesn't not modify the original.
+         *
          * @function autolink
-         * @param {Array} items array of strings to autolink
+         * @param {Array|String} items array of strings or a single string to autolink
          * @param {Object} options [optional = {}] linkifyjs options object; the only default changed is classname (rv-linkified) for consistency
-         * @return {Array} array of autolinked strings
+         * @return {Array|String} array or string of autolinked strings
          */
         function autolink(items, options = {}) {
             // item must be a string
-            const results = items.map(item =>
-                linkifyStr((item || '').toString(), angular.extend(defaultOptions, options)));
+            const results = Array.isArray(items) ?
+                items.map(process) :
+                process(items);
 
             return results;
+
+            /**
+             * Autolink helper function.
+             *
+             * @function process
+             * @private
+             * @param {String} item string to autolink
+             * @return {String} autolinked string
+             */
+            function process(item) {
+                return linkifyStr((item || '').toString(), angular.extend(defaultOptions, options));
+            }
         }
     }
 })();

--- a/src/app/common/formatters.filter.js
+++ b/src/app/common/formatters.filter.js
@@ -1,0 +1,36 @@
+/* global linkifyStr */
+(() => {
+    'use strict';
+
+    /**
+     * @name autolink
+     * @constant
+     * @memberof app.common
+     * @description
+     *
+     * The autolink filter using https://github.com/SoapBox/linkifyjs.
+     */
+    angular
+        .module('app.common')
+        .filter('autolink', autolink);
+
+    function autolink() {
+        const defaultOptions = { className: 'rv-linkified' };
+
+        return autolink;
+
+        /**
+         * @function autolink
+         * @param {Array} items array of strings to autolink
+         * @param {Object} options [optional = {}] linkifyjs options object; the only default changed is classname (rv-linkified) for consistency
+         * @return {Array} array of autolinked strings
+         */
+        function autolink(items, options = {}) {
+            // item must be a string
+            const results = items.map(item =>
+                linkifyStr((item || '').toString(), angular.extend(defaultOptions, options)));
+
+            return results;
+        }
+    }
+})();

--- a/src/app/ui/details/details-content.html
+++ b/src/app/ui/details/details-content.html
@@ -13,10 +13,10 @@
         </ul>
 
         <!-- Plain text presentation  -->
-        <pre ng-switch-when="Text">{{ self.item.data[0] }}</pre>
+        <div class="rv-details-text" ng-switch-when="Text" ng-bind-html="self.item.data[0] | autolink"></div>
 
         <!-- Raw HTML presentation  -->
-        <rv-svg ng-switch-when="HTML" src="self.item.data[0]"></rv-svg>
+        <rv-svg class="rv-details-html" ng-switch-when="HTML" src="self.item.data[0]"></rv-svg>
 
         <md-divider></md-divider>
     </div>

--- a/src/app/ui/details/details-record-esrifeature.directive.js
+++ b/src/app/ui/details/details-record-esrifeature.directive.js
@@ -16,7 +16,7 @@
         .module('app.ui.details')
         .directive('rvDetailsRecordEsrifeature', rvDetailsRecordEsrifeature);
 
-    function rvDetailsRecordEsrifeature($compile, geoService) {
+    function rvDetailsRecordEsrifeature($compile, $filter, geoService) {
         const directive = {
             restrict: 'E',
             templateUrl: 'app/ui/details/details-record-esrifeature.html',
@@ -68,13 +68,13 @@
                     const LIST = listItems =>
                         `<ul class="ng-hide rv-details-list rv-toggle-slide"
                             ng-show="self.item.isExpanded">
-                            ${listItems}
+                            ${ listItems }
                         </ul>`;
 
                     const LIST_ITEM = (key, value) =>
                         `<li>
-                            <div class="rv-details-attrib-key">${key}</div>
-                            <div class="rv-details-attrib-value">${value}</div>
+                            <div class="rv-details-attrib-key">${ key }</div>
+                            <div class="rv-details-attrib-value">${ $filter('autolink')([value]) }</div>
                         </li>`;
 
                     const detailsHhtml = LIST(

--- a/src/app/ui/details/details-record-esrifeature.directive.js
+++ b/src/app/ui/details/details-record-esrifeature.directive.js
@@ -74,7 +74,7 @@
                     const LIST_ITEM = (key, value) =>
                         `<li>
                             <div class="rv-details-attrib-key">${ key }</div>
-                            <div class="rv-details-attrib-value">${ $filter('autolink')([value]) }</div>
+                            <div class="rv-details-attrib-value">${ $filter('autolink')(value) }</div>
                         </li>`;
 
                     const detailsHhtml = LIST(

--- a/src/app/ui/toc/entry-symbology.directive.js
+++ b/src/app/ui/toc/entry-symbology.directive.js
@@ -51,6 +51,10 @@
             const self = scope.self;
 
             self.expanded = false; // holds the state of symbology section
+
+            // when symbology is displayed in the details panel, it is not connected to the layer record entry and the two lines below were generating lots of console errors
+            self.entry = self.entry || {};
+
             // TODO: these should be attached to self.symbology instead of self.entry once geo module refactor is complete
             self.entry.toggleSymbology = self.toggleSymbology = toggleSymbology;
             self.entry.wiggleSymbology = self.wiggleSymbology = wiggleSymbology;

--- a/src/content/styles/modules/_details.scss
+++ b/src/content/styles/modules/_details.scss
@@ -275,7 +275,7 @@ $details-record-height: rem(6.0);
 }
 
 @mixin Text {
-    pre {
+    .rv-details-text {
         white-space: pre-wrap;
         font-family: inherit;
         padding: rem(0.8) rem(1.6);
@@ -284,7 +284,9 @@ $details-record-height: rem(6.0);
 }
 
 @mixin HTML {
+    .rv-details-html {
 
+    }
 }
 
 @mixin nothing {


### PR DESCRIPTION
## Description
Adds url and email autolinking in the details panel. Not possible at the moment in the datagrid. See issue comment for details.

Related #1564

## Testing
Eyeballing with this layer: http://section917.cloudapp.net/arcgis/rest/services/JOSM_SSB/JOSM_SSB_en/MapServer/1

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1572)
<!-- Reviewable:end -->
