### PR TITLE
fix(ui): remove side menu scrollbars in IE

### DIFF
--- a/src/content/styles/modules/_app-menu.scss
+++ b/src/content/styles/modules/_app-menu.scss
@@ -5,6 +5,7 @@
             max-width: 300px;
             min-width: 300px;
             flex-direction: column;
+            overflow: hidden;
 
             @include media($rv-sm...) {
                 width: 80%;


### PR DESCRIPTION
## Description
Removes extra scrollbars from the sidemenu in IE; see issue for details.

Closes #1578

## Testing
Eyeballing.

## Documentation
Nope.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~[ ] release notes have been updated~ not needed as the bug was not released.
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1585)
<!-- Reviewable:end -->
