### PR TITLE
fix(ui): center details panel header in IE

### DIFF
--- a/src/content/styles/modules/_details.scss
+++ b/src/content/styles/modules/_details.scss
@@ -18,6 +18,8 @@
 
     rv-details-header {
         position: relative;
+        display: flex; // go on IE with your obscure bugs: http://stackoverflow.com/a/33222765; fixes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1646
+        flex-direction: column; //this bug is apparently fixed in IE Edge;
     }
 
     .rv-details-summary {


### PR DESCRIPTION
## Description
IE has many interesting bugs... In this case, a flexbox didn't want to vertically center it's content, unless you set it's height to a concrete number or wrap it in another flexbox.
Closes #1646

## Testing
Eyeballing.

## Documentation
Inline.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ not a relased bug
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1647)
<!-- Reviewable:end -->
