### PR TITLE
feat(filters): Add keytable extension to navigate the table with arro…

### DIFF
--- a/src/app/ui/filters/filters-default.html
+++ b/src/app/ui/filters/filters-default.html
@@ -1,16 +1,17 @@
-<rv-content-pane
-    header-controls="rv-filters-default-menu"
-    static-content="true"
-    title-style="title"
-    title-value="{{ 'filter.title' | translate }}{{ self.display.requester.name }}"
-    is-loading="self.display.isLoading">
+<div rv-trap-focus="{{ ::self.appID }}">
+    <rv-content-pane
+        header-controls="rv-filters-default-menu"
+        static-content="true"
+        title-style="title"
+        title-value="{{ 'filter.title' | translate }}{{ self.display.requester.name }}"
+        is-loading="self.display.isLoading">
 
-    <div class="rv-filters" rv-ignore-focusout>
+        <!-- do not put rv-ignore-focusout here because it will exclude header from tabing -->
+        <div class="rv-filters">
+            <!--md-button ng-click="self.draw()">click this button if you don't see the table below</md-button-->
 
-        <!--md-button ng-click="self.draw()">click this button if you don't see the table below</md-button-->
+            <div class="rv-filters-data-container"></div>
 
-        <div class="rv-filters-data-container"></div>
-
-    </div>
-
-</rv-content-pane>
+        </div>
+    </rv-content-pane>
+</div>

--- a/src/content/styles/modules/_filters.scss
+++ b/src/content/styles/modules/_filters.scss
@@ -49,37 +49,35 @@
 
                         tbody {
                             // for datatable KeyTable extension
-                            td.focus {
+                            td.rv-cell-focus {
                                 outline: 1px solid $focus-color;
                                 outline-offset: -1px;
+
+                                & > .rv-render-tooltip {
+                                    display: block;
+                                    position: absolute;
+                                    border: 1px solid #D3D3D3;
+                                    background-color: #F2F2F2;
+                                    padding: 2px 5px;
+                                    box-shadow: 1px 1px 2px #CCC;
+                                    max-width: 250px;
+                                    white-space: normal;
+                                    word-wrap: break-word;
+                                }
                             }
 
-                            // ellipsis renderer when text is longer then field width
-                            .rv-render-ellipsis {
-                                width: 100%;
-                                border: none;
-                                background: none;
-                                padding: 0;
-                                font-size: 14px;
-                                cursor: text;
-                                overflow: hidden;
-                                text-overflow: ellipsis;
-                            }
-
+                            // hide tooltip if td doesn't have the focus
                             .rv-render-tooltip {
                                 display: none;
                             }
 
-                            // on keyboard focus show tooltip to be wcag compliant
-                            .rv-render-ellipsis:focus + .rv-render-tooltip {
-                                display: block;
-                                position: absolute;
-                                border: 1px solid #D3D3D3;
-                                background-color: #F2F2F2;
-                                padding: 2px 5px;
-                                box-shadow: 1px 1px 2px #CCC;
-                                max-width: 250px;
-                                white-space: normal;
+                            // ellipsis renderer when text is longer then field width
+                            .rv-render-ellipsis {
+                                cursor: text;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                white-space: nowrap;
+                                display: list-item;
                             }
 
                             .rv-data {


### PR DESCRIPTION
…w key. Modify the way long text is displayed when cell receive focus from the extension.

Closes #1577, #1589

## Description
<!-- Link to an issue or include a description -->
The keytable extension let user navigate datatable like an Excel spreadsheet. To switch focus between the cells, arrow keys must be use. Tab key only navigate on the focusable element in datatable like interactive buttons. 

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
in FF, Chrome and Safari

- Navigate in the table with the arrow
- Mix keyboard and mouse navigation
- Mix arrow and tab navigation

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1606)
<!-- Reviewable:end -->
