### PR TITLE
feat(filters): add reorder column fonctionnality, fix some bugs from …

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "datatables-scroller": "~1.4.0",
     "datatables-select": "~1.1.2",
     "datatables-keytable": "~2.2.0",
+    "datatables.net-colreorder": "~1.3.2",
     "datatables.net": "~1.10.10",
     "datatables.net-dt": "~1.10.10",
     "dotjem-angular-tree": "~0.2.1",

--- a/src/app/geo/layer-record.class.js
+++ b/src/app/geo/layer-record.class.js
@@ -265,6 +265,7 @@
                             filter: { },
                             width: '',
                             init: false,
+                            position: -1, // use to synchronize columns when reorder
                         };
                     });
 

--- a/src/app/ui/common/dragula.directive.js
+++ b/src/app/ui/common/dragula.directive.js
@@ -40,6 +40,13 @@
                 mirrorContainer: el[0]
             };
 
+            // extend default rvDrag functions so if they are not include in rvDragulaOptions it will not fail
+            const dragOptions = { rvDragCancel: () => { },
+                                    rvDragDrop: () => { },
+                                    rvDragStart: () => { }
+                                };
+            angular.extend(dragulaOptions, dragOptions);
+
             // extend default options with extras from the the parent scope
             angular.extend(dragulaOptions, dragulaScope.self[attr.rvDragulaOptions]);
             dragulaService.options(dragulaScope, attr.rvDragula, dragulaOptions);

--- a/src/app/ui/filters/filters-default.html
+++ b/src/app/ui/filters/filters-default.html
@@ -1,6 +1,6 @@
 <div rv-trap-focus="{{ ::self.appID }}">
     <rv-content-pane
-        header-controls="rv-filters-default-menu"
+        header-controls="rv-filters-default-menu;rv-filters-search"
         static-content="true"
         title-style="title"
         title-value="{{ 'filter.title' | translate }}{{ self.display.requester.name }}"

--- a/src/app/ui/filters/filters-setting-panel.directive.js
+++ b/src/app/ui/filters/filters-setting-panel.directive.js
@@ -20,22 +20,130 @@
      * @function rvFiltersSettingPanel
      * @return {object} directive body
      */
