### PR TITLE
chore(build): clean up console logs on prod builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -248,7 +248,8 @@ function jsbuild() {
             single_quotes: true
         }))
         .pipe($.angularFilesort())
-        .pipe($.concat(config.jsSingleFile));
+        .pipe($.concat(config.jsSingleFile))
+        .pipe($.if(PROD_MODE, $.removeLogging()));
 }
 
 // NOTE assetcopy should only be used for samples for development
@@ -280,7 +281,8 @@ gulp.task('jsrollup', 'Roll up all js into one file',
         const seed = gulp.src([config.jsGlobalRegistry, config.jsAppSeed])
             .pipe($.plumber({ errorHandler: injectError }))
             .pipe($.babel())
-            .pipe($.plumber.stop());
+            .pipe($.plumber.stop())
+            .pipe($.if(PROD_MODE, $.removeLogging()));
 
         // global registry goes after the lib package
         // app-seed `must` be the last item
@@ -314,7 +316,7 @@ gulp.task('jsinjector', 'Copy fixed assets to the build directory',
         // the only one we have is Object.entries and it is very small
         // if it gets bigger we should split it into a separate file
         const injector = merge(
-            gulp.src(config.jsInjectorFile).pipe($.babel()),
+            gulp.src(config.jsInjectorFile).pipe($.babel()).pipe($.if(PROD_MODE, $.removeLogging())),
             polyfills
         )
             .pipe($.order(config.injectorOrder))

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gulp-uglify": "^1.4.2",
     "gulp-util": "^3.0.6",
     "gulp-zip": "^3.1.0",
+    "gulp-remove-logging": "^1.2.0",
     "http-server": "^0.6.1",
     "jasmine-core": "^2.3.4",
     "jsdoc": "^3.4.0",

--- a/src/app/app.module.js
+++ b/src/app/app.module.js
@@ -30,11 +30,13 @@
          * Feature areas
          */
         'app.layout'
-    ]).config(($compileProvider, $mdInkRippleProvider) => {
+    ]).config(($compileProvider, $mdInkRippleProvider, $mdAriaProvider) => {
         // to improve IE performance disable ripple effects globally and debug info
         if (RV.isIE) {
             $mdInkRippleProvider.disableInkRipple();
         }
+
+        $mdAriaProvider.disableWarnings();
     });
 
     // a separate templates module is needed to facilitate directive unit testing


### PR DESCRIPTION
Closes #1692

## Description
Removes most console logs on prod builds. To keep a log message simply append `/*RemoveLogging:skip*/`. For example:

```js
console.log('This message will be logged'); /*RemoveLogging:skip*/
```

Cannot unilaterally remove logging for libraries and bower files since it breaks them in some cases. 

## Testing
:eye: 

## Documentation
No

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1699)
<!-- Reviewable:end -->
