### PR TITLE
fix(ui): truncate overflowing details values

### DIFF
--- a/src/content/styles/modules/_details.scss
+++ b/src/content/styles/modules/_details.scss
@@ -207,6 +207,16 @@
             padding-left: 15px;
             position: relative;
             float: right;
+
+            // fix for https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1635
+            // truncate values that do not wrap (links for example)
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+
+            a {
+                white-space: nowrap;
+            }
         }
 
         .rv-sub-subhead {


### PR DESCRIPTION
## Description
Truncate overflowing details values that cannot be wrapped.
Closes #1635

http://fgpv.cloudapp.net/demo/users/AleksueiR/1635-truncate-autolinks/prod/samples/index-fgp-en.html?keys=JOSM

## Testing
Eyeballing.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ not needed
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1645)
<!-- Reviewable:end -->
