### PR TITLE
fix(ui): added rv-ignore-focusout to focus manager

### DIFF
--- a/src/app/ui/filters/filters-default.html
+++ b/src/app/ui/filters/filters-default.html
@@ -5,7 +5,7 @@
     title-value="{{ 'filter.title' | translate }}{{ self.display.requester.name }}"
     is-loading="self.display.isLoading">
 
-    <div class="rv-filters">
+    <div class="rv-filters" rv-ignore-focusout>
 
         <!--md-button ng-click="self.draw()">click this button if you don't see the table below</md-button-->
 


### PR DESCRIPTION
## Description
Any child of an element with the rv-ignore-focusout property is ignored
when it loses focus, and the next tab press is handled by the browser.

Closes #1557

## Testing
:eye: 

## Documentation
inline where needed

## Checklist

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1580)
<!-- Reviewable:end -->
