### PR TITLE
feat(filter): add complex query for global search

### DIFF
--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -225,28 +225,28 @@
                         // set position if not defined
                         if (column.position === -1) { column.position = index; }
 
-                        if (field.type === 'esriFieldTypeString') {
-                            const width = getColumnWidth(column.title, field.length, 250);
-                            column.width = `${width}px`;
-                            column.render = renderEllipsis(width);
-                        } else if (field.type === 'esriFieldTypeOID') {
-                            // set column to be 100px width because of details and zoom to buttons
-                            column.width = '100px';
-                        } else if (field.type === 'esriFieldTypeDate') {
-                            // convert each date cell to a better format
-                            displayData.rows.forEach(r => r[field.name] = $filter('dateTimeZone')(r[field.name]));
-                            const width = getColumnWidth(column.title, 0, 400, 375);
-                            column.width =  `${width}px`;
-                        } else {
-                            const width = getColumnWidth(column.title, 0, 250, 120);
-                            column.width = `${width}px`;
-                            column.render = renderEllipsis(width);
-                        }
-
-                        // set filter initial value if not initialize
+                        // set filter and column initial values if not initialize
                         if (!column.filter.init) {
                             column.filter = columnTypes[field.type].init();
                             column.filter.init = true;
+
+                            if (field.type === 'esriFieldTypeString') {
+                                const width = getColumnWidth(column.title, field.length, 250);
+                                column.width = `${width}px`;
+                                column.render = renderEllipsis(width);
+                            } else if (field.type === 'esriFieldTypeOID') {
+                                // set column to be 100px width because of details and zoom to buttons
+                                column.width = '100px';
+                            } else if (field.type === 'esriFieldTypeDate') {
+                                // convert each date cell to a better format
+                                displayData.rows.forEach(r => r[field.name] = $filter('dateTimeZone')(r[field.name]));
+                                const width = getColumnWidth(column.title, 0, 400, 375);
+                                column.width =  `${width}px`;
+                            } else {
+                                const width = getColumnWidth(column.title, 0, 250, 120);
+                                column.width = `${width}px`;
+                                column.render = renderEllipsis(width);
+                            }
                         }
                     }
                 });
@@ -414,15 +414,15 @@
                         // TODO: in 1.6 when we add the filters we will need a way to go to setting panel (skip the table)
                         layoutService.panes.filter.find('.dataTables_scrollBody').attr('rv-ignore-focusout', '');
 
-                        // recalculate scroller space on table init because if the preopen table was maximized in setting view
-                        // the scroller is still in split view
-                        self.table.scroller.measure();
-
                         // initialize a temporary array to store all the custom filters so they don't fire every time we add new one
                         $.fn.dataTable.ext.searchTemp = [];
 
                         // set active table so it can be accessed in filter-search.directive for global table search
                         filterService.setTable(self.table, displayData.filter.globalSearch);
+
+                        // recalculate scroller space on table init because if the preopen table was maximized in setting view
+                        // the scroller is still in split view
+                        self.table.scroller.measure();
 
                         // fired event to create filters
                         $rootScope.$broadcast(events.rvTableReady);

--- a/src/app/ui/filters/filters-search-directive.js
+++ b/src/app/ui/filters/filters-search-directive.js
@@ -20,46 +20,111 @@
      * @function rvFiltersSearch
      * @return {object} directive body
      */
