### PR TITLE
fix(ui): fix geosearch resutls overflow

### DIFF
--- a/src/app/layout/layout.service.js
+++ b/src/app/layout/layout.service.js
@@ -61,7 +61,7 @@
          * @function onResize
          * @param {Object} element a node to watch for size changes
          * @param {Function} callback a function to call on size changes; the callback is called with { oldDimensions, newDimensions }; dimension objects specify element's height and width { width: <Number>, height: <Number> };
-         * @return {Function} a functions to deregister listener
+         * @return {Function} a function to deregister listener
          */
         function onResize(element, callback) {
 

--- a/src/app/ui/geosearch/geosearch.directive.js
+++ b/src/app/ui/geosearch/geosearch.directive.js
@@ -1,4 +1,3 @@
-/* global RV */
 (() => {
     'use strict';
 
@@ -21,7 +20,7 @@
      * @function rvGeosearch
      * @return {object} directive body
      */
-    function rvGeosearch(storageService, layoutService, debounceService) {
+    function rvGeosearch(storageService, layoutService, debounceService, globalRegistry) {
         const directive = {
             restrict: 'E',
             templateUrl: 'app/ui/geosearch/geosearch.html',
@@ -35,7 +34,7 @@
                 // IE requires a specific fix because it will not size a flex child's height correctly unless its parent has a set height (not percentage); so the height is set explicitly every time the main panel height changes;
                 // read here for more details http://stackoverflow.com/a/35537510
                 // tecnhically, this fix will work for all browsers, but it's ugly and should be reserved for IE only; other browsers are fixes using CSS just fine;
-                if (RV.isIE) {
+                if (globalRegistry.isIE) {
                     const geosearchContentNode = element.find('.rv-geosearch-content:first');
 
                     const debounceUpdateMaxHeight = debounceService.registerDebounce(newDimensions =>

--- a/src/app/ui/geosearch/geosearch.directive.js
+++ b/src/app/ui/geosearch/geosearch.directive.js
@@ -1,3 +1,4 @@
+/* global RV */
 (() => {
     'use strict';
 
@@ -20,14 +21,29 @@
      * @function rvGeosearch
      * @return {object} directive body
      */
-    function rvGeosearch() {
+    function rvGeosearch(storageService, layoutService, debounceService) {
         const directive = {
             restrict: 'E',
             templateUrl: 'app/ui/geosearch/geosearch.html',
             scope: {},
             controller: Controller,
             controllerAs: 'self',
-            bindToController: true
+            bindToController: true,
+            link: (scope, element) => {
+
+                // https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1668
+                // IE requires a specific fix because it will not size a flex child's height correctly unless its parent has a set height (not percentage); so the height is set explicitly every time the main panel height changes;
+                // read here for more details http://stackoverflow.com/a/35537510
+                // tecnhically, this fix will work for all browsers, but it's ugly and should be reserved for IE only; other browsers are fixes using CSS just fine;
+                if (RV.isIE) {
+                    const geosearchContentNode = element.find('.rv-geosearch-content:first');
+
+                    const debounceUpdateMaxHeight = debounceService.registerDebounce(newDimensions =>
+                        geosearchContentNode.css('max-height', newDimensions.height - 10), 175, false, true); // 10 accounts for top margin :()
+
+                    layoutService.onResize(storageService.panels.main, debounceUpdateMaxHeight);
+                }
+            }
         };
 
         return directive;

--- a/src/app/ui/panels/panel.directive.js
+++ b/src/app/ui/panels/panel.directive.js
@@ -21,7 +21,7 @@
      * @function rvPanel
      * @return {object} directive body
      */
-    function rvPanel() {
+    function rvPanel(storageService) {
         const directive = {
             restrict: 'E',
             templateUrl: function (element, attr) {
@@ -32,10 +32,24 @@
             },
             controller: Controller,
             controllerAs: 'self',
-            bindToController: true
+            bindToController: true,
+            link
         };
 
         return directive;
+
+        /**
+         * Directive's link function. Stores the panel element in the storage for other code to access.
+         *
+         * @function link
+         * @private
+         * @param {Object} scope directive's scope
+         * @param {Object} element directive's node
+         * @param {Array} attr directive's attributes
+         */
+        function link(scope, element, attr) {
+            storageService.panels[attr.type] = element;
+        }
     }
 
     /**

--- a/src/app/ui/tooltip/tooltip.directive.js
+++ b/src/app/ui/tooltip/tooltip.directive.js
@@ -37,6 +37,7 @@
                     self.isRendered = true;
                 }, 20, false, true);
 
+                // TODO: use layoutservice on resize here somehow to avoid duplication
                 scope.$watch(watchBBoxChanges, (newDimensions) =>
                         debouncedUpdateDimensions(newDimensions), true); // the last argument (true) is set for $watch to do object equality comparison instead of reference equality
 

--- a/src/content/styles/modules/_geosearch.scss
+++ b/src/content/styles/modules/_geosearch.scss
@@ -43,18 +43,18 @@ $result-item-height-touch: rem(4.8);
         max-height: 100%;
 
         display: flex;
-        flex-direction: column;
-
         pointer-events: all;
 
         .rv-geosearch-content {
             background-color: white;
 
             position: relative;
-            margin-top: 10px;
+            margin-top: rem(1.0);
 
             display: flex;
             flex-direction: column;
+
+            width: 100%;
 
             %geosearch-fixed-section {
                 height: rem(4.0);


### PR DESCRIPTION
## Description
Adds a size change listener to the main panel and updates the `max-height` attribute on the geosearch content node to have it size up correctly in IE (other browser behaviour is fixed by CSS only). This might seems as an overkill for an IE bug, but we probably can use `onResize` in other places, like tooltip (it has a similar logic for watching tooltip dimension changes).

Please, check the demo in IE and Firefox to make sure it's working correctly for you.

Closes #1668

## Testing
IEballs.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] ~~release notes have been updated~~ not a released bug
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1687)
<!-- Reviewable:end -->
