### PR TITLE
fix(filter): set filter menu layout the same as side nav layout

### DIFF
--- a/src/app/ui/common/menuItem.decorator.js
+++ b/src/app/ui/common/menuItem.decorator.js
@@ -48,22 +48,24 @@
                     const button = el.find('.md-button');
 
                     // specify icon for checkbox and radio in rv-right-icon - done here since angular material actively removes icons to place its own checkmark icon
-                    if ((attrs.type === 'checkbox' || attrs.type === 'radio') && attrs.rvRightIcon) {
-                        button.append($compile(
-                            `<md-icon md-svg-icon="${attrs.rvRightIcon}"></md-icon>`
-                        )(scope));
-                    }
+                    if (attrs.rvRightIcon) {
+                        if (attrs.type === 'checkbox' || attrs.type === 'radio') {
 
-                    if (icon.length > 0 && button.length > 0) {
-                        // append empty icon to non checkbox/radio items so that they have a common alignment
-                        if (attrs.rvRightIcon && attrs.type !== 'checkbox' && attrs.type !== 'radio') {
+                            // specifying any string that is not an actual icon name will create an empty icon; use `rv-right-icon="none"` for consistency
+                            button.prepend($compile(`<md-icon md-svg-icon="${attrs.rvRightIcon}"></md-icon>`)(scope));
+
+                            // reverse the checkbox icon so it is icon/text and remove the ident class
+                            el.removeClass('md-indent');
+
+                            // need to apped the icon to the button, otherwise the button will shrink
                             button.append(icon);
                         } else {
                             button.prepend(icon);
                         }
-                        // wrap the button content in div, so we can set flex on that div as Firefox doesn't support display: flex on button nodes yet: https://bugzilla.mozilla.org/show_bug.cgi?id=984869#c24
-                        button.wrapInner(`<div class='rv-button-flex'></div>`);
                     }
+
+                    // wrap the button content in div, so we can set flex on that div as Firefox doesn't support display: flex on button nodes yet: https://bugzilla.mozilla.org/show_bug.cgi?id=984869#c24
+                    button.wrapInner(`<div class='rv-button-flex'></div>`);
                 };
             };
         }

--- a/src/app/ui/filters/filters-default-menu.html
+++ b/src/app/ui/filters/filters-default-menu.html
@@ -14,11 +14,11 @@
                 {{ 'filter.menu.minimize' | translate }}
             </md-menu-item-->
 
-            <md-menu-item type="radio" ng-model="self.filtersMode" value="default" ng-click="self.setMode(self.filtersMode)" ng-if="self.currentLayout() === 'large'">
+            <md-menu-item type="radio" ng-model="self.filtersMode" value="default" ng-click="self.setMode(self.filtersMode)" ng-if="self.currentLayout() === 'large'" rv-right-icon="none">
                 {{ 'filter.menu.splitView' | translate }}
             </md-menu-item>
 
-            <md-menu-item type="radio" ng-model="self.filtersMode" value="full" ng-click="self.setMode(self.filtersMode)" ng-if="self.currentLayout() === 'large'">
+            <md-menu-item type="radio" ng-model="self.filtersMode" value="full" ng-click="self.setMode(self.filtersMode)" ng-if="self.currentLayout() === 'large'" rv-right-icon="none">
                 {{ 'filter.menu.maximize' | translate }}
             </md-menu-item>
 
@@ -46,17 +46,17 @@
                 </md-menu-item>
             <md-menu-divider></md-menu-divider>
 
-            <md-menu-item rv-right-icon="true">
+            <md-menu-item>
                 <md-button ng-click="self.dataPrint()">
-                    {{ 'filter.menu.print' | translate }}
                     <md-icon md-svg-icon="action:print"></md-icon>
+                    {{ 'filter.menu.print' | translate }}
                 </md-button>
             </md-menu-item>
 
-            <md-menu-item rv-right-icon="true">
+            <md-menu-item>
                 <md-button ng-click="self.dataExportCSV()">
-                    {{ 'filter.menu.export' | translate }}
                     <md-icon md-svg-icon="editor:insert_drive_file"></md-icon>
+                    {{ 'filter.menu.export' | translate }}
                 </md-button>
             </md-menu-item>
 

--- a/src/content/styles/vendor/_special.scss
+++ b/src/content/styles/vendor/_special.scss
@@ -45,12 +45,12 @@ md-menu-content {
 
     md-menu-item {
 
+        md-icon {
+            width: rem(2.4);
+        }
+
         &[rv-right-icon] .md-button {
             padding-right: rem(1.6) !important;
-
-            md-icon:last-of-type {
-                margin-right: 0;
-            }
         }
 
         &[rv-right-icon="true"] .md-button {


### PR DESCRIPTION
Closes #1743

## Description
<!-- Link to an issue or include a description -->
Set filters menu the same layout as other menu (icon / text / checkbox)

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1819)
<!-- Reviewable:end -->
