### PR TITLE
fix(ui): remove split/max options in datatable for sm/md layouts

### DIFF
--- a/src/app/ui/filters/filters-default-menu.directive.js
+++ b/src/app/ui/filters/filters-default-menu.directive.js
@@ -14,7 +14,7 @@
         .module('app.ui.filters')
         .directive('rvFiltersDefaultMenu', rvFiltersDefaultMenu);
 
-    function rvFiltersDefaultMenu() {
+    function rvFiltersDefaultMenu(layoutService) {
         const directive = {
             restrict: 'E',
             templateUrl: 'app/ui/filters/filters-default-menu.html',
@@ -29,8 +29,9 @@
 
         /*********/
 
-        function link() { // scope, el, attr, ctrl) {
-
+        function link(scope) {
+            const self = scope.self;
+            self.currentLayout = layoutService.currentLayout;
         }
     }
 

--- a/src/app/ui/filters/filters-default-menu.html
+++ b/src/app/ui/filters/filters-default-menu.html
@@ -14,11 +14,11 @@
                 {{ 'filter.menu.minimize' | translate }}
             </md-menu-item-->
 
-            <md-menu-item type="radio" ng-model="self.filtersMode" value="default" ng-click="self.setMode(self.filtersMode)" class="rv-lg">
+            <md-menu-item type="radio" ng-model="self.filtersMode" value="default" ng-click="self.setMode(self.filtersMode)" ng-if="self.currentLayout() === 'large'">
                 {{ 'filter.menu.splitView' | translate }}
             </md-menu-item>
 
-            <md-menu-item type="radio" ng-model="self.filtersMode" value="full" ng-click="self.setMode(self.filtersMode)" class="rv-lg">
+            <md-menu-item type="radio" ng-model="self.filtersMode" value="full" ng-click="self.setMode(self.filtersMode)" ng-if="self.currentLayout() === 'large'">
                 {{ 'filter.menu.maximize' | translate }}
             </md-menu-item>
 


### PR DESCRIPTION
## Description
remove split/max options in datatable for sm/md layouts

Closes #1678 

## Testing
:eye: 

## Documentation
none

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1705)
<!-- Reviewable:end -->
