### PR TITLE
fix(ui): filter rvInteractive column from details

### DIFF
--- a/src/app/ui/details/details-record-esrifeature.directive.js
+++ b/src/app/ui/details/details-record-esrifeature.directive.js
@@ -75,30 +75,29 @@
              */
             function renderDetails() {
                 if (!isCompiled) {
-                    const LIST = listItems =>
+                    const excludedColumns = ['rvSymbol', 'rvInteractive'];
+
+                    // there should be no spaces between the row values and surrounding div tags, they mess up layout
+                    const detailsHTMLTemplate =
                         `<ul class="ng-hide rv-details-list rv-toggle-slide"
                             ng-show="self.item.isExpanded">
-                            ${ listItems }
+
+                            <li ng-repeat="row in self.item.filteredData" ng-switch on="row.type">
+                                <div class="rv-details-attrib-key">{{ ::row.key }}</div>
+                                <span flex></span>
+
+                                <div class="rv-details-attrib-value"
+                                    ng-switch-when="esriFieldTypeDate">{{ ::row.value | dateTimeZone }}</div>
+                                <div class="rv-details-attrib-value"
+                                    ng-switch-default>{{ ::row.value | autolink }}</div>
+                            </li>
                         </ul>`;
 
-                    const LIST_ITEM = (key, value, type) =>
-                        `<li>
-                            <div class="rv-details-attrib-key">${ key }</div>
-                            <span flex></span>
-                            <div class="rv-details-attrib-value">
-                                ${ $filter(type === 'esriFieldTypeDate' ? 'dateTimeZone' : 'autolink')(value) }
-                            </div>
-                        </li>`;
+                    self.item.filteredData =
+                        self.item.data.filter(column =>
+                            excludedColumns.indexOf(column.key) === -1);
 
-                    const detailsHhtml = LIST(
-                        self.item.data.map(row =>
-                            // skip over the symbol column
-                            // TODO: see #689
-                            row.key !== 'rvSymbol' ? LIST_ITEM(row.key, row.value, row.type) : '')
-                        .join('')
-                    );
-
-                    const details = $compile(detailsHhtml)(scope); // compile with the local scope to set proper bindings
+                    const details = $compile(detailsHTMLTemplate)(scope); // compile with the local scope to set proper bindings
                     el.after(details);
                     isCompiled = true;
                 }

--- a/src/content/styles/modules/_details.scss
+++ b/src/content/styles/modules/_details.scss
@@ -244,6 +244,7 @@ $details-record-height: rem(6.0);
             li {
                 display: flex;
                 flex-wrap: wrap;
+                justify-content: flex-end; // forces the key value to move the rigth of the container; key name is pushed to the left by the flexed span
             }
 
             .rv-details-attrib-key {


### PR DESCRIPTION
## Description
Filters out `rvInteractive` column from the details view.

Simplifies the template and fixes a small bug when the key value might not
be flush with the right edge of the container.

Closes #1661

## Testing
Eyeballing.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1673)
<!-- Reviewable:end -->