-    function rvFiltersSearch() {
+    function rvFiltersSearch(filterService, stateManager) {
         const directive = {
             restrict: 'E',
             templateUrl: 'app/ui/filters/filters-search.html',
             scope: {},
+            link,
             controller: Controller,
             controllerAs: 'self',
             bindToController: true
         };
 
         return directive;
+
+        function link(scope, el) {
+            el.find('input').on('focus', () => {
+                changeColumnsName('data');
+            });
+
+            el.find('input').on('blur', () => {
+                changeColumnsName('title');
+            });
+        }
+
+        /**
+         * On search input focus show column field name, on blur show column title
+         *
+         * @function changeColumnsName
+         * @param   {String}   value   value to use to show column name (data = data source and title = alias name)
+         */
+        function changeColumnsName(value) {
+            const columns = stateManager.display.filters.data.columns;
+
+            angular.element(filterService.getTable().header()).find('th').each((i, el) => {
+                if (columns[i].data !== 'rvSymbol' && columns[i].data !== 'rvInteractive') {
+                    el.innerHTML = columns[i][value];
+                }
+            });
+        }
     }
 
-    function Controller(filterService, debounceService, $timeout, $rootElement, stateManager, $rootScope, events) {
+    function Controller(filterService, debounceService, $timeout, $rootElement, stateManager, $rootScope, events,
+        $scope) {
         'ngInject';
         const self = this;
 
         self.searchText = '';
-        self.search = debounceService.registerDebounce(search, 700, false);
+        self.search = debounceService.registerDebounce(search, 1200, false);
         self.clear = clear;
+
+        self.searchFilter = {};
+
+        // all test operations for filtering (\\ is use to escape character when we remove the operand)
+        const operators = {
+            '\\<': (a, b) => a < b[0],
+            '\\<=': (a, b) => a <= b[0],
+            '\\>': (a, b) => a > b[0],
+            '\\>=': (a, b) => a >= b[0],
+            '\\[|]': (a, b) => a >= b[0] && a <= b[1],
+            string: (a, b) => b.test(a.toUpperCase())
+        };
 
         $rootScope.$on(events.rvTableReady, () => {
             // set global search from saved state
             self.searchText = stateManager.display.filters.data.filter.globalSearch;
+
+            // filter for complex query
+            $.fn.dataTable.ext.searchTemp.push((settings, data) => {
+                return filterComplex(settings, data);
+            });
+
+            search();
+        });
+
+        $scope.stateManager = stateManager;
+        $scope.$watch('stateManager.display.filters.data.filter.globalSearch', value => {
+            if (value === '_reset_') {
+                stateManager.display.filters.data.filter.globalSearch = '';
+                self.searchText = '';
+            }
         });
 
         /**
          * Apply global search to the table.
          *
          * @function search
+         * @param   {Boolean}   [init=false] - true if the table is initialize, false otherwise
          */
-        function search() {
+        function search(init = false) {
             // show processing
             $rootElement.find('.dataTables_processing').css('display', 'block');
 
-            // redraw table with search parameter (use timeout for redraw so processing can show)
-            $timeout(() => { filterService.getTable().search(self.searchText).draw(); }, 100);
+            // set filter information if user enter value
+            const table = filterService.getTable();
+            buildFilters(table);
+
+            // if user enter value is not valid filters, simply search the whole datatable
+            // redraw table with search parameter (use timeout for redraw so processing can show
+            if (self.searchFilter.filters.length === 0) {
+                $timeout(() => { table.search(self.searchText).draw(); }, 100);
+            } else {
+                $timeout(() => { table.search('').draw(); }, 100);
+            }
 
             // keep global search value for this table
-            stateManager.display.filters.data.filter.globalSearch = self.searchText;
+            if (!init) { stateManager.display.filters.data.filter.globalSearch = self.searchText; }
         }
 
         /**
@@ -70,6 +135,129 @@
         function clear() {
             self.searchText = '';
             search();
+        }
+
+        /**
+         * Build filters object use by the custom filter to search the table
+         *
+         * @function buildFilters
+         * @param {Object} table table to search
+         */
+        function buildFilters(table) {
+            // reinitialize filters each time, if no valid filter, custom filter will not try to filter the table
+            self.searchFilter.filters = []; // reinitialize filters each time
+
+            // if no text or open quote is not close
+            if (self.searchText !== '' && (self.searchText.match(/"/g) || []).length % 2 === 0) {
+
+                // split all search value pairs (field:value). Keep string inside quote as one value
+                // (?:         # non-capturing group
+                //   [^\s"]+   # anything that's not a space or a double-quote
+                //   |         #   or…
+                //   "         # opening double-quote
+                //     [^"]*   # …followed by zero or more chacacters that are not a double-quote
+                //   "         # …closing double-quote
+                // )+          # each match is one or more of the things described in the group
+                const filters = self.searchText.match(/(?:[^\s"]+|"[^"]*")+/g);
+                filters.forEach(field => {
+                    const info = field.split(':');
+                    const value = (info.length === 2) ? info[1].replace(/"/g, '') : null; // make sure there is a value and remove quotes
+
+                    // check if user has enter a value for a column
+                    if (value !== null) {
+                        // check if column exist, if so set filter information
+                        const column = table.columns().dataSrc().toArray()
+                            .find(v => v.toUpperCase() === info[0].toUpperCase());
+
+                        if (typeof column !== 'undefined') {
+                            setFilterInfo(column, value);
+                        }
+                    }
+                });
+            }
+        }
+
+        /**
+         * Set information for a filter
+         *
+         * @function setFilterInfo
+         * @param {String} column column name to search on
+         * @param {String} value the search term
+         */
+        function setFilterInfo(column, value) {
+            // default filter object
+            const filter = { column, searchTerm: null, operator: null };
+
+            // see if value contain one of the operand
+            let operator = value.match(/(>=?|>=|<=?|<=|\[|\])/g); // check for presence of >, >=, <, <=, []
+
+            // get proper search term. If no operator, it is a string
+            if (operator === null) {
+                filter.searchTerm = (value === '') ? null : new RegExp(value.toUpperCase());
+                filter.operator = operators.string;
+                filter.type = 'string';
+            } else {
+                // check if it is a valid operator (add some characters so we can easely remove operators from search term)
+                operator = `\\${operator.join('|')}`;
+                if (typeof operators[operator] !== 'undefined') {
+                    filter.operator = operators[operator];
+
+                    // parse search term as float to see if it is a number (split .. for range and - for date)
+                    const userValue = value.replace(new RegExp(operator), '').split(/\.\.|-/g)
+                        .map(val => parseFloat(val));
+
+                    // check if it is only numbers
+                    if (!userValue.some(isNaN)) {
+                        // set filter type and if it is a date, create date object
+                        filter.type = (userValue.length <= 2) ? 'number' : 'date';
+                        filter.searchTerm = (filter.type === 'number') ?
+                            userValue :
+                            [new Date(userValue.splice(0, 3).join('-')), new Date(userValue.splice(0, 3).join('-'))];
+                    }
+                }
+            }
+
+            // add the filter to searchFilter object so it can be accessed from the custom filter
+            if (filter.searchTerm !== null && filter.operator !== null) {
+                self.searchFilter.filters.push(filter);
+            }
+        }
+
+        /**
+         * Filter (search) table with a complex query
+         *
+         * @function filterComplex
+         * @param {Object} settings table settings to search on
+         * @param {Array} data data for the row to test if it pass the filters
+         */
+        function filterComplex(settings, data) {
+            let dataFlag = true;
+
+            if (self.searchFilter.filters.length > 0) {
+                const filters = self.searchFilter.filters;
+
+                filters.forEach(filter => {
+                    // if one of the filters is not good we already know we should hide the row (AND approach)
+                    if (dataFlag) {
+                        // get column index to find row data
+                        const column = settings.aoColumns
+                            .find(v => v.data.toUpperCase() === filter.column.toUpperCase());
+
+                        // check if we need to parse the value
+                        let value = data[column.idx];
+                        if (filter.type === 'number') {
+                            value = parseFloat(value);
+                        } else if (filter.type === 'date') {
+                            value = new Date(value.split(' ')[0]);
+                        }
+
+                        // check if it pass the filter
+                        dataFlag = filter.operator(value, filter.searchTerm);
+                    }
+                });
+            }
+
+            return dataFlag;
         }
     }
 })();

--- a/src/app/ui/filters/filters.service.js
+++ b/src/app/ui/filters/filters.service.js
@@ -113,13 +113,9 @@
          *
          * @function setTable
          * @param   {Object}   table   active table
-         * @param   {String}   search   search filter to apply
          */
-        function setTable(table, search) {
+        function setTable(table) {
             activeTable = table;
-
-            // set global search for the active table
-            table.search(search);
 
             // reset all filters state to false (they will be populated by the loading table)
             filtersObject = table.columns().dataSrc();
@@ -155,6 +151,9 @@
         function clearFilters() {
             const filters = stateManager.display.filters;
 
+            // show processing
+            $rootElement.find('.dataTables_processing').css('display', 'block');
+
             // set isApplied to hide apply filters on map button
             service.filter.isApplied = true;
             filters.data.filter.isApplied = service.filter.isApplied;  // set on layer so it can persist when we change layer
@@ -162,6 +161,9 @@
             // check if we need to show filter flag
             filters.requester.legendEntry.flags.filter.visible =
                 (service.filter.isActive) ? true : false;
+
+            // reset global search ($watch in filters-search.directive will remove the value)
+            stateManager.display.filters.data.filter.globalSearch = '_reset_';
 
             // reset all filters state to false
             filtersObject.each((el) => {
@@ -183,9 +185,6 @@
                     }
                 }
             });
-
-            // show processing
-            $rootElement.find('.dataTables_processing').css('display', 'block');
 
             // if filter by extent is enable, manually trigger the on extentChange event to refresh the table
             if (service.filter.isActive) { onExtentChange(); }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Related to #1619

Use GitHub search syntax to search datatable for complex query. We can still only put text and datatable will try to find the value everywhere inside the table. To have a more specific search, user can search by field. All field:value pairs are cumulative and treated as AND query.

user can filter a string field who contain number as a numeric field. Some field seems to be date but they are not (e.g. 2/23/2208). Trying to filter those field by date will give bad results

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome, FF and Safari

All field:value pairs is separated by a space

string - fieldName:value e.g. tc_id:myvalue
e.g. tc_id:"this is my value" (if spaces in the query enclose text in "")
e.g. tc_id:valueA|valueB (pipe character | is used to say OR)

number fieldName: (select operand <=, <, >=, >, []
e.g. tc_id:>10
e.g. tc_ic:[0..100]

date works the same way but they need to be in this format: yyyy-mm-dd e.g.: tc_id:>2014-01-01

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1735)
<!-- Reviewable:end -->
