### PR TITLE
fix(ui): properly bind autolinked html snippets

### DIFF
--- a/src/app/ui/details/details-record-esrifeature.directive.js
+++ b/src/app/ui/details/details-record-esrifeature.directive.js
@@ -87,9 +87,10 @@
                                 <span flex></span>
 
                                 <div class="rv-details-attrib-value"
-                                    ng-switch-when="esriFieldTypeDate">{{ ::row.value | dateTimeZone }}</div>
+                                    ng-switch-when="esriFieldTypeDate"
+                                    ng-bind-html="::row.value | dateTimeZone"></div>
                                 <div class="rv-details-attrib-value"
-                                    ng-switch-default>{{ ::row.value | autolink }}</div>
+                                    ng-switch-default ng-bind-html="::row.value | autolink"></div>
                             </li>
                         </ul>`;
 


### PR DESCRIPTION
## Description
Autolinked html snippets were incorrectly bound to the details panel and displayed as plain text.
![](https://i.imgur.com/NJYxpU5.png)

Relates #1661

## Testing
Eyeballs.

## Documentation
Nope.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ unreleased bug
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1680)
<!-- Reviewable:end -->
