### PR TITLE
fix(filters): option data not read from config file

### DIFF
--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -225,6 +225,11 @@
                     identifyResults[legendEntry.featureIdx] = identifyResult;
                 });
 
+                // if all the dynamic layer children are unqueriable, do not run identify as with `opts.layerrIds` it will search through all of them and fail trying to access items in `identifyResults` which is also empty
+                if (opts.layerIds.length === 0) {
+                    return {};
+                }
+
                 opts.tolerance = layerRecord.clickTolerance;
 
                 const identifyPromise = gapiService.gapi.layer.serverLayerIdentify(layerRecord._layer, opts)

--- a/src/app/geo/legend-entry.service.js
+++ b/src/app/geo/legend-entry.service.js
@@ -201,6 +201,12 @@
                     this.flags.query.visible = !this.options.query.value;
                 }
 
+                // need to initialize the data flag as it's value defaults to layer type data flag value (feature and dynamic layers have data; others do not)
+                // solves https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1628
+                if (this.options.data) {
+                    this.flags.data.visible = this.options.data.enabled;
+                }
+
                 // this.state = layerStates.default; ??
                 const colour = (new RColor()).get(true, 0.4, 0.8);
                 gapiService.gapi.symbology.generatePlaceholderSymbology(this.name, colour).then(symbologyItem => {

--- a/src/app/ui/toc/entry-flag.directive.js
+++ b/src/app/ui/toc/entry-flag.directive.js
@@ -48,6 +48,15 @@
             self.control = ctrl.entry.flags[self.name];
             self.template = tocService.presets.flags[self.name];
             self.isFunction = angular.isFunction;
+
+            // set flags visibility from configuration file if present
+            if (typeof ctrl.entry.options[self.name] !== 'undefined') {
+                // if the flag is query, the visible value is reverse of option value because flag is shown if layer is exclude from identify.
+                // for other flag, it is the value of enabled
+                const visible = (self.name === 'query') ?
+                    !ctrl.entry.options[self.name].value : ctrl.entry.options[self.name].enabled;
+                ctrl.entry.flags[self.name].visible = visible;
+            }
         }
     }
 })();

--- a/src/app/ui/toc/entry-flag.directive.js
+++ b/src/app/ui/toc/entry-flag.directive.js
@@ -48,15 +48,6 @@
             self.control = ctrl.entry.flags[self.name];
             self.template = tocService.presets.flags[self.name];
             self.isFunction = angular.isFunction;
-
-            // set flags visibility from configuration file if present
-            if (typeof ctrl.entry.options[self.name] !== 'undefined') {
-                // if the flag is query, the visible value is reverse of option value because flag is shown if layer is exclude from identify.
-                // for other flag, it is the value of enabled
-                const visible = (self.name === 'query') ?
-                    !ctrl.entry.options[self.name].value : ctrl.entry.options[self.name].enabled;
-                ctrl.entry.flags[self.name].visible = visible;
-            }
         }
     }
 })();

--- a/src/app/ui/toc/entry-flag.directive.spec.js
+++ b/src/app/ui/toc/entry-flag.directive.spec.js
@@ -17,7 +17,7 @@ describe('rvLayerItemFlag', () => {
                     visible: true
                 }
             }
-        },
+        }
     };
 
     function mockLayoutService($provide) {

--- a/src/app/ui/toc/templates/layer-entry.html
+++ b/src/app/ui/toc/templates/layer-entry.html
@@ -4,7 +4,7 @@
     rv-help="layer-item"
     ng-mouseover="self.entry.wiggleSymbology(true)"
     ng-mouseleave="self.entry.wiggleSymbology(false)"
-    ng-if="self.entry.options.data"
+    ng-if="self.entry.options.data.enabled"
     ng-click="self.defaultAction(self.entry)">
     <!-- TODO: add aria attribues on the button to provide context on what it does; also mute the actual layer name below, so a screen reader wouldn't pronounce it twice-->
 </md-button>

--- a/src/config.en-CA.json
+++ b/src/config.en-CA.json
@@ -157,7 +157,7 @@
       "id":"ecogeo",
       "name": "Eco Geo",
       "layerType":"esriDynamic",
-      "layerEntries": [{"index": 6}, {"index": 7}, {"index": 8}, {"index": 9}],
+      "layerEntries": [{"index": 6, "data": {"enabled": false}}, {"index": 7}, {"index": 8}, {"index": 9}],
       "url":"http://section917.cloudapp.net/arcgis/rest/services/EcoGeo/MapServer",
       "metadataUrl": "http://intranet.ecdmp-stage.cmc.ec.gc.ca/geonetwork/srv/eng/csw?service=CSW&version=2.0.2&request=GetRecordById&outputSchema=csw:IsoRecord&id=1c0eb1b2-93ae-49ae-a3ce-e495d8fd767b&_=1417717957845"
     },
@@ -175,7 +175,9 @@
       "layerType":"esriFeature",
       "url":"http://ec.gc.ca/arcgis/rest/services/data_donnees/be12386d/MapServer/0",
       "options": {
-        "opacity": { "value": 0.1 }
+        "opacity": { "value": 0.1 },
+        "data": { "enabled": false },
+        "query": { "enabled": true, "value": false }
       }
     },
     {


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->

config file option.data was not properly read from the config file.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
index-one.html
With feature layer Land Pub Standard Zone Details ("data": { "enabled": false })
With dynamic layer Eco Geo first layer ({"index": 6, "data": {"enabled": false}})

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1652)
<!-- Reviewable:end -->
