### PR TITLE
fix(ui): prioritize layers with data in slider

### DIFF
--- a/src/app/ui/details/layer-list-slider.html
+++ b/src/app/ui/details/layer-list-slider.html
@@ -1,7 +1,7 @@
 
 <ul class="rv-list">
     <li
-        ng-repeat="item in self.display.data"
+        ng-repeat="item in self.display.data | orderBy:['data.length == 0','-isLoading']"
         ng-class="{'rv-selected': item === self.selectedItem }"
         class="rv-details-layer-list-item">
 


### PR DESCRIPTION
Closes #984

## Description
Present layers with data above those without while maintaining ordering within these groups.

## Testing
:eye: 

## Documentation
None yet as 1.6 branch is missing jsDocs tutorial implementation.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1696)
<!-- Reviewable:end -->
