### PR TITLE
fix(ui): datatable scrollbars restored

### DIFF
--- a/src/content/styles/modules/_filters.scss
+++ b/src/content/styles/modules/_filters.scss
@@ -32,11 +32,14 @@
                     flex-direction: column;
                     min-height: 0; // Firefox fix; otherwise div won't shrink: http://stackoverflow.com/questions/27424831/firefox-flexbox-overflow
 
-                    .dataTables_scrollHead {}
+                    .dataTables_scrollHead {
+                        width: 100% !important;
+                    }
 
                     .dataTables_scrollBody {
                         flex: 1; // this needed for the body to fill available space
                         background: lighten($divider-color, 20%);
+                        width: 100% !important;
 
                         tbody {
                             // for datatable KeyTable extension


### PR DESCRIPTION
## Description
Scroll area width set to 100% to prevent custom width being applied

Closes #1576

## Testing
:eye: chrome, ie

## Documentation
none needed

## Checklist

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1581)
<!-- Reviewable:end -->
