### PR TITLE
fix(focus): allow focus to move into input on search selection

### DIFF
--- a/docs/developer/technical/focus_manager.md
+++ b/docs/developer/technical/focus_manager.md
@@ -11,6 +11,7 @@ To be accessible and WCAG 2 compliant, the viewer needs to support keyboard user
 | rv-ignore-focusout    |  Normally the focus manager attempts to recover from a loss of focus by moving back through its history. This attribute disables this behaviour so no recovery is initiated.
 | rv-focus-init         |  Allows the use of focus() on the viewer element with this attribute or any of its children if focus is not current on the element or any of its children. This allows outside libraries to set initial focus normally, yet restricts them on subsequent movement attempts.
 | rv-focus-member | Declares an element and all its children are a part of the viewer. Unlike rv-focus-trap, focus is not trapped inside these elements. The most common use case is for elements rendered outside the viewers DOM structure where we do not want to control focus - we only wish to recognize that it is a part of the viewer so that action taken within it do not deactivate the focus manager.  |
+| rv-focus-exempt | Declares an element and all its children to be exempt from setting their own focus. This has no effect on the normal flow of focus by the FM.  |
 
 
 #### Important concepts you should know

--- a/src/app/ui/geosearch/geosearch-bar.html
+++ b/src/app/ui/geosearch/geosearch-bar.html
@@ -8,7 +8,7 @@
         <md-icon md-svg-src="navigation:menu"></md-icon>
     </md-button>
 
-    <md-input-container md-no-float flex >
+    <md-input-container md-no-float flex rv-focus-exempt>
         <md-autocomplete flex class="rv-no-message-input rv-clearable-input"
             md-autofocus="true"
             md-menu-class="{{ ::self.geosearchMenuClass }}"


### PR DESCRIPTION
## Description
Introduces new attribute rv-focus-exempt for an element and its children to gain focus via the normal .focus() implementation. Differs from rv-focus-init where focus can only move onto the element or its children from outside (and further focus attempts are rejected)

Closes #1770

## Testing
Yes

## Documentation
inline, docs

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1802)
<!-- Reviewable:end -->
