### PR TITLE
fix(ui): use append-selector to avoid squashing

### DIFF
--- a/src/content/styles/common/_all.scss
+++ b/src/content/styles/common/_all.scss
@@ -25,8 +25,10 @@ $fade-in-out-duration: 130ms;
 $keyboard-only: '.rv-keyboard-only';
 
 @mixin keyboard {
-    @at-root.rv-keyboard#{&} {
-        @content;
+    @at-root {
+        #{selector-append('.rv-keyboard', &)} {
+            @content;
+        }
     }
 }
 
@@ -39,34 +41,38 @@ $keyboard-only: '.rv-keyboard-only';
 }
 
 @mixin touch {
-    @at-root.rv-touch#{&} {
-        @content;
+    @at-root {
+        #{selector-append('.rv-touch', &)} {
+            @content;
+        }
     }
 }
 
 @mixin include-size($name) {
     @if $name == rv-gt-sm {
         @at-root {
-            .rv-medium#{&}, .rv-large#{&} {
+            #{selector-append('.rv-medium', &)},
+            #{selector-append('.rv-large', &)} {
                 @content;
             }
         }
     } @else if $name == rv-sm {
-        @at-root.rv-small#{&} {
+        @at-root #{selector-append('.rv-small', &)} {
             @content;
         }
     } @else if $name == rv-lt-lg {
         @at-root {
-            .rv-small#{&}, .rv-medium#{&} {
+            #{selector-append('.rv-small', &)},
+            #{selector-append('.rv-medium', &)} {
                 @content;
             }
         }
     } @else if $name == rv-md {
-        @at-root.rv-medium#{&} {
+        @at-root #{selector-append('.rv-medium', &)} {
             @content;
         }
     } @else if $name == rv-lg {
-        @at-root.rv-large#{&} {
+        @at-root #{selector-append('.rv-large', &)} {
             @content;
         }
     }


### PR DESCRIPTION
## Description
App's top level selectors (`fgpv` class and `is="rv-map"`) were treated as a single selector breaking any map using `fgpv` class instead of `is="rv-map"`.

Closes #1737

## Testing
Eyeballs.

## Documentation
Nope.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1738)
<!-- Reviewable:end -->
