### PR TITLE
fix(core): pin angular messages dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,13 +6,14 @@
   "license": "MIT",
   "private": true,
   "devDependencies": {
-    "angular-mocks": "~1.4.3",
+    "angular-mocks": "1.4.12",
     "bardjs": "0.1.10"
   },
   "dependencies": {
     "angular": "1.4.12",
     "angular-animate": "1.4.12",
     "angular-aria": "1.4.12",
+    "angular-messages": "1.4.12",
     "angular-dragula": "1.2.7",
     "angular-material": "1.1.3",
     "angular-minicolors": "^0.0.9",


### PR DESCRIPTION
## Description
Angular material is using "angular-messages": "^1.4.8" which pulls 1.6.x
of the angular messages which breaking the build. Pin `angular-messages` and `angular-mocks`. Thank you.

## Testing
Yeah!

## Documentation
Nope.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1747)
<!-- Reviewable:end -->
