### PR TITLE
fix(ui): Improve export header for small viewports

### DIFF
--- a/src/content/styles/modules/_export.scss
+++ b/src/content/styles/modules/_export.scss
@@ -6,10 +6,30 @@
         border-radius: 0;
         max-height: calc(100% - #{$viewport-gutter} * 2);
 
+        @include include-size(rv-sm) {
+            .md-button {
+                min-width: 0;
+            }
+
+            .md-select-value {
+                padding: 0;
+                min-width: 100px;
+            }
+
+            .md-button.md-icon-button {
+                margin: 0;
+                width: auto;
+            }
+        }
+
         // TODO: abstract that into some generic rv- class
         // this is to make primary buttons stand out, as in the import wizard
         .md-primary {
             min-width: rem(12);
+
+            @include include-size(rv-sm) {
+                min-width: rem(10);
+            }
         }
 
         md-dialog-actions {
@@ -26,6 +46,10 @@
                 max-width: rem(23);
                 min-width: rem(5);
                 flex: 2;
+
+                @include include-size(rv-sm) {
+                    min-width: rem(7.5);
+                }
             }
         }
 


### PR DESCRIPTION
## Description
Minor changes to CSS affecting only small viewports. 

Closes #1474

## Testing
Tested on iPhone and chrome mobile emulation.

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1726)
<!-- Reviewable:end -->
