### PR TITLE
fix(build): remove-apikey didn't execute async

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -361,11 +361,11 @@ gulp.task('inject', 'Adds configured dependencies to the HTML page',
         aliases: ['build']
     });
 
-gulp.task('remove-apikey', 'Remove internal Google API key from config', ['inject'], () => {
+gulp.task('remove-apikey', 'Remove internal Google API key from config', ['inject'], () =>
     gulp.src([config.sampleBuild + 'config*.json'])
         .pipe($.deleteLines({ filters: [/\s*"googleAPIKey": \S+/] }))
-        .pipe(gulp.dest(config.sampleBuild));
-});
+        .pipe(gulp.dest(config.sampleBuild))
+);
 
 gulp.task('samples', 'Generate sample archives for distribution', ['remove-apikey'], () =>
     merge(
@@ -393,7 +393,7 @@ gulp.task('packages', 'Generate package archives for distribution', ['inject'], 
             .pipe(gulp.dest('dist')))
 );
 
-gulp.task('prod', 'Sets production mode', () => PROD_MODE = true);
+gulp.task('prod', 'Sets production mode', () => (PROD_MODE = true));
 
 gulp.task('dist', 'Generate tgz and zip files for distribution', done => {
     // delete any previous distribution files


### PR DESCRIPTION
## Description
The `samples` task was not waiting properly on the `remove-apikey` task completion as it wasn't returning a promise.

@alyec maybe this was the problem with one of the config files in the samples archive being completely empty.

## Testing
Made local sample builds.

## Documentation
Not needed.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1746)
<!-- Reviewable:end -->
