### PR TITLE
fix(focus): md-select actions no longer deactivate FM

### DIFF
--- a/docs/developer/technical/focus_manager.md
+++ b/docs/developer/technical/focus_manager.md
@@ -10,6 +10,7 @@ To be accessible and WCAG 2 compliant, the viewer needs to support keyboard user
 | rv-focus-status       |  Added to the main viewer HTML element with a value of either NONE, INACTIVE, WAITING, ACTIVE to signify the current focus state of the viewer. This is useful for outside libraries to see the current state of any given viewer.
 | rv-ignore-focusout    |  Normally the focus manager attempts to recover from a loss of focus by moving back through its history. This attribute disables this behaviour so no recovery is initiated.
 | rv-focus-init         |  Allows the use of focus() on the viewer element with this attribute or any of its children if focus is not current on the element or any of its children. This allows outside libraries to set initial focus normally, yet restricts them on subsequent movement attempts.
+| rv-focus-member | Declares an element and all its children are a part of the viewer. Unlike rv-focus-trap, focus is not trapped inside these elements. The most common use case is for elements rendered outside the viewers DOM structure where we do not want to control focus - we only wish to recognize that it is a part of the viewer so that action taken within it do not deactivate the focus manager.  |
 
 
 #### Important concepts you should know

--- a/src/app/ui/common/select-menu.decorator.js
+++ b/src/app/ui/common/select-menu.decorator.js
@@ -1,0 +1,37 @@
+(() => {
+    'use strict';
+
+    /**
+     * @module mdSelectMenuDirective
+     * @memberof material.components.select
+     */
+    angular
+        .module('material.components.select')
+        .decorator('mdSelectMenuDirective', mdSelectMenuDirective);
+
+    function mdSelectMenuDirective($delegate, appInfo) {
+        'ngInject';
+
+        const mdSelectMenuDirective = $delegate[0]; // get the vanilla directive
+        const originalCompile = mdSelectMenuDirective.compile; // store reference to its compile function
+        mdSelectMenuDirective.compile = decorateCompile(originalCompile); // decorate compile function
+
+        return ([mdSelectMenuDirective]);
+
+        /**
+         * Decorates the original menu compile functions.
+         * @function decorateCompile
+         * @param  {Function} originalCompile original compile function
+         * @return {Function}                 enhances link function returned by the decorated compile function
+         */
+        function decorateCompile(originalCompile) {
+            return (...args) => {
+                const originalLink = originalCompile(...args);
+                return (scope, el, attrs, ctrls) => {
+                    originalLink.pre(scope, el, attrs, ctrls); // note this directive uses a pre-link only
+                    el.attr('rv-focus-member', appInfo.id);
+                };
+            };
+        }
+    }
+})();


### PR DESCRIPTION
## Description
Introduced new FM attribute rv-focus-memeber which indicates element and
its children are a part of the viewer but does not assume focus
responsibilities.

Closes #1771, #1772

## Testing
Yes

## Documentation
Docs, jsDocs, inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1773)
<!-- Reviewable:end -->
