### PR TITLE
feat(legend): Add support for tile based layers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "datatables.net-dt": "~1.10.11",
     "dotjem-angular-tree": "~0.2.1",
     "file-saver": "^1.3.3",
-    "geoapi": "https://github.com/fgpv-vpgf/geoApi/releases/download/v1.1.2/geoapi-1.1.2.tgz",
+    "geoapi": "https://github.com/fgpv-vpgf/geoApi/releases/download/v1.1.4/geoapi-1.1.4.tgz",
     "gsap": "^1.18.0",
     "jquery": "^2.2.1",
     "jquery-hoverintent": "~1.8.1",

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -148,6 +148,13 @@
                 const state = legendEntryFactory.singleEntryItem(layer.config, layer);
                 layer.legendEntry = state;
 
+                // get our legend from the server (as we have no local renderer)
+                // FIXME in legend-entry.service, function SINGLE_ENTRY_ITEM.init, there is a FIXME to prevent
+                // the stripping of the final part of the url for non-feature layers.
+                // for now, we correct the issue here. when it is fixed, this function should be re-adjusted
+                gapiService.gapi.symbology.mapServerToLocalLegend(`${state.url}/${state.featureIdx}`).then(legendData =>
+                    applySymbology(state, legendData.layers[0]));
+
                 return state;
             }
 


### PR DESCRIPTION
## Description
Adds viewer support for tile based layers. 

geoApi PR https://github.com/fgpv-vpgf/geoApi/pull/185 must be merged first.

## Testing
No, depends on pending geoApi code 

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1767)
<!-- Reviewable:end -->
