### PR TITLE
feat(focus): Add arrow support for md-menu and other improvements

### DIFF
--- a/docs/developer/technical/focus_manager.md
+++ b/docs/developer/technical/focus_manager.md
@@ -2,6 +2,16 @@
 
 To be accessible and WCAG 2 compliant, the viewer needs to support keyboard users as well as mice-wielding ones (by extension, dual-class power users who use both devices also need to be thought of). The focus manager is therefore responsible for allowing users to navigate through the viewer seamlessly, making content easy to reach no matter what input device is used.
 
+### Element Attributes
+
+| Name | Description |
+| **** | *********** |
+| rv-trap-focus         |  Once focus enters an element or child of this element, focus movement is restricted within it. If focus is at the end of the trap, it is moved to the first focusable element in the trap. Focus can only leave if the focus manager is disabled, or the entire trapped element is not focusabled (i.e. is hidden, destroyed). The value must be the viewers HTML id. This can be used on elements whos HTML is rendered outside the viewers HTML so that focus manager includes it as part of the viewers focus movement flow.
+| rv-focus-status       |  Added to the main viewer HTML element with a value of either NONE, INACTIVE, WAITING, ACTIVE to signify the current focus state of the viewer. This is useful for outside libraries to see the current state of any given viewer.
+| rv-ignore-focusout    |  Normally the focus manager attempts to recover from a loss of focus by moving back through its history. This attribute disables this behaviour so no recovery is initiated.
+| rv-focus-init         |  Allows the use of focus() on the viewer element with this attribute or any of its children if focus is not current on the element or any of its children. This allows outside libraries to set initial focus normally, yet restricts them on subsequent movement attempts.
+
+
 #### Important concepts you should know
 
 Before we go into how it works, there are some key concepts you'll need to be aware of that affect all parts of the viewer:
@@ -9,19 +19,21 @@ Before we go into how it works, there are some key concepts you'll need to be aw
 - The `$rootElement` has an `rv-trap-focus` property set in `bootstrap.js` (more on this later)
 - Any element which is not a descendent of `$rootElement` but should be considered a part of the viewer must have an `rv-trap-focus` property set with a value equal to the `$rootElement` id property
 - The javascript prototype functions `focus`, `preventDefault`, `stopPropagation`, and `stopImmediatePropagation` are disabled for all elements and descendents of an `rv-trap-focus`.
-    - To set focus, use `focusService.setFocus(myElement)`
-    - `preventDefault`, `stopPropagation`, and `stopImmediatePropagation` can be used by passing an extra parameter `true` as in `$('#myElement').preventDefault(true)`. You should never prevent or stop the bubbling of `mousedown`,`keydown` or `keyup` as they are needed for the focus manager to work effectively.
-- The tabindex of all focusable elements inside the viewer (except for the map) is set to -1. You should not set or rely on tabindex for proper tab order.
+    - To set focus, use `element.rvFocus()`
+    - `preventDefault`, `stopPropagation`, and `stopImmediatePropagation` can be used by passing an extra parameter `true` as in `element.preventDefault(true)`. You should never prevent or stop the bubbling of `mousedown`,`keydown` or `keyup` as they are needed for the focus manager to work effectively.
+- The tabindex of all browser focusable elements inside a viewer is set to -1. You should not set or rely on tabindex for proper tab order.
+- A tabindex of -2 is a special value which indicates that the viewer element is focusable.
+- A tabindex of -3 is a special value which indicates that the viewer element is not only focusable, it is focusable through the focus() prototype property which is usually restricted. This is useful for granting outside libraries focus access to a specific element.
 
 #### rv-trap-focus
 
