### PR TITLE
fix(log): removed console output in production

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -248,8 +248,7 @@ function jsbuild() {
             single_quotes: true
         }))
         .pipe($.angularFilesort())
-        .pipe($.concat(config.jsSingleFile))
-        .pipe($.if(PROD_MODE, $.removeLogging()));
+        .pipe($.concat(config.jsSingleFile));
 }
 
 // NOTE assetcopy should only be used for samples for development
@@ -281,8 +280,7 @@ gulp.task('jsrollup', 'Roll up all js into one file',
         const seed = gulp.src([config.jsGlobalRegistry, config.jsAppSeed])
             .pipe($.plumber({ errorHandler: injectError }))
             .pipe($.babel({ presets: ['latest'] }))
-            .pipe($.plumber.stop())
-            .pipe($.if(PROD_MODE, $.removeLogging()));
+            .pipe($.plumber.stop());
 
         // global registry goes after the lib package
         // app-seed `must` be the last item
@@ -293,7 +291,7 @@ gulp.task('jsrollup', 'Roll up all js into one file',
             .pipe($.concat(config.jsCoreFile))
             // can't use lazy pipe with uglify
             .pipe($.if(PROD_MODE, $.sourcemaps.init()))
-            .pipe($.if(PROD_MODE, $.uglify()))
+            .pipe($.if(PROD_MODE, $.uglify({ compress: { drop_console:true } })))
             .pipe($.if(PROD_MODE, $.sourcemaps.write('./maps')))
             .pipe(gulp.dest(config.libBuild));
     });
@@ -316,9 +314,7 @@ gulp.task('jsinjector', 'Copy fixed assets to the build directory',
         // the only one we have is Object.entries and it is very small
         // if it gets bigger we should split it into a separate file
         const injector = merge(
-            gulp.src(config.jsInjectorFile)
-                .pipe($.babel({ presets: ['latest'] }))
-                .pipe($.if(PROD_MODE, $.removeLogging())),
+            gulp.src(config.jsInjectorFile).pipe($.babel({ presets: ['latest'] })),
             polyfills
         )
             .pipe($.order(config.injectorOrder))
@@ -327,7 +323,7 @@ gulp.task('jsinjector', 'Copy fixed assets to the build directory',
         const streams = [iePolyfills, injector].map(stream => {
             return stream
                 .pipe($.if(PROD_MODE, $.sourcemaps.init()))
-                .pipe($.if(PROD_MODE, $.uglify()))
+                .pipe($.if(PROD_MODE, $.uglify({ compress: { drop_console:true } })))
                 .pipe($.if(PROD_MODE, $.sourcemaps.write('./maps')))
                 .pipe(gulp.dest(config.libBuild));
         });

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "gulp-order": "^1.1.1",
     "gulp-plumber": "^1.0.1",
     "gulp-print": "^1.1.0",
-    "gulp-remove-logging": "^1.2.0",
     "gulp-replace": "^0.5.4",
     "gulp-sass": "^2.3.2",
     "gulp-sourcemaps": "^1.6.0",

--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -9,6 +9,8 @@
 
     // check if the global RV registry object already exists and store a reference
     const RV = window.RV = typeof window.RV === 'undefined' ? {} : window.RV;
+    // TODO: Replace with an actual logging library
+    RV.logManager = console;
 
     // test user browser, true if IE false otherwise
     RV.isIE = /Edge\/|Trident\/|MSIE /.test(window.navigator.userAgent);
@@ -94,7 +96,7 @@
     // in cases when Angular is loaded by the host page before jQuery (or jQuery is not loaded at all), the viewer will not work as Angular will not bind jQuery correctly even if bootstrap loads a correct version of jQuery
     // more info, third paragraph from the top: https://code.angularjs.org/1.4.12/docs/api/ng/function/angular.element
     if (window.angular && !window.jQuery) {
-        console.error('The viewer requires jQuery to work correctly.' +
+        RV.logManager.error('The viewer requires jQuery to work correctly.' +
             'Ensure a compatible version of jQuery is loaded before Angular by the host page.');
 
         // stopping initialization
@@ -278,8 +280,8 @@
         // TODO v2.0: Remove the following deprecation warning
         // deprecating class fgpv on node for 2.0 release - use is="fgpv" instead
         if (node.classList.contains('fgpv')) {
-            console.warn('Using class fgpv on the map DOM node is deprecated' +
-                'and will be removed on v2.0 release. Use is="fgpv" instead.'); /*RemoveLogging:skip*/
+            RV.logManager.warn('Using class fgpv on the map DOM node is deprecated' +
+                'and will be removed on v2.0 release. Use is="fgpv" instead.');
         }
 
         customAttrs
@@ -397,7 +399,7 @@
             `(${ versionDiff > 0 ? 'more recent' : 'older' } that expected ${ourVersion} version). ` +
             `No tests were done with this version. The viewer might be unstable or not work correctly.`;
 
-        console.warn(warningMessgage); /*RemoveLogging:skip*/
+        RV.logManager.warn(warningMessgage);
     }
 })();
 


### PR DESCRIPTION
## Description
All console output is removed in production builds. To force a console
output in production use RV.logManager.* (where * can be any console
method such as log, warn or error).

Closes #1702

## Testing
`index-mobile.html` shows warnings on prod build

## Documentation
No

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1763)
<!-- Reviewable:end -->
