### PR TITLE
fix(ui): restored dialog opening animation

### DIFF
--- a/src/app/ui/details/details-modal.html
+++ b/src/app/ui/details/details-modal.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Details Summary" ng-cloak class="rv-details-summary">
+<md-dialog aria-label="Details Summary" class="rv-details-summary">
     <!-- TODO: add metadata translation -->
     <rv-content-pane
         close-panel="self.cancel()"

--- a/src/app/ui/export/export.html
+++ b/src/app/ui/export/export.html
@@ -1,5 +1,5 @@
 <md-dialog class="rv-export">
-    <form ng-cloak name="exportForm">
+    <form name="exportForm">
         <md-dialog-content>
             <div class="md-dialog-content" ng-class="{ 'rv-error': self.isError }">
 

--- a/src/app/ui/help/help-summary.html
+++ b/src/app/ui/help/help-summary.html
@@ -1,4 +1,4 @@
-<md-dialog ng-cloak class="rv-help-summary">
+<md-dialog class="rv-help-summary">
 
     <rv-content-pane
         close-panel="self.closeHelpSummary()"

--- a/src/app/ui/metadata/metadata-modal.html
+++ b/src/app/ui/metadata/metadata-modal.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Help Summary" ng-cloak class="rv-help-summary">
+<md-dialog aria-label="Help Summary" class="rv-help-summary">
     <!-- TODO: add metadata translation -->
     <rv-content-pane close-panel="self.cancel()" title-style="title" title-value="Metadata: {{self.display.requester.name}}">
         <div class="md-dialog-content">

--- a/src/app/ui/sidenav/share-dialog.html
+++ b/src/app/ui/sidenav/share-dialog.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="{{'sidenav.label.sharelink' | translate}}" ng-cloak class="side-nav-summary">
+<md-dialog aria-label="{{'sidenav.label.sharelink' | translate}}" class="side-nav-summary">
     <rv-content-pane close-panel="self.close()" title-style="title" title-value="{{'sidenav.label.sharelink' | translate}}">
 
         <md-switch class="md-primary" ng-if="self.googleAPIUrl" dir="rtl" md-no-ink aria-label="{{'sidenav.label.shortlink' | translate}}" ng-model="self.isShortLink" ng-change="self.switchChanged(self.isShortLink)">


### PR DESCRIPTION
## Description
AM only supports the opening animation for dialogs without ng-cloak.
There is no plan on changing this.

Closing #1312

## Testing
:eyes: 

## Documentation
none

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1742)
<!-- Reviewable:end -->