-    function rvFiltersSettingPanel() {
+    function rvFiltersSettingPanel(stateManager, dragulaService, animationService, filterService, $timeout) {
         const directive = {
             restrict: 'E',
             templateUrl: 'app/ui/filters/filters-setting-panel.html',
             scope: { },
+            link: link,
             controller: Controller,
             controllerAs: 'self',
             bindToController: true
         };
 
         return directive;
+
+        function link(scope, directiveElement) {
+            const self = scope.self;
+
+            // TODO convert this object into an ES6 class
+            // jscs doesn't like enhanced object notation
+            // jscs:disable requireSpacesInAnonymousFunctionExpression
+            self.dragulaOptions = {
+
+                // only let the user move the item if drag handle is selected
+                moves(el, source, handle) {
+                    // prevent drag from starting if something other than a handle was grabbed
+                    if (angular.element(handle).parentsUntil(el, '[rv-drag-handle]').length > 0) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                },
+
+                accepts(dragElement, target, source, sibling) {
+                    // only accepts if there is handle on the sibling (thre is no handle on rvSymbol and rvInteractive)
+                    // when sibling element is the last one, class gu-mirror is present.
+                    if (angular.element(sibling).find('[rv-drag-handle]').length > 0 ||
+                        sibling.className === 'gu-mirror') {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                },
+
+                rvDragDrop() {
+                    // update datatable order (need to reset before setting back the order, if not order is not set properly)
+                    const table = filterService.getTable();
+                    table.colReorder.reset();
+
+                    // set a timeout because model needs ot be updated before we reorder the fields
+                    $timeout(() => {
+                        table.colReorder.order(stateManager.display.filters.data.columns.map(item => item.position));
+                    }, 250);
+                }
+            };
+            // jscs:enable requireSpacesInAnonymousFunctionExpression
+
+            // set an empty animation object in the event a method is called prior
+            // to a scroll animation being created
+            let scrollAnimation = { pause: () => {}, isActive: () => false };
+
+            // on drag start
+            // TODO: abstract the scrolling animation, to avoid code duplication (already in toc.directive)
+            scope.$on('filters-bag.drag', (evt, dragElement, source) => {
+                // handle autoscroll when dragging layers
+                const scrollElem = source.closest('md-content');
+                directiveElement.on('mousemove touchmove', event => {
+
+                    const pageY = event.pageY ? event.pageY :  event.originalEvent.touches[0].clientY;
+
+                    // scroll animation is linear
+                    let scrollDuration;
+                    const speedRatio = 1 / 500; // 500 px in 1 second
+
+                    // scrolling upwards
+                    if (scrollElem.offset().top + dragElement.height() > pageY) {
+                        scrollDuration = scrollElem.scrollTop() * speedRatio;
+
+                        if (!scrollAnimation.isActive()) {
+                            scrollAnimation = animationService.to(scrollElem, scrollDuration,
+                                { scrollTo: { y: 0 }, ease: 'Linear.easeNone' });
+                        }
+
+                    // scrolling downwards
+                    } else if (scrollElem.height() - pageY <= 0) {
+                        if (!scrollAnimation.isActive()) {
+                            scrollDuration = (scrollElem[0].scrollHeight -
+                                scrollElem.height() - scrollElem.scrollTop()) * speedRatio;
+
+                            scrollAnimation = animationService.to(scrollElem, scrollDuration,
+                                { scrollTo: { y: scrollElem[0].scrollHeight - scrollElem.height() },
+                                ease: 'Linear.easeNone' });
+                        }
+
+                    // stop scrolling
+                    } else {
+                        scrollAnimation.pause();
+                    }
+                });
+            });
+
+            // on drop, set columns order on stateManager
+            scope.$on('filters-bag.drop-model', () => {
+                self.dragulaOptions.rvDragDrop();
+
+                // stop and remove autoscroll
+                directiveElement.off('mousemove touchmove');
+                scrollAnimation.pause();
+            });
+
+            // on cancel
+            scope.$on('filters-bag.cancel', () => {
+                // stop and remove autoscroll
+                directiveElement.off('mousemove touchmove');
+                scrollAnimation.pause();
+            });
+        }
     }
 
     function Controller($scope, events, filterService, stateManager) {
         'ngInject';
         const self = this;
+
+        self.sort = onSort;
+        self.display = onDisplay;
+        self.filterService = filterService;
 
         $scope.$on(events.rvTableReady, () => {
             self.columns = stateManager.display.filters.data.columns;
@@ -43,11 +151,6 @@
 
             init();
         });
-
-        self.reorder = onReorder;
-        self.sort = onSort;
-        self.display = onDisplay;
-        self.filterService = filterService;
 
         /**
          * On table load, initialize sort and display for all columns
@@ -84,17 +187,6 @@
             if (sorts.length) {
                 table.order(sorts).draw();
             }
-        }
-
-        /**
-         * On drag click to reorder the column
-         *
-         * @function onReorder
-         * @param   {Object}   columnInfo   column information
-         */
-        function onReorder(columnInfo) {
-            // use same approach as https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1457
-            console.log(`dragClick ${columnInfo.name}`);
         }
 
         /**

--- a/src/app/ui/filters/filters-setting-panel.html
+++ b/src/app/ui/filters/filters-setting-panel.html
@@ -4,45 +4,51 @@
 
     <ul>
         <li>
-            <span class="rv-filter-settting-reorder" ng-if="false"></span>
+            <span class="rv-filter-settting-reorder">{{ 'filter.settings.label.reorder' | translate }}</span>
             <span class="rv-filter-settting-name">{{ 'filter.settings.label.name' | translate }}</span>
             <span class="rv-filter-settting-item">{{ 'filter.settings.label.filter' | translate }}</span>
             <span class="rv-filter-settting-sort">{{ 'filter.settings.label.sort' | translate }}</span>
             <span class="rv-filter-settting-display">{{ 'filter.settings.label.display' | translate }}</span>
         </li>
-        <li ng-repeat="column in self.columns" ng-show="$index > 1"> <!-- do not show first 2 columns (symbol and interactive buttons) -->
-           <md-button
-                translate translate-attr-aria-label="filter.settings.reorder"
-                class="md-icon-button"
-                ng-click="self.reorder(column)"
-                ng-if="false"> <!-- TODO: need to implement. Need to check side effect with display and sort because it works on index. need to store index when table is recreated. -->
-                    <md-tooltip>{{ 'filter.settings.reorder' | translate }}</md-tooltip>
-                    <md-icon md-svg-src="editor:drag_handle"></md-icon>
-            </md-button>
+         <!--only create the element when columns is set. If not, the dragula directive fired and scope is not set -->
+         <ul class="rv-filter-list"
+            rv-dragula="filters-bag" rv-dragula-options="dragulaOptions" rv-dragula-model="self.columns"
+            ng-if="self.columns.length">
+            <!-- do not show first 2 columns (symbol and interactive buttons). Uge ng-show because ng-if doesn't work with dragula -->
+            <li ng-repeat="column in self.columns"  data-name="{{ ::column.data }}" ng-show="$index>1" class="rv-filter-setting-item">
+                <div rv-drag-handle ng-if="$index>1">  <!-- no rv-drag-handle so they will not be use when reorder -->
+                   <md-button
+                        translate translate-attr-aria-label="filter.settings.reorder"
+                        class="rv-filter-settting-reorder md-icon-button">
+                            <md-tooltip>{{ 'filter.settings.reorder' | translate }}</md-tooltip>
+                            <md-icon md-svg-src="editor:drag_handle"></md-icon>
+                    </md-button>
+                </div>
 
-            <span class="rv-filter-settting-name">{{ column.title }}</span>
+                <span class="rv-filter-settting-name">{{ column.title }}</span>
 
-            <div rv-filters-definition class="rv-filter-settting-item" info="column"></div>
+                <div rv-filters-definition class="rv-filter-settting-item" info="column"></div>
 
-            <div class="rv-filter-settting-sort">
-                <md-button
-                    translate translate-attr-aria-label="filter.settings.sort"
-                    class="md-icon-button"
-                    ng-click="self.sort(column)">
-                        <md-tooltip>{{ 'filter.settings.sort' | translate }}</md-tooltip>
-                        <md-icon md-svg-src="navigation:arrow_downward" ng-show="column.sort === 'desc'"></md-icon>
-                        <md-icon md-svg-src="navigation:arrow_upward" ng-show="column.sort === 'asc'"></md-icon>
-                        <md-icon md-svg-src="content:remove" ng-show="column.sort === 'none'"></md-icon>
-                </md-button>
-            </div>
+                <div class="rv-filter-settting-sort">
+                    <md-button
+                        translate translate-attr-aria-label="filter.settings.sort"
+                        class="md-icon-button"
+                        ng-click="self.sort(column)">
+                            <md-tooltip>{{ 'filter.settings.sort' | translate }}</md-tooltip>
+                            <md-icon md-svg-src="navigation:arrow_downward" ng-show="column.sort === 'desc'"></md-icon>
+                            <md-icon md-svg-src="navigation:arrow_upward" ng-show="column.sort === 'asc'"></md-icon>
+                            <md-icon md-svg-src="content:remove" ng-show="column.sort === 'none'"></md-icon>
+                    </md-button>
+                </div>
 
-            <div class="rv-filter-settting-display">
-                <md-checkbox
-                    ng-model="column.display"
-                    class="md-primary"
-                    ng-change="self.display(column)">
-                </md-checkbox>
-            </div>
-        </li>
+                <div class="rv-filter-settting-display">
+                    <md-checkbox
+                        ng-model="column.display"
+                        class="md-primary"
+                        ng-change="self.display(column)">
+                    </md-checkbox>
+                </div>
+            </li>
+        </ul>
     </ul>
 </md-content>

--- a/src/app/ui/filters/filters.service.js
+++ b/src/app/ui/filters/filters.service.js
@@ -119,7 +119,7 @@
             activeTable = table;
 
             // set global search for the active table
-            table.search(search).draw();
+            table.search(search);
 
             // reset all filters state to false (they will be populated by the loading table)
             filtersObject = table.columns().dataSrc();
@@ -132,7 +132,9 @@
                     col.data === stateManager.display.filters.data.oidField);
 
             // add a DataTable filter which only accepts rows with oidField values in the validOIDs list
-            $.fn.dataTable.ext.search.push((settings, data) => validOIDs.indexOf(parseInt(data[oidColNum])) !== -1);
+            $.fn.dataTable.ext.searchTemp.push((settings, data) => {
+                return validOIDs.indexOf(parseInt(data[settings._colReorder.fnTranspose(oidColNum)])) !== -1;
+            });
         }
 
         /**

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -380,7 +380,8 @@
                             title: '',
                             orderable: false,
                             render: '',
-                            width: '20px' // for datatables
+                            width: '20px', // for datatables
+                            position: 1 // for datatable colreorder extension
                         });
 
                         // add a column for symbols
@@ -389,7 +390,8 @@
                             title: '',
                             orderable: false,
                             render: data => `<div class="rv-wrapper rv-symbol">${data}</div>`,
-                            width: '20px' // for datatables
+                            width: '20px', // for datatables
+                            position: 0 // for datatable colreorder extension
                         });
                     }
 

--- a/src/content/styles/modules/_filters.scss
+++ b/src/content/styles/modules/_filters.scss
@@ -57,6 +57,10 @@
                                 display: flex;
                             }
                         }
+
+                        th {
+                            user-select: none; // do not select header text to avoid table selection when drag & drop columns
+                        }
                     }
 
                     .dataTables_scrollBody {
@@ -216,6 +220,7 @@ rv-filters-setting-panel {
     position: absolute;
     padding-bottom: 45px;
     overflow-y: auto;
+    user-select: none; // do not select header text to avoid table selection when drag & drop columns
 
     md-content {
         height: 100%;
@@ -233,6 +238,15 @@ rv-filters-setting-panel {
         ul {
             list-style-type: none;
 
+            .rv-filter-list {
+                padding-left: 0px;
+            }
+
+            li.rv-mirror {
+                box-shadow: $whiteframe-shadow-4dp;
+                background-color: $primary-color;
+            }
+
             li {
                 display: flex;
                 align-content: center;
@@ -244,11 +258,13 @@ rv-filters-setting-panel {
                 }
 
                 .rv-filter-settting-reorder {
-                    width: 52px;
+                    display: flex;
+                    justify-content: center;
                 }
 
                 .rv-filter-settting-name {
                     flex: 1 0 30%;
+                    margin-left: 12px;
                 }
 
                 .rv-filter-settting-item {

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -54,6 +54,7 @@ DataTable date max filter placeholder,filter.placeholder.datemax, date max,date 
 Datatables setting section title,filter.settings.title, Settings, Paramètres
 Datatable sort setting tooltip,filter.settings.sort,Sort,Trier
 Datatable reorder fields setting tooltip,filter.settings.reorder,Reorder fields,Réorganiser les champs
+Datatable settings reorder column label,filter.settings.label.reorder,Reorder,Réorganiser
 Datatable settings name column label,filter.settings.label.name,Name,Nom
 Datatable settings filter column label,filter.settings.label.filter,Filter,Filtre
 Datatable settings sort column label,filter.settings.label.sort,Sort,Trier


### PR DESCRIPTION
## Description
Capability to reorder columns in datatables (colReoder extension). Reorder can be done by dragging the field on datatable, by draggin the field (handle) in setting panel or with the keyboard in setting panel.

This PR contains some other small modifications from the rebase.

## Testing
Chrome, FF and Safari

## Documentation
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1693)
<!-- Reviewable:end -->
