### PR TITLE
fix(filter): focus with keytable extension

### DIFF
--- a/src/app/ui/filters/filters-default.html
+++ b/src/app/ui/filters/filters-default.html
@@ -6,7 +6,7 @@
         title-value="{{ 'filter.title' | translate }}{{ self.display.requester.name }}"
         is-loading="self.display.isLoading">
 
-        <!-- do not put rv-ignore-focusout here because it will exclude header from tabing -->
+        <!-- do not put rv-ignore-focusout here because it will exclude header from tabing. Remove from code as well because it creates a double tab problem and it is not needed anymore -->
         <div class="rv-filters">
             <!--md-button ng-click="self.draw()">click this button if you don't see the table below</md-button-->
 

--- a/src/content/styles/modules/_filters.scss
+++ b/src/content/styles/modules/_filters.scss
@@ -49,7 +49,7 @@
 
                         tbody {
                             // for datatable KeyTable extension
-                            td.rv-cell-focus {
+                            td:focus {
                                 outline: 1px solid $focus-color;
                                 outline-offset: -1px;
 


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
#1825, #1816 

Tried to optimize when user scroll continuously with the keyboard by debouncing the focus. Can only do it when there is no redraw because redraw mess up the scroller info when scroll with the keyboard and keytable extension.

Tried to make it faster by excluding all the focus when scrolling with the keyboard and only focus when it is finish but always have problems with shifting focus.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Hope enough

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1841)
<!-- Reviewable:end -->
