### PR TITLE
fix(details): be able to show details key-pair with html tag

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -45,7 +45,8 @@
     "linkifyjs": {
       "main": [
         "linkify.js",
-        "linkify-string.js"
+        "linkify-string.js",
+        "linkify-html.js"
       ]
     },
     "canvas-toBlob.js": {

--- a/src/app/common/formatters.filter.js
+++ b/src/app/common/formatters.filter.js
@@ -1,4 +1,4 @@
-/* global linkifyStr, moment */
+/* global linkifyStr, linkifyHtml, moment */
 (() => {
     'use strict';
 
@@ -41,7 +41,7 @@
     }
 
     function autolink() {
-        const defaultOptions = { className: 'rv-linkified' };
+        const defaultOptions = { className: 'rv-linkified', ignoreTags: ['script'] };
 
         return autolink;
 
@@ -70,7 +70,11 @@
              * @return {String} autolinked string
              */
             function process(item) {
-                return linkifyStr((item || '').toString(), angular.extend(defaultOptions, options));
+                // check if we need to use linkify html or linkify string
+                const html = /<(?=.*? .*?\/ ?>|br|hr|input|!--|wbr)[a-z]+.*?>|<([a-z]+).*?<\/\1>/; // https://regex101.com/r/cX0eP2/1
+                const opts = angular.extend(defaultOptions, options);
+                return (html.test(item)) ?
+                    linkifyHtml((item || '').toString(), opts) : linkifyStr((item || '').toString(), opts);
             }
         }
     }

--- a/src/content/styles/modules/_details.scss
+++ b/src/content/styles/modules/_details.scss
@@ -269,6 +269,12 @@ $details-record-height: rem(6.0);
                 overflow: hidden;
                 text-overflow: ellipsis;
 
+                // only use when render html inside details panel
+                ul li {
+                    display: list-item;
+                    list-style-type: disc;
+                }
+
                 a {
                     // fix for https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1635
                     // prevent wrapping links to truncate them as we don't want them to wrap

--- a/src/content/styles/modules/_filters.scss
+++ b/src/content/styles/modules/_filters.scss
@@ -73,7 +73,7 @@
 
                             // ellipsis renderer when text is longer then field width
                             .rv-render-ellipsis {
-                                cursor: text;
+                                height: rem(2);
                                 overflow: hidden;
                                 text-overflow: ellipsis;
                                 white-space: nowrap;


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Be able to show details key-pair with html tag inside details panel. At the same time show html tag and links inside the filters panel.

Note: There is a problem with rvFocus from focus manager. When testing, the focus can be lost. I will create a new issue.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome, FF and Safari with a layer internal to NRCan for html tag and http://geoappext.nrcan.gc.ca/arcgis/rest/services/MMS/IMA_E/MapServer/0 for the links

image sample

![screen shot 2017-03-29 at 3 45 00 pm](https://cloud.githubusercontent.com/assets/3472990/24473309/cfa28f1a-1496-11e7-8fee-8698f0f633d2.png)
![screen shot 2017-03-29 at 3 45 46 pm](https://cloud.githubusercontent.com/assets/3472990/24473314/d454c5a0-1496-11e7-86e9-2449ca99174d.png)


## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1815)
<!-- Reviewable:end -->
