### PR TITLE
fix(symbol): Safari doesn't render svg

### DIFF
--- a/src/app/ui/common/svg.directive.js
+++ b/src/app/ui/common/svg.directive.js
@@ -43,6 +43,18 @@
 
             const stopWatch = scope.$watch('src', newValue => {
                 if (newValue) {
+                    // check if this is a svg node and if it contain an image. If so, we need to modify the href element (for Safari)
+                    const node = angular.element(scope.src);
+                    const img = node.find('image');
+                    if (node.is('svg') && img.length > 0) {
+                        // for Safari, xlink:href element is named href. Rename the element xlink:href to show symbology
+                        // it seems to be a bug from svg.js library
+                        // TODO: send issue to svg library
+                        if (typeof img.attr('href') !== 'undefined') {
+                            scope.src = scope.src.replace('href', 'xlink:href');
+                        }
+                    }
+
                     el.empty().append(scope.src);
 
                     // do not watch for updates to src anymore


### PR DESCRIPTION
Closes #1671, #1642

## Description
<!-- Link to an issue or include a description -->

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome and Safari

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1780)
<!-- Reviewable:end -->