-An element with this property ensures that focus will not leave, unless the element itself is destroyed or hidden. When the last element is reached and the `tab` key is pressed the first focusable element is focused. 
+An element with this property ensures that focus will not leave, unless the element itself is destroyed or hidden. When the last element is reached and the `tab` key is pressed the first focusable element is focused.
 
 #### How it works
 
 When focus reaches the viewer in an embedded page, a dialog appears asking if the user would like to enter the viewer, or provides the option to skip over it. In full screen viewers, or when navigated to by mouse, the viewer is activated automatically. If the user chooses to skip the viewer, the tab key moves focus to the next element outside the viewer. Since all viewer elements have a tabindex of `-1`, this is handled natively by the browser itself. If the user chooses to enter the viewer, the focus manager intercepts all tab key presses and handles the focus movement.
 
-It's common for focused elements to be destroyed or hidden during normal viewer use such as when a panel is closed or a menu disappears. When this happens, the last known focusable element is automatically focused. 
+It's common for focused elements to be destroyed or hidden during normal viewer use such as when a panel is closed or a menu disappears. When this happens, the last known focusable element is automatically focused.
 
 To escape the viewer the user must press `escape` + `tab`. This disables focus management and the tab key naturally moves to the next focusable element outside the viewer. Mouse clicking outside the viewer also disables it.
 
@@ -30,4 +42,4 @@ To escape the viewer the user must press `escape` + `tab`. This disables focus m
 There are two instances you should use the focus manager:
 
 - When a user action (like a click or keypress) changes the viewer and you'd like focus moved to some other area of the viewer. A common scenario is when a dialog opens and you'd like focus moved to the close button.
-- When you want to override the default focus movement behaviour between two elements. This is done automatically in table of contents when you select `settings` and the settings panel opens. A link between the toc layer and the setting panel has been created. 
+- When you want to override the default focus movement behaviour between two elements. This is done automatically in table of contents when you select `settings` and the settings panel opens. A link between the toc layer and the setting panel has been created.

--- a/gulp.config.js
+++ b/gulp.config.js
@@ -51,6 +51,7 @@ module.exports = function () {
             'global-registry.js',
             'app.js',
             'templates.js',
+            'focus-manager.js',
             'app-seed.js',
             'corePlugins.js',
         ],

--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -313,7 +313,6 @@
     // load core.js last and execute any deferred polyfills/patches
     loadScript(`${repo}/core.js`, () => {
         RV._deferredPolyfills.forEach(dp => dp());
-        RV.focusManager.init();
         RV.allScriptsLoaded = true;
         fireRvReady();
     });

--- a/src/app/geo/overview-toggle.directive.js
+++ b/src/app/geo/overview-toggle.directive.js
@@ -32,7 +32,7 @@
                     translate
                     translate-attr-aria-label="geo.aria.overviewtoggle"
                     class="md-icon-button rv-button-24 md-button"
