### PR TITLE
fix(bootstrap): check for angular loaded by host

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,14 +26,13 @@
     "datatables-scroller": "~1.4.0",
     "datatables-select": "~1.1.2",
     "datatables-keytable": "~2.2.0",
-    "datatables.net": "~1.10.10",
-    "datatables.net-dt": "~1.10.10",
+    "datatables.net": "~1.10.11",
+    "datatables.net-dt": "~1.10.11",
     "dotjem-angular-tree": "~0.2.1",
     "file-saver": "^1.3.3",
     "geoapi": "https://github.com/fgpv-vpgf/geoApi/releases/download/v1.1.2/geoapi-1.1.2.tgz",
     "gsap": "^1.18.0",
-    "include-media": "^1.4.8",
-    "jquery": "^2.1.4",
+    "jquery": "^2.2.1",
     "jquery-hoverintent": "~1.8.1",
     "ng-flow": "~2.7.1",
     "RandomColor": "https://github.com/sterlingwes/RandomColor.git",
@@ -54,10 +53,10 @@
     "svg.textflow.js": {
       "main": "svg.textflow.js"
     },
-    "jquery": {
+    "angular": {
       "ignore": true
     },
-    "include-media": {
+    "jquery": {
       "ignore": true
     },
     "jquery-minicolors": {

--- a/gulp.config.js
+++ b/gulp.config.js
@@ -190,6 +190,7 @@ module.exports = function () {
             files: [].concat(
                 config.specHelpers, // order matters
                 bowerModules + 'jquery/dist/jquery.js',
+                bowerModules + 'angular/angular.min.js',
                 bowerModules + 'datatables.net/js/jquery.dataTables.js',
                 bowerFiles(),
                 src + 'polyfill/*.js',

--- a/src/index-mobile.html
+++ b/src/index-mobile.html
@@ -14,6 +14,11 @@
         /* Edge hack, seems like body is at z-index 0 and sits on top of the map which is at z-index: -1 */
         body { background: transparent; }
     </style>
+
+    <!-- example of host page loading angular and jquery dependencies by itself -->
+    <script src="http://ajax.aspnetcdn.com/ajax/jQuery/jquery-2.2.0.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.11/angular.min.js"></script>
+
 </head>
 
 <body>


### PR DESCRIPTION
## Description
Only load Angular if not present on the host page; output console warning
if the angular version does not match expected version.
If Angular is loaded by the host page before jQuery (or jQuery is not loaded at all), output console error and stop viewer initialization as jQuery must be loaded before Angular for it to bind correctly.

Removed not-needed "include-media" dependency. Updated datatable dependencies to `1.10.11` as specified in bootstrap.

Closes #960

## Testing
Eyeballs.

## Documentation
Some inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1694)
<!-- Reviewable:end -->
