### PR TITLE
fix(angular): allow multiple versions of angular on a page

### DIFF
--- a/gulp.config.js
+++ b/gulp.config.js
@@ -40,7 +40,8 @@ module.exports = function () {
             src + 'index-jso.html',
             src + 'index-fgp-en.html',
             src + 'index-fgp-fr.html',
-            src + 'bookmark-decode.html'
+            src + 'bookmark-decode.html',
+            src + 'multiple-angular.html'
         ],
         indexProtractor: src + 'index-protractor.html',
 

--- a/src/app/app-seed.js
+++ b/src/app/app-seed.js
@@ -1,28 +1,32 @@
-/**
- * @function app.core.seed
- * @inner
- * @desc `seed` is an implicit function which runs on application startup to
- * initialize all marked DOM nodes to map instances
- */
-angular.element(document)
-    .ready(() => {
-        'use strict';
-        // NOTE: let and const cannot be used in this file due to protractor problems
+$(function () {
+    (function (angular) {
+        /**
+         * @function app.core.seed
+         * @inner
+         * @desc `seed` is an implicit function which runs on application startup to
+         * initialize all marked DOM nodes to map instances
+         */
+        angular.element(document)
+            .ready(() => {
+                'use strict';
+                // NOTE: let and const cannot be used in this file due to protractor problems
 
-        // The app nodes in the dom
-        window.RV._nodes.forEach(node => {
+                // The app nodes in the dom
+                window.RV._nodes.forEach(node => {
 
-            // load shell template into the node
-            // we need to create an explicit child under app's root node, otherwise animation
-            // doesnt' work; see this plunk: http://plnkr.co/edit/7EIM71IOwC8h1HdguIdD
-            // or this one: http://plnkr.co/edit/Ds8e8d?p=preview
-            node.appendChild(angular.element('<rv-shell class="md-body-1">')[0]);
+                    // load shell template into the node
+                    // we need to create an explicit child under app's root node, otherwise animation
+                    // doesnt' work; see this plunk: http://plnkr.co/edit/7EIM71IOwC8h1HdguIdD
+                    // or this one: http://plnkr.co/edit/Ds8e8d?p=preview
+                    node.appendChild(angular.element('<rv-shell class="md-body-1">')[0]);
 
-            // bootstrap each node as an Angular app
-            // strictDi enforces explicit dependency names on each component: ngAnnotate should find most automatically
-            // this checks for any failures; to fix a problem add 'ngInject'; to the function preamble
-            angular.bootstrap(node, ['app'], {
-                strictDi: true
+                    // bootstrap each node as an Angular app
+                    // strictDi enforces explicit dependency names on each component: ngAnnotate should find most automatically
+                    // this checks for any failures; to fix a problem add 'ngInject'; to the function preamble
+                    angular.bootstrap(node, ['app'], {
+                        strictDi: true
+                    });
+                });
             });
-        });
-    });
+    })(angular);
+});

--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -51,7 +51,7 @@
             get url() { return `//cdn.datatables.net/${this.ourVersion}/js/jquery.dataTables.min.js`; }
         }
     };
-    const dependenciesOrder = ['jQuery', 'dataTables', 'angular'];
+    const dependenciesOrder = ['jQuery', 'dataTables'];
 
     const d = document;
     const scripts = d.getElementsByTagName('script'); // get scripts
@@ -91,6 +91,14 @@
             scriptsArr.push(dependency.url);
         }
     });
+
+    // if host page contains an angular version that differs from ours, clear global and push our version
+    // host page can continue to use their version if their app is loaded before ours, or they can manually
+    // bootstrap a scoped angular object like we do in app-seed.js
+    if (window.angular && window.angular.version.full !== dependencies.angular.ourVersion) {
+        window.angular = null;
+        scriptsArr.push(dependencies.angular.url);
+    }
 
     // in cases when Angular is loaded by the host page before jQuery (or jQuery is not loaded at all), the viewer will not work as Angular will not bind jQuery correctly even if bootstrap loads a correct version of jQuery
     // more info, third paragraph from the top: https://code.angularjs.org/1.4.12/docs/api/ng/function/angular.element

--- a/src/multiple-angular.html
+++ b/src/multiple-angular.html
@@ -1,0 +1,67 @@
+<html>
+    <head>
+        <style>
+            div.myMap {
+                height: 675px;
+            }
+            div#app1, div#app2 {
+                padding: 5px;
+            }
+        </style>
+
+        <!-- Load any version of angular you'd like to use for host page angular application -->
+        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.3/angular.js"></script>
+    </head>
+
+
+    <body>
+        <!-- This is our custom angular app. It can be placed before or after the viewer html below (order not important) -->
+        <div id="app1">
+            <div ng-controller="myController">
+                App1 version number: {{version}}
+            </div>
+        </div>
+
+        <div id="app2">
+            <div ng-controller="myController">
+                App2 version number: {{version}}
+            </div>
+        </div>
+
+        <!-- This is the viewer app, it displays the map-->
+        <div id="fgpmap" is="rv-map" class="myMap" data-rv-config="config-mobile.json" data-rv-langs='["en-CA", "fr-CA"]' data-rv-service-endpoint="http://section917.cloudapp.net:8000/" rv-keys='["Airports"]' rv-restore-bookmark="bookmark"></div>
+
+        <script>
+            // note that we wrap our custom application in an Immediately-Invoked Function Expression (IIFE) with angular scoped in
+            // this must be done before the inject:js comment below, since the viewer will override our custom angular version when it loads
+            (function (angular) {
+                angular.module('myApp1', [])
+                    .controller('myController', function ($scope, $interval) {
+                        $interval(() => {
+                            $scope.version = angular.version.full;
+                        }, 1000);
+                });
+                angular.bootstrap(document.getElementById("app1"), ['myApp1']);
+            })(angular);
+
+            // If scoping angular is not ideal for your custom application you can also assign it to another global variable as we do here
+            // However you must remember to use your custom global angular version throughout your application as the global "angular" will
+            // reference the viewers angular version once it is loaded.
+
+            window.myAngular = angular;
+            myAngular.module('myApp2', [])
+                    .controller('myController', function ($scope, $interval) {
+                        $interval(() => {
+                            // note that we use "myAngular", using "angular" will show the viewers version
+                            $scope.version = myAngular.version.full;
+                        }, 1000);
+                });
+            myAngular.bootstrap(document.getElementById("app2"), ['myApp2']);
+
+        </script>
+
+
+        <!-- inject:js -->
+        <!-- endinject -->
+    </body>
+</html>


### PR DESCRIPTION
## Description
This allows for multiple angular versions to run on the same page. This still requires additional testing however it does currently work if:
- host page has angular app initialized prior to our, or;
- loads their version of angular after our application loads and scopes it into their bootstrap

Closes #960

## Testing
some, more needed, just an idea

## Documentation
inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1844)
<!-- Reviewable:end -->