-                    tabindex="0"
+                    tabindex="-2"
                     ng-click="toggleOverview()">
                     <md-icon md-svg-src="community:apple-keyboard-control"></md-icon>
                 </md-button>`,

--- a/src/app/ui/basemap/basemap.service.js
+++ b/src/app/ui/basemap/basemap.service.js
@@ -54,7 +54,7 @@
             return $mdSidenav('right')
                 .open()
                 // Once the side panel is open, set focus on the panel
-                .then(() => $('md-sidenav[md-component-id="right"] button').first().focus(true));
+                .then(() => $('md-sidenav[md-component-id="right"] button').first().rvFocus());
 
             /**
              * Makes all other chrome almost transparent so the basemap is more clearly visible

--- a/src/app/ui/common/dialog.decorator.js
+++ b/src/app/ui/common/dialog.decorator.js
@@ -34,15 +34,26 @@
             return $q(resolve => {
                 opts.focusOnOpen = opts.focusOnOpen === false ? false : true;
                 opts.onComplete = (_, element) => {
-                    // newly created focus trap tabindex must be -1 as required by focus manager for all focusable elements
-                    element
-                        .find('.md-dialog-focus-trap')
-                        .attr('tabindex', -1);
+                    // these traps are not needed and can cause issues, remove from DOM
+                    element.find('.md-dialog-focus-trap').remove();
 
+                    // keep focus within the dialog
                     element
                         .find('md-dialog')
                         .attr('rv-trap-focus', '')
-                        .focus(opts.focusOnOpen);
+                        .removeAttr('tabindex');
+
+                    // if an element with property rv-close-button exists we set focus on it. Sometimes the close button is
+                    // not the first focusable element, but in most cases it should be the first focused element
+                    if (opts.focusOnOpen) {
+                        const closeBtn = $(element).find('[rv-close-button]');
+                        if (closeBtn.length === 0) {
+                            element.nextFocus();
+                        } else {
+                            closeBtn.first().rvFocus();
+                        }
+                    }
+
                     resolve();
                 };
                 origShow(opts);

--- a/src/app/ui/common/dragula.directive.js
+++ b/src/app/ui/common/dragula.directive.js
@@ -229,7 +229,7 @@
              * Set focus to the drag handle of the supplied dom node if any.
              */
             function setFocusToDragHandle(element) {
-                element.find(`${dragHandleSelector}:first`).focus(true);
+                element.find(`${dragHandleSelector}:first`).rvFocus();
             }
 
             /**
@@ -301,7 +301,7 @@
                 isReordering = true; // prevents escaping focus from ending dragging
 
                 targetBelowElement.before(dragElement); // move the dragElement
-                target.focus(true); // reset focus on the drag handle of the moved element
+                target.rvFocus(); // reset focus on the drag handle of the moved element
 
                 isReordering = false;
 

--- a/src/app/ui/common/menu.decorator.js
+++ b/src/app/ui/common/menu.decorator.js
@@ -1,0 +1,45 @@
+(() => {
+    'use strict';
+
+    /**
+     * @module mdMenuDirective
+     * @memberof material.components.menu
+     * @description
+     *
+     * Allows mdMenus to set their own initial focus on open. After this, focus manager handles movement within the menu.
+     */
+
+    angular
+        .module('material.components.menu')
+        .decorator('mdMenuDirective', mdMenuDirective);
+
+    function mdMenuDirective($delegate) {
+        'ngInject';
+
+        const mdMenuDirective = $delegate[0]; // get the vanilla directive
+        const originalCompile = mdMenuDirective.compile; // store reference to its compile function
+        mdMenuDirective.compile = decorateCompile(originalCompile); // decorate compile function
+
+        return ([mdMenuDirective]);
+
+        /**
+         * Decorates the original menu compile functions.
+         * @function decorateCompile
+         * @param  {Function} originalCompile original compile function
+         * @return {Function}                 enhances link function returned by the decorated compile function
+         */
+        function decorateCompile(originalCompile) {
+            return (...args) => {
+                const originalLink = originalCompile(...args);
+
+                // return a decorated link function
+                return (scope, el, attrs, ctrls) => {
+                    // call the original link function
+                    originalLink(scope, el, attrs, ctrls);
+                    // allow menu directive to set initial focus
+                    el.find('md-menu-content').attr('rv-focus-init', '');
+                };
+            };
+        }
+    }
+})();

--- a/src/app/ui/common/select.decorator.js
+++ b/src/app/ui/common/select.decorator.js
@@ -1,0 +1,44 @@
+(() => {
+    'use strict';
+
+    /**
+     * @module mdSelectDirective
+     * @memberof material.components.menu
+     * @description
+     *
+     * Allows mdMenus to set their own initial focus on open. After this, focus manager handles movement within the menu.
+     */
+
+    angular
+        .module('material.components.select')
+        .decorator('mdSelectDirective', mdSelectDirective);
+
+    function mdSelectDirective($delegate) {
+        'ngInject';
+
+        const mdSelectDirective = $delegate[0]; // get the vanilla directive
+        const originalCompile = mdSelectDirective.compile; // store reference to its compile function
+        mdSelectDirective.compile = decorateCompile(originalCompile); // decorate compile function
+
+        return ([mdSelectDirective]);
+
+        /**
+         * Decorates the original menu compile functions.
+         * @function decorateCompile
+         * @param  {Function} originalCompile original compile function
+         * @return {Function}                 enhances link function returned by the decorated compile function
+         */
+        function decorateCompile(originalCompile) {
+            return (...args) => {
+                const originalLink = originalCompile(...args);
+
+                // return a decorated link function
+                return (scope, el, attrs, ctrls) => {
+                    // call the original link function
+                    originalLink(scope, el, attrs, ctrls);
+                    el.attr('tabindex', '-3');
+                };
+            };
+        }
+    }
+})();

--- a/src/app/ui/common/stepper/stepper.class.js
+++ b/src/app/ui/common/stepper/stepper.class.js
@@ -165,7 +165,7 @@
                         // when step is closed. We put 250 ms because with 100ms Safari sometimes lose focus.
                         if (typeof this.currentStep.focus !== 'undefined') {
                             $timeout(() => {
-                                $rootElement.find(`[name=${this.currentStep.focus}]`).first().focus(true);
+                                $rootElement.find(`[name=${this.currentStep.focus}]`).first().rvFocus();
                             }, 250);
                         }
                     }

--- a/src/app/ui/export/custom-size.directive.js
+++ b/src/app/ui/export/custom-size.directive.js
@@ -1,0 +1,24 @@
+(() => {
+    'use strict';
+
+    /**
+     * @module rvExportCustomSize
+     * @memberof app.ui
+     * @restrict E
+     * @description
+     *
+     * This directive contains the html template for setting a custom width and height for the
+     * export image. It sets focus on the first input (width) whenever it is created.
+     */
+    angular
+        .module('app.ui')
+        .directive('rvExportCustomSize', rvExportCustomSize);
+
+    function rvExportCustomSize() {
+        return {
+            restrict: 'E',
+            templateUrl: 'app/ui/export/custom-size.html',
+            link: (scope, el) => el.find('input').first().rvFocus({ delay: 400 })
+        };
+    }
+})();

--- a/src/app/ui/export/custom-size.html
+++ b/src/app/ui/export/custom-size.html
@@ -1,0 +1,41 @@
+<md-input-container ng-disabled="self.isError">
+    <input type="number" required md-no-asterisk="true"
+        name="customSizeWidth"
+        min="{{ ::self.exportSizes.width.min }}"
+        max="{{ ::self.exportSizes.width.max }}"
+        ng-pattern="/\d/"
+        step="any"
+        placeholder="{{ 'export.size.customwidth' | translate }}"
+        ng-model="self.exportSizes.tempOption.width">
+ 
+    <div ng-messages="exportForm.customSizeWidth.$error" role="alert">
+        <div ng-message="min">
+            {{ 'export.error.minwidth' | translate:self.exportSizes.width }}
+        </div>
+        <div ng-message="max">
+            {{ 'export.error.maxwidth' | translate:self.exportSizes.width }}
+        </div>
+    </div>
+</md-input-container>
+ 
+<md-icon md-svg-src="navigation:close"></md-icon>
+ 
+<md-input-container ng-disabled="self.isError">
+    <input type="number" required md-no-asterisk
+        name="customSizeHeight"
+        min="{{ ::self.exportSizes.height.min }}"
+        max="{{ ::self.exportSizes.height.max }}"
+        step="any"
+        ng-pattern="/\d/"
+        placeholder="{{ 'export.size.customheight' | translate }}"
+        ng-model="self.exportSizes.tempOption.height">
+ 
+    <div ng-messages="exportForm.customSizeHeight.$error" role="alert">
+        <div ng-message="min">
+            {{ 'export.error.minheight' | translate:self.exportSizes.height }}
+        </div>
+        <div ng-message="max">
+            {{ 'export.error.maxheight' | translate:self.exportSizes.height }}
+        </div>
+    </div>
+</md-input-container>

--- a/src/app/ui/export/export.html
+++ b/src/app/ui/export/export.html
@@ -10,47 +10,7 @@
                     <p class="md-caption">{{ 'export.custom.note1' | translate }}</p>
                     <div class="rv-container" layout="column">
                         <div layout="row" layout-wrap>
-                            <md-input-container ng-disabled="self.isError">
-                                <input type="number" required md-no-asterisk="true"
-                                    name="customSizeWidth"
-                                    min="{{ ::self.exportSizes.width.min }}"
-                                    max="{{ ::self.exportSizes.width.max }}"
-                                    ng-pattern="/\d/"
-                                    step="any"
-                                    placeholder="{{ 'export.size.customwidth' | translate }}"
-                                    ng-model="self.exportSizes.tempOption.width">
-
-                                <div ng-messages="exportForm.customSizeWidth.$error" role="alert">
-                                    <div ng-message="min">
-                                        {{ 'export.error.minwidth' | translate:self.exportSizes.width }}
-                                    </div>
-                                    <div ng-message="max">
-                                        {{ 'export.error.maxwidth' | translate:self.exportSizes.width }}
-                                    </div>
-                                </div>
-                            </md-input-container>
-
-                            <md-icon md-svg-src="navigation:close"></md-icon>
-
-                            <md-input-container ng-disabled="self.isError">
-                                <input type="number" required md-no-asterisk
-                                    name="customSizeHeight"
-                                    min="{{ ::self.exportSizes.height.min }}"
-                                    max="{{ ::self.exportSizes.height.max }}"
-                                    step="any"
-                                    ng-pattern="/\d/"
-                                    placeholder="{{ 'export.size.customheight' | translate }}"
-                                    ng-model="self.exportSizes.tempOption.height">
-
-                                <div ng-messages="exportForm.customSizeHeight.$error" role="alert">
-                                    <div ng-message="min">
-                                        {{ 'export.error.minheight' | translate:self.exportSizes.height }}
-                                    </div>
-                                    <div ng-message="max">
-                                        {{ 'export.error.maxheight' | translate:self.exportSizes.height }}
-                                    </div>
-                                </div>
-                            </md-input-container>
+                            <rv-export-custom-size></rv-export-custom-size>
                         </div>
                         <div layout="row">
                             <span flex></span>
@@ -173,7 +133,8 @@
 
             <md-button
                 class="rv-button-square"
-                ng-click="self.close()">
+                ng-click="self.close()"
+                rv-close-button>
                 {{ 'export.close' | translate }}
             </md-button>
 

--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -412,7 +412,7 @@
                     // focus on close button when table open (wcag requirement)
                     // at the same time it solve a problem because when focus is on menu button, even if focus is on the
                     // table cell it goes inside the menu and loop through it at the same time as we navigate the table
-                    $timeout(() => { $rootElement.find('[type=\'filters\'] button.rv-close').focus(true); }, 100);
+                    $rootElement.find('[type=\'filters\'] button.rv-close').rvFocus({ delay: 100 });
 
                     // when we navigate with the keyboard, the scroller extension has buffer items in memory. Without this
                     // workaround, the keyboard can only navigate inside those items.
@@ -431,7 +431,7 @@
                         // if there is a button inside the node, focus to it so keyboard user can interact with it
                         // pressing tab will focus the next button
                         const node = $(cell.node()).find('button');
-                        if (node.length > 0) { node.first().focus(true); }
+                        if (node.length > 0) { node.first().rvFocus(); }
 
                         if (!key || !draw) {
                             // need to scroll where the focus is (if outside the visible items). It is not always done automatically
@@ -446,7 +446,7 @@
                             // after the draw, datatable.scroller.page() info are wrong so we can't use them to know if we are
                             // in the visible area
                             const focusRow = scrollCell[0][0].row;
-                            self.table.cell(focusRow, cellInfo.column).focus();
+                            self.table.cell(focusRow, cellInfo.column).rvFocus();
                             self.table.row(focusRow - 1).scrollTo(false); // false because we doesn't want animation
                             draw = false;
                             scrollCell = false;

--- a/src/app/ui/geosearch/geosearch-bar.directive.js
+++ b/src/app/ui/geosearch/geosearch-bar.directive.js
@@ -42,7 +42,7 @@
         /***/
         function link(scope, el) {
             // auto focus on the search field when created
-            el.find('md-autocomplete').focus(true);
+            el.find('md-autocomplete').rvFocus();
         }
     }
 

--- a/src/app/ui/loader/loader-file.directive.js
+++ b/src/app/ui/loader/loader-file.directive.js
@@ -373,7 +373,7 @@
 
             // there is a bug with Firefox and Safari on a Mac. They don't focus back to add layer when close
             $timeout(() => {
-                $rootElement.find('.rv-loader-add').first().focus(true);
+                $rootElement.find('.rv-loader-add').first().rvFocus();
             }, 0);
         }
     }

--- a/src/app/ui/loader/loader-menu.directive.js
+++ b/src/app/ui/loader/loader-menu.directive.js
@@ -64,7 +64,7 @@
          */
         function setFocus(name) {
             $timeout(() => {
-                $rootElement.find(`${name} .rv-header-float button`).first().focus(true);
+                $rootElement.find(`${name} .rv-header-float button`).first().rvFocus();
             }, 0);
         }
     }

--- a/src/app/ui/loader/loader-service.directive.js
+++ b/src/app/ui/loader/loader-service.directive.js
@@ -260,7 +260,7 @@
 
             // there is a bug with Firefox and Safari on a Mac. They don't focus back to add layer when close
             $timeout(() => {
-                $rootElement.find('.rv-loader-add').first().focus(true);
+                $rootElement.find('.rv-loader-add').first().rvFocus();
             }, 0);
         }
     }

--- a/src/app/ui/panels/content-pane.html
+++ b/src/app/ui/panels/content-pane.html
@@ -26,7 +26,8 @@
             translate-attr-aria-label="contentPane.aria.close"
             class="rv-close md-icon-button black rv-button-24"
             ng-click="self.closePanel()"
-            ng-if="self.closePanel">
+            ng-if="self.closePanel"
+            rv-close-button>
             <md-tooltip>{{'contentPane.tooltip.close' | translate}}</md-tooltip>
             <md-icon class="rv-lt-lg" md-svg-src="navigation:arrow_back"></md-icon>
             <md-icon class="rv-lg" md-svg-src="navigation:close"></md-icon>
@@ -43,7 +44,8 @@
             aria-label="Close"
             class="md-icon-button black rv-button-auto"
             ng-click="self.closePanel()"
-            ng-if="self.closePanel">
+            ng-if="self.closePanel"
+            rv-close-button>
             <md-tooltip>Close</md-tooltip>
             <md-icon class="rv-show-single" md-svg-src="navigation:arrow_back"></md-icon>
             <md-icon class="rv-hide-single" md-svg-src="navigation:close"></md-icon>

--- a/src/app/ui/sidenav/sidenav.service.js
+++ b/src/app/ui/sidenav/sidenav.service.js
@@ -248,7 +248,7 @@
         function open() {
             $mdSidenav('left')
                 .open()
-                .then(() => $('md-sidenav[md-component-id="left"] button').first().focus(true));
+                .then(() => $('md-sidenav[md-component-id="left"] button').first().rvFocus());
         }
 
         /**

--- a/src/app/ui/toc/templates/entry-flag.html
+++ b/src/app/ui/toc/templates/entry-flag.html
@@ -1,6 +1,6 @@
 <div
     class="rv-icon-14 rv-layer-item-flag"
-    tabindex="0"
+    tabindex="-2"
     ng-if="self.control.visible"
     rv-help="layer-flag"
     aria-label="{{ self.template.tooltip[self.control.value] || self.template.tooltip | translate:self.data }}">


### PR DESCRIPTION
## Description
- Removed requirement for calling init(), now initialized before
app-seed but after jQuery (required)
- Added new HTML and jQuery element prototype rvFocus() which replaces focus(true) when
setting focus on viewer elements. They are now exclusive and will raise
a warning when used incorrectly.
- Added attribute rv-focus-init which allows the use of focus() on a
viewer element or one of its children if focus is outside the element
- Added jQuery element prototype nextFocus() which moves focus to the
next element
- Documentation added

Closes #1623, #1373

## Testing
Yes, quite a bit

## Documentation
Of course!

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1741)
<!-- Reviewable:end -->
