### PR TITLE
fix(focus): improve export dialog support with focus manager

### DIFF
--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -12,7 +12,7 @@
     // jQuery selectors for elements that are likely focusable
     // since we don't want focus on md-sidenav (focus instead on close button) we omit this with [tabindex]:not(md-sidenav)
     const focusSelector = `a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]),
-        button:not([disabled]), iframe, object, embed, [tabindex]:not(md-sidenav), [contenteditable]`;
+        button:not([disabled]), iframe, object, embed, [contenteditable], [tabindex]:not(label, md-dialog, md-sidenav)`;
     // object containing all currently depressed keyboard keys
     const keys = {};
     // ordered list of elements which has received focus
@@ -530,6 +530,11 @@
 
         $.fn.link = function (targetElement) {
             link($(this), $(targetElement));
+        };
+
+        // sets focus on the next focusable element starting at currently scoped element
+        $.fn.nextFocus = function () {
+            focusableSearch($(this), true).focus(true);
         };
 
         /**

--- a/src/app/ui/common/dialog.decorator.js
+++ b/src/app/ui/common/dialog.decorator.js
@@ -34,15 +34,24 @@
             return $q(resolve => {
                 opts.focusOnOpen = opts.focusOnOpen === false ? false : true;
                 opts.onComplete = (_, element) => {
-                    // newly created focus trap tabindex must be -1 as required by focus manager for all focusable elements
-                    element
-                        .find('.md-dialog-focus-trap')
-                        .attr('tabindex', -1);
+                    // these traps are not needed and can cause issues, remove from DOM
+                    element.find('.md-dialog-focus-trap').remove();
 
+                    // keep focus within the dialog
                     element
                         .find('md-dialog')
-                        .attr('rv-trap-focus', '')
-                        .focus(opts.focusOnOpen);
+                        .attr('rv-trap-focus', '');
+
+                    // if an element with property rv-close-button exists we set focus on it. Sometimes the close button is
+                    // not the first focusable element, but in most cases it should be the first focused element
+                    if (opts.focusOnOpen) {
+                        const closeBtn = $('[rv-close-button]');
+                        if (closeBtn.length === 0) {
+                            element.nextFocus();
+                        } else {
+                            closeBtn.first().focus(true);
+                        }
+                    }
                     resolve();
                 };
                 origShow(opts);

--- a/src/app/ui/export/custom-size.directive.js
+++ b/src/app/ui/export/custom-size.directive.js
@@ -1,0 +1,24 @@
+(() => {
+    'use strict';
+
+    /**
+     * @module rvExportCustomSize
+     * @memberof app.ui
+     * @restrict E
+     * @description
+     *
+     * This directive contains the html template for setting a custom width and height for the
+     * export image. It sets focus on the first input (width) whenever it is created.
+     */
+    angular
+        .module('app.ui')
+        .directive('rvExportCustomSize', rvExportCustomSize);
+
+    function rvExportCustomSize() {
+        return {
+            restrict: 'E',
+            templateUrl: 'app/ui/export/custom-size.html',
+            link: (scope, el) => el.find('input').first().focus(true)
+        };
+    }
+})();

--- a/src/app/ui/export/custom-size.html
+++ b/src/app/ui/export/custom-size.html
@@ -1,0 +1,41 @@
+<md-input-container ng-disabled="self.isError">
+    <input type="number" required md-no-asterisk="true"
+        name="customSizeWidth"
+        min="{{ ::self.exportSizes.width.min }}"
+        max="{{ ::self.exportSizes.width.max }}"
+        ng-pattern="/\d/"
+        step="any"
+        placeholder="{{ 'export.size.customwidth' | translate }}"
+        ng-model="self.exportSizes.tempOption.width">
+
+    <div ng-messages="exportForm.customSizeWidth.$error" role="alert">
+        <div ng-message="min">
+            {{ 'export.error.minwidth' | translate:self.exportSizes.width }}
+        </div>
+        <div ng-message="max">
+            {{ 'export.error.maxwidth' | translate:self.exportSizes.width }}
+        </div>
+    </div>
+</md-input-container>
+
+<md-icon md-svg-src="navigation:close"></md-icon>
+
+<md-input-container ng-disabled="self.isError">
+    <input type="number" required md-no-asterisk
+        name="customSizeHeight"
+        min="{{ ::self.exportSizes.height.min }}"
+        max="{{ ::self.exportSizes.height.max }}"
+        step="any"
+        ng-pattern="/\d/"
+        placeholder="{{ 'export.size.customheight' | translate }}"
+        ng-model="self.exportSizes.tempOption.height">
+
+    <div ng-messages="exportForm.customSizeHeight.$error" role="alert">
+        <div ng-message="min">
+            {{ 'export.error.minheight' | translate:self.exportSizes.height }}
+        </div>
+        <div ng-message="max">
+            {{ 'export.error.maxheight' | translate:self.exportSizes.height }}
+        </div>
+    </div>
+</md-input-container>

--- a/src/app/ui/export/export.html
+++ b/src/app/ui/export/export.html
@@ -10,47 +10,7 @@
                     <p class="md-caption">{{ 'export.custom.note1' | translate }}</p>
                     <div class="rv-container" layout="column">
                         <div layout="row" layout-wrap>
-                            <md-input-container ng-disabled="self.isError">
-                                <input type="number" required md-no-asterisk="true"
-                                    name="customSizeWidth"
-                                    min="{{ ::self.exportSizes.width.min }}"
-                                    max="{{ ::self.exportSizes.width.max }}"
-                                    ng-pattern="/\d/"
-                                    step="any"
-                                    placeholder="{{ 'export.size.customwidth' | translate }}"
-                                    ng-model="self.exportSizes.tempOption.width">
-
-                                <div ng-messages="exportForm.customSizeWidth.$error" role="alert">
-                                    <div ng-message="min">
-                                        {{ 'export.error.minwidth' | translate:self.exportSizes.width }}
-                                    </div>
-                                    <div ng-message="max">
-                                        {{ 'export.error.maxwidth' | translate:self.exportSizes.width }}
-                                    </div>
-                                </div>
-                            </md-input-container>
-
-                            <md-icon md-svg-src="navigation:close"></md-icon>
-
-                            <md-input-container ng-disabled="self.isError">
-                                <input type="number" required md-no-asterisk
-                                    name="customSizeHeight"
-                                    min="{{ ::self.exportSizes.height.min }}"
-                                    max="{{ ::self.exportSizes.height.max }}"
-                                    step="any"
-                                    ng-pattern="/\d/"
-                                    placeholder="{{ 'export.size.customheight' | translate }}"
-                                    ng-model="self.exportSizes.tempOption.height">
-
-                                <div ng-messages="exportForm.customSizeHeight.$error" role="alert">
-                                    <div ng-message="min">
-                                        {{ 'export.error.minheight' | translate:self.exportSizes.height }}
-                                    </div>
-                                    <div ng-message="max">
-                                        {{ 'export.error.maxheight' | translate:self.exportSizes.height }}
-                                    </div>
-                                </div>
-                            </md-input-container>
+                            <rv-export-custom-size></rv-export-custom-size>
                         </div>
                         <div layout="row">
                             <span flex></span>
@@ -173,7 +133,8 @@
 
             <md-button
                 class="rv-button-square"
-                ng-click="self.close()">
+                ng-click="self.close()"
+                rv-close-button>
                 {{ 'export.close' | translate }}
             </md-button>
 


### PR DESCRIPTION
## Description
Note that the following point in the issue

> On close with esc, the focus should go back to export menu item and side panel should reopen

is not addressed here as this is more related to side-nav and menu interaction. The same behaviour is seen with the help dialog. We can discuss and open a separate issue if need be for such a change.

Closes #1623

## Testing
🙄 

## Documentation
inline, jsdocs

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1734)
<!-- Reviewable:end -->
