### PR TITLE
fix(datatable): corrected focus assignment

### DIFF
--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -446,7 +446,7 @@
                             // after the draw, datatable.scroller.page() info are wrong so we can't use them to know if we are
                             // in the visible area
                             const focusRow = scrollCell[0][0].row;
-                            self.table.cell(focusRow, cellInfo.column).rvFocus();
+                            self.table.cell(focusRow, cellInfo.column).focus();
                             self.table.row(focusRow - 1).scrollTo(false); // false because we doesn't want animation
                             draw = false;
                             scrollCell = false;


### PR DESCRIPTION
## Description
`self.table.cell(...)` returns a datatable object, not a DOM node. The
datatable object implements a focus function. This was likely missed
during FM updates where most focus methods were replaced by rvFocus.

Closes #1816

## Testing
Browser

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1817)
<!-- Reviewable:end -->
