### PR TITLE
fix(filter): duplicate values when export

### DIFF
--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -242,14 +242,16 @@
                                 extend: 'print',
                                 title: self.display.requester.name,
                                 exportOptions: {
-                                    columns: exportColumns(displayData.columns)
+                                    columns: exportColumns(displayData.columns),
+                                    orthogonal: null // use real data, not renderer
                                 }
                             },
                             {
                                 extend: 'csvHtml5',
                                 title: self.display.requester.name,
                                 exportOptions: {
-                                    columns: exportColumns(displayData.columns)
+                                    columns: exportColumns(displayData.columns),
+                                    orthogonal: null // use real data, not renderer
                                 }
                             }
                         ],


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
See #1683 

The problem was Datatables use rendererto export data. Setting orthogonal = null in the option solve the problem. Now Datatable use the real data for export and print.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome, FF and Safari

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1710)
<!-- Reviewable:end -->
