### PR TITLE
draft: icons as a font

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "angular-material": "1.1.3",
     "angular-minicolors": "^0.0.9",
     "angular-sanitize": "1.4.12",
-    "angular-translate": "^2.13.0",
+    "angular-translate": "^2.15.1",
     "angular-translate-loader-static-files": "^2.13.0",
     "bezier-easing": "^1.0.0",
     "canvas-toBlob.js": "https://github.com/eligrey/canvas-toBlob.js.git",

--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -74,10 +74,17 @@
 
     // inject fonts
     const fontsLink = d.createElement('link');
-    fontsLink.href = '//fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic';
+    fontsLink.href = '//fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic|Material+Icons';
     fontsLink.rel = 'stylesheet';
 
     headNode.appendChild(fontsLink);
+
+    // inject mdi fonts
+    const mdiFontsLink = d.createElement('link');
+    mdiFontsLink.href = '//cdn.materialdesignicons.com/1.9.32/css/materialdesignicons.min.css';
+    mdiFontsLink.rel = 'stylesheet';
+
+    headNode.appendChild(mdiFontsLink);
 
     const scriptsArr = [];
 

--- a/src/app/layout/shell.html
+++ b/src/app/layout/shell.html
@@ -1,5 +1,5 @@
 <div class="rv-icon-24 rv-north-arrow">
-    <md-icon md-svg-src="maps:navigation"></md-icon>
+    <md-icon>navigation</md-icon>
 </div>
 
 <div class="rv-map-coordinates rv-lg">

--- a/src/app/ui/appbar/appbar.html
+++ b/src/app/ui/appbar/appbar.html
@@ -1,12 +1,11 @@
 <div class="main-appbar rv-whiteframe-z2" ng-show="!self.stateManager.state.mainGeosearch.active">
     <md-button
-        translate
         translate-attr-aria-label="appbar.aria.menu"
         class="md-icon-button black"
         rv-help="sidenav-button"
         ng-click="self.layoutService.sidenav.open()">
         <md-tooltip>{{'appbar.tooltip.menu' | translate}}</md-tooltip>
-        <md-icon md-svg-src="navigation:menu"></md-icon>
+        <md-icon>menu</md-icon>
     </md-button>
 
     <!-- TODO: find a better way to conditionally show all these icons and names -->
@@ -20,22 +19,20 @@
     </div>
 
     <md-button
-        translate
         translate-attr-aria-label="appbar.aria.geosearch"
         class="md-icon-button primary"
         ng-click="self.toggleGeosearch()">
         <md-tooltip>{{ 'appbar.tooltip.geosearch' | translate }}</md-tooltip>
-        <md-icon md-svg-src="action:search"></md-icon>
+        <md-icon>search</md-icon>
     </md-button>
 
     <md-button
-        translate
         translate-attr-aria-label="nav.tooltip.basemap"
         class="md-icon-button primary"
         ng-click="self.openBasemapSelector()"
         ng-show="self.stateManager.state.mainToc.active">
         <md-tooltip>{{ 'nav.tooltip.basemap' | translate }}</md-tooltip>
-        <md-icon md-svg-src="maps:map"></md-icon>
+        <md-icon>map</md-icon>
     </md-button>
 
     <span
@@ -43,7 +40,6 @@
     </span>
 
     <md-button
-        translate
         translate-attr-aria-label="appbar.aria.pointInfo"
         class="md-icon-button primary"
         rv-help="details-button"
@@ -51,18 +47,17 @@
         ng-click="self.toggleDetails()"
         ng-show="self.stateManager.display.details.requestId">
         <md-tooltip>{{'appbar.tooltip.pointInfo' | translate}}</md-tooltip>
-        <md-icon md-svg-src="maps:place"></md-icon>
+        <md-icon>place</md-icon>
     </md-button>
 
     <md-button
-        translate
         translate-attr-aria-label="appbar.aria.layers"
         class="md-icon-button primary"
         rv-help="toc-button"
         ng-class="{ selected: self.stateManager.state.mainToc.active }"
         ng-click="self.toggleToc()">
         <md-tooltip>{{'appbar.tooltip.layers' | translate}}</md-tooltip>
-        <md-icon md-svg-src="maps:layers"></md-icon>
+        <md-icon>layers</md-icon>
     </md-button>
 
     <!-- hiding tools section for now; TODO: re-enable when we have tools -->
@@ -74,7 +69,7 @@
         ng-class="{ selected: self.stateManager.state.mainToolbox.active }"
         ng-click="self.toggleToolbox()">
         <md-tooltip>{{'appbar.tooltip.tools' | translate}}</md-tooltip>
-        <md-icon md-svg-src="content:create"></md-icon>
+        <md-icon></md-icon>
     </md-button-->
 </div>
 

--- a/src/app/ui/basemap/basemap-item.html
+++ b/src/app/ui/basemap/basemap-item.html
@@ -24,7 +24,6 @@
     <span flex></span>
 
     <md-button
-        translate
         translate-attr-aria-label="basemap.{{ self.isDescriptionVisible ? 'hide' : 'show' }}description"
         class="md-icon-button rv-button-32 rv-icon-20"
         ng-class="{ selected: self.isDescriptionVisible }"
@@ -33,17 +32,16 @@
         <!-- I don't like tooltips here... -->
         <!--md-tooltip md-direction="top">I'm no tooltip.</md-tooltip-->
 
-        <md-icon md-svg-src="action:info{{ self.isDescriptionVisible ? '' : '_outline' }}"></md-icon>
+        <md-icon>info{{ self.isDescriptionVisible ? '' : '_outline' }}</md-icon>
 
     </md-button>
 </div>
 
 <div class="rv-basemap-check" ng-if="self.basemap.selected">
-    <md-icon md-svg-src="navigation:check" ></md-icon>
+    <md-icon>check</md-icon>
 </div>
 
 <md-button
-    translate
     translate-attr-aria-label='basemap.select'
     aria-describedby="{{ ::$root.uid($id) }}-basemap-desc"
     class="rv-body-button rv-button-square"

--- a/src/app/ui/basemap/basemap.html
+++ b/src/app/ui/basemap/basemap.html
@@ -4,7 +4,7 @@ This prevents focus from being applied to elements outside the basemap selector 
     <rv-content-pane rv-trap-focus>
 
         <md-button class="md-icon-button black rv-button-32 rv-minimize-button" ng-click="self.minimize()">
-            <md-icon md-svg-src="community:chevron-double-left"></md-icon>
+            <md-icon>community:chevron-double-left</md-icon>
         </md-button>
 
         <div class="rv-subsection" ng-repeat="projection in self.projections">
@@ -12,7 +12,7 @@ This prevents focus from being applied to elements outside the basemap selector 
             <div class="rv-subheader">
                 <h3 class="md-title" >{{ 'basemap.projection.title' | translate:projection }}</h3>
                 <div class="rv-icon-16" ng-show="self.selectedWkid != projection.wkid">
-                    <md-icon md-svg-src="action:info" class="rv-basemap-warning"></md-icon>
+                    <md-icon class="rv-basemap-warning">info</md-icon>
                     <span class="md-catpion" >{{ 'basemap.refresh.req' | translate }}</span>
                 </div>
             </div>

--- a/src/app/ui/common/icon.decorator.js
+++ b/src/app/ui/common/icon.decorator.js
@@ -40,11 +40,13 @@
                 return (scope, el, attrs, ctrls) => {
                     // call the original link function
                     originalLink(scope, el, attrs, ctrls);
-
+                    fontSwitching(el);
                     // used to prevent multiple callbacks from firing where svgElements.attr
                     // can trigger another DOMSubtreeModified event
                     let allowDOMSubtreeModified = false;
                     el.on('DOMSubtreeModified', () => {
+
+                        fontSwitching(el);
                         let svgElements = el.find('svg');
                         // always set to true if there are no svg elements since the next DOMSubtreeModified
                         // event could be triggered by adding an SVG element
@@ -55,6 +57,17 @@
                     });
                 };
             };
+        }
+
+        function fontSwitching(el) {
+            const elHTML = el.html();
+
+            const communitySet = elHTML.split('community:');
+            if (communitySet.length === 2) {
+                el.addClass('mdi').addClass(`mdi-${communitySet[1]}`);
+                el.removeClass('material-icons');
+                el.html('');
+            }
         }
     }
 })();

--- a/src/app/ui/common/stepper/stepper-item.html
+++ b/src/app/ui/common/stepper/stepper-item.html
@@ -7,8 +7,7 @@
         <md-icon
             class="rv-stepper-item-check"
             ng-class="{ 'rv-active': self.isActive || self.step.isActive }"
-            md-svg-src="action:check_circle"
-            ng-if="self.isCompleted || self.step.isCompleted"></md-icon>
+            ng-if="self.isCompleted || self.step.isCompleted">check_circle</md-icon>
 
         <div class="rv-stepper-item-title">
             <h5 class="md-body-2">{{ self.titleValue || self.step.titleValue | translate }}</h5>

--- a/src/app/ui/details/details-header.html
+++ b/src/app/ui/details/details-header.html
@@ -9,13 +9,13 @@
 
     <md-button class="md-icon-button black rv-button-24 rv-gt-sm" ng-click="self.expandPanel()">
         <md-tooltip>{{ 'details.tooltip.expand' | translate }}</md-tooltip>
-        <md-icon md-svg-src="action:open_in_new"></md-icon>
+        <md-icon>open_in_new</md-icon>
     </md-button>
 
-    <md-button translate translate-attr-aria-label="contentPane.aria.close" class="rv-close md-icon-button black rv-button-24"
+    <md-button translate-attr-aria-label="contentPane.aria.close" class="rv-close md-icon-button black rv-button-24"
         ng-click="self.closeDetails()">
         <md-tooltip>{{ 'contentPane.tooltip.close' | translate }}</md-tooltip>
-        <md-icon class="rv-lt-lg" md-svg-src="navigation:arrow_back"></md-icon>
-        <md-icon class="rv-lg" md-svg-src="navigation:close"></md-icon>
+        <md-icon class="rv-lt-lg">arrow_back</md-icon>
+        <md-icon class="rv-lg">close</md-icon>
     </md-button>
 </div>

--- a/src/app/ui/details/details-record-esrifeature.html
+++ b/src/app/ui/details/details-record-esrifeature.html
@@ -17,7 +17,7 @@
     <md-button class="md-icon-button rv-icon-20" ng-click="self.zoomToFeature()"
         ng-disabled="!self.requester.layerRec.visible || !self.directLegendEntry.options.visibility.value">
         <md-tooltip md-direction="top">{{ 'filter.tooltip.zoom' | translate }}</md-tooltip>
-        <md-icon md-svg-src="action:zoom_in"></md-icon>
+        <md-icon>zoom_in</md-icon>
     </md-button>
 
 </div>
@@ -25,6 +25,6 @@
 <div ng-if="::!self.solorecord" class="rv-icon-24 rv-group-toggle-icon">
     <md-icon
         class="md-toggle-icon"
-        ng-class="{ 'rv-toggled' : self.item.isExpanded }"
-        md-svg-src="hardware:keyboard_arrow_down"></md-icon>
+        ng-class="{ 'rv-toggled' : self.item.isExpanded }">
+        keyboard_arrow_down</md-icon>
 </div>

--- a/src/app/ui/export/custom-size.html
+++ b/src/app/ui/export/custom-size.html
@@ -18,7 +18,7 @@
     </div>
 </md-input-container>
  
-<md-icon md-svg-src="navigation:close"></md-icon>
+<md-icon>close</md-icon>
  
 <md-input-container ng-disabled="self.isError">
     <input type="number" required md-no-asterisk

--- a/src/app/ui/export/export.html
+++ b/src/app/ui/export/export.html
@@ -126,7 +126,7 @@
                 ng-if="::self.isSettingsEditable()"
                 ng-class="{ selected: self.isExportSettingsOpen }"
                 ng-click="self.isExportSettingsOpen = !self.isExportSettingsOpen">
-                <md-icon md-svg-src="action:settings"></md-icon>
+                <md-icon>settings</md-icon>
             </md-button>
 
             <span flex></span>

--- a/src/app/ui/filters/filters-default-menu.html
+++ b/src/app/ui/filters/filters-default-menu.html
@@ -2,11 +2,10 @@
     <md-menu md-position-mode="target-right target">
 
         <md-button
-            translate
             translate-attr-aria-label="filter.aria.menu"
             class="md-icon-button black rv-button-24"
             ng-click="$mdOpenMenu($event)">
-            <md-icon md-svg-src="navigation:more_vert"></md-icon>
+            <md-icon>more_vert</md-icon>
         </md-button>
 
         <md-menu-content rv-trap-focus="{{::self.appID}}" class="rv-menu rv-dense" width="5">
@@ -27,14 +26,14 @@
 
             <md-menu-item>
                 <md-button ng-click="self.toggleNotifications()" md-prevent-menu-close="md-prevent-menu-close">
-                    <md-icon md-svg-icon="action:search"></md-icon>
+                    <md-icon></md-icon>
                     {{'filter.menu.enableSearch' | translate}}
                 </md-button>
             </md-menu-item>
 
             <md-menu-item>
                 <md-button ng-click="self.toggleNotifications()" md-prevent-menu-close="md-prevent-menu-close">
-                    <md-icon md-svg-icon="community:filter"></md-icon>
+                    <md-icon></md-icon>
                     {{'filter.menu.enableFilters' | translate}}
                 </md-button>
             </md-menu-item>
@@ -48,14 +47,14 @@
 
             <md-menu-item>
                 <md-button ng-click="self.dataPrint()">
-                    <md-icon md-svg-icon="action:print"></md-icon>
+                    <md-icon>print</md-icon>
                     {{ 'filter.menu.print' | translate }}
                 </md-button>
             </md-menu-item>
 
             <md-menu-item>
                 <md-button ng-click="self.dataExportCSV()">
-                    <md-icon md-svg-icon="editor:insert_drive_file"></md-icon>
+                    <md-icon>insert_drive_file</md-icon>
                     {{ 'filter.menu.export' | translate }}
                 </md-button>
             </md-menu-item>

--- a/src/app/ui/geosearch/geosearch-bar.html
+++ b/src/app/ui/geosearch/geosearch-bar.html
@@ -1,11 +1,10 @@
 <div class="rv-geosearch-bar rv-whiteframe-z2" ng-attr-rv-trap-focus="{{!self.service.isResultsVisible ? '' : undefined}}">
     <md-button
-        translate
         translate-attr-aria-label="appbar.aria.menu"
         class="md-icon-button black"
         ng-click="self.layoutService.sidenav.open();">
         <md-tooltip>{{ 'appbar.tooltip.menu' | translate }}</md-tooltip>
-        <md-icon md-svg-src="navigation:menu"></md-icon>
+        <md-icon>menu</md-icon>
     </md-button>
 
     <md-input-container md-no-float flex rv-focus-exempt>
@@ -26,16 +25,15 @@
         </md-autocomplete>
     </md-input-container>
 
-    <md-icon md-svg-src="action:search"></md-icon>
+    <md-icon>search</md-icon>
 
     <span class="rv-button-divider-24 rv-lg"></span>
 
     <md-button
-        translate
         translate-attr-aria-label="appbar.aria.geosearchclose"
         class="md-icon-button black"
         ng-click="self.service.toggle()">
         <md-tooltip>{{ 'appbar.aria.geosearchclose' | translate }}</md-tooltip>
-        <md-icon md-svg-src="navigation:close"></md-icon>
+        <md-icon>close</md-icon>
     </md-button>
 </div>

--- a/src/app/ui/geosearch/geosearch-top-filters.html
+++ b/src/app/ui/geosearch/geosearch-top-filters.html
@@ -24,11 +24,10 @@
 
     <md-button
         ng-disabled="!self.selectedType && !self.selectedProvince"
-        translate
         translate-attr-aria-label="appbar.aria.geosearchclose"
         class="md-icon-button rv-icon-20 rv-button-24 black"
         ng-click="self.clear()">
         <md-tooltip>{{ 'appbar.aria.geosearchclose' | translate }}</md-tooltip>
-        <md-icon md-svg-src="community:filter-remove"></md-icon>
+        <md-icon>community:filter-remove</md-icon>
     </md-button>
 </div>

--- a/src/app/ui/help/help-search.html
+++ b/src/app/ui/help/help-search.html
@@ -13,9 +13,9 @@
         ng-click="self.searchTerm = ''; self.onSearchTermChange('')"
         ng-if="self.searchTerm">
         <md-tooltip>{{ 'helpui.clearsearch' | translate }}</md-tooltip>
-        <md-icon md-svg-src="navigation:close"></md-icon>
+        <md-icon>close</md-icon>
     </md-button>
 </md-input-container>
 
-<md-icon md-svg-src="action:search"></md-icon>
+<md-icon>search</md-icon>
 <span class="rv-button-divider-24 rv-lg"></span>

--- a/src/app/ui/help/help-summary.html
+++ b/src/app/ui/help/help-summary.html
@@ -30,8 +30,8 @@
                     <div class="rv-icon-24 rv-group-toggle-icon">
                         <md-icon
                             class="md-toggle-icon"
-                            ng-class="{ 'rv-toggled' : section.isExpanded }"
-                            md-svg-src="hardware:keyboard_arrow_down"></md-icon>
+                            ng-class="{ 'rv-toggled' : section.isExpanded }">
+                            keyboard_arrow_down</md-icon>
                     </div>
                 </div>
 

--- a/src/app/ui/loader/loader-file.html
+++ b/src/app/ui/loader/loader-file.html
@@ -33,7 +33,7 @@
                                 flow-attrs="{ accept: '.csv,.zip,.json' }"
                                 name="dataUpload"
                                 ng-click="self.upload.step.reset()">
-                                <md-icon md-svg-src="file:file_upload"></md-icon>
+                                <md-icon>file_upload</md-icon>
                                 {{ "import.file.upload.choose" | translate }}
                             </md-button>
                         </div>
@@ -178,7 +178,7 @@
         <div class="rv-file-drop-container" flow-drop>
             <div class="rv-file-drop-title">
                 <span class="md-display-2" translate>import.file.upload.drop</span>
-                <md-icon md-svg-src="file:file_upload"></md-icon>
+                <md-icon>file_upload</md-icon>
             </div>
         </div>
     </div>

--- a/src/app/ui/loader/loader-menu.html
+++ b/src/app/ui/loader/loader-menu.html
@@ -3,27 +3,27 @@
     <!-- TODO: add translate filters -->
 
     <md-button
-        translate translate-attr-aria-label="import.title"
+        translate-attr-aria-label="import.title"
         class="md-icon-button primary rv-loader-add"
         ng-click="$mdOpenMenu($event)">
         <md-tooltip>{{ 'import.title' | translate }}</md-tooltip>
-        <md-icon md-svg-src="content:add"></md-icon>
+        <md-icon>add</md-icon>
     </md-button>
 
     <md-menu-content rv-trap-focus="{{ ::self.appID }}" class="rv-menu rv-dense" width="4">
         <md-menu-item>
             <md-button
                 ng-click="self.openFileLoader()"
-                translate translate-attr-aria-label="import.file.title">
-                <md-icon md-svg-icon="editor:insert_drive_file"></md-icon>
+                translate-attr-aria-label="import.file.title">
+                <md-icon>insert_drive_file</md-icon>
                 {{ 'import.file.title' | translate }}
             </md-button>
         </md-menu-item>
 
         <md-menu-item>
             <md-button ng-click="self.openServiceLoader()"
-                translate translate-attr-aria-label="import.service.title">
-                <md-icon md-svg-icon="file:cloud"></md-icon>
+                translate-attr-aria-label="import.service.title">
+                <md-icon>cloud</md-icon>
                 {{ 'import.service.title' | translate }}
             </md-button>
         </md-menu-item>
@@ -33,7 +33,7 @@
 
         <md-menu-item >
             <md-button ng-click="self.openCatalogueLoader()" ng-disabled="true" aria-label="From Data Catalogue">
-                <md-icon md-svg-icon="action:shopping_cart"></md-icon>
+                <md-icon>shopping_cart</md-icon>
                 From Data Catalogue
             </md-button>
         </md-menu-item>-->

--- a/src/app/ui/mapnav/mapnav-button.html
+++ b/src/app/ui/mapnav/mapnav-button.html
@@ -5,6 +5,6 @@
     ng-click="self.control.action($event)">
 
     <md-tooltip md-direction="left">{{ self.control.tooltip | translate }}</md-tooltip>
-    <md-icon md-svg-src="{{ self.control.icon }}"></md-icon>
+    <md-icon>{{self.control.icon}}</md-icon>
 
 </md-button>

--- a/src/app/ui/mapnav/mapnav.service.js
+++ b/src/app/ui/mapnav/mapnav.service.js
@@ -48,14 +48,14 @@
         service.controls = {
             fullScreen: {
                 label: 'sidenav.label.fullscreen',
-                icon: 'navigation:fullscreen',
+                icon: 'fullscreen',
                 tooltip: 'sidenav.label.fullscreen',
                 visible: fullScreenService.isFullPageApp,
                 action: fullScreenService.toggle
             },
             zoomIn: {
                 label: 'nav.label.zoomIn',
-                icon: 'content:add',
+                icon: 'add',
                 tooltip: 'nav.tooltip.zoomIn',
                 action: () => geoService.shiftZoom(1)
             },
@@ -64,31 +64,31 @@
             },
             zoomOut: {
                 label: 'nav.label.zoomOut',
-                icon: 'content:remove',
+                icon: 'remove',
                 tooltip: 'nav.tooltip.zoomOut',
                 action: () => geoService.shiftZoom(-1)
             },
             geoLocator: {
                 label: 'nav.label.geoLocation',
-                icon: 'maps:my_location',
+                icon: 'my_location',
                 tooltip: 'nav.tooltip.geoLocation',
                 action: locateService.find
             },
             marquee: {
                 label: 'nav.label.search',
-                icon: 'action:search',
+                icon: 'search',
                 tooltip: 'nav.tooltip.search',
                 action: function () {} // FIXME: user proper call
             },
             home: {
                 label: 'nav.label.home',
-                icon: 'action:home',
+                icon: 'home',
                 tooltip: 'nav.tooltip.home',
                 action: () => geoService.setFullExtent()
             },
             history: {
                 label: 'nav.label.history',
-                icon: 'action:history',
+                icon: 'history',
                 tooltip: 'nav.tooltip.history',
                 action: function () {} // FIXME: user proper call
             },
@@ -100,7 +100,7 @@
             },
             basemap: {
                 label: 'nav.label.basemap',
-                icon: 'maps:map',
+                icon: 'map',
                 tooltip: 'nav.tooltip.basemap',
 
                 selected: () => stateManager.state.mapnav.morph !== 'default',

--- a/src/app/ui/metadata/metadata-expand.html
+++ b/src/app/ui/metadata/metadata-expand.html
@@ -1,4 +1,4 @@
 <md-button class="md-icon-button black rv-button-24 rv-gt-sm" ng-click="self.expandPanel()">
     <md-tooltip>{{ 'metadata.expand.tooltip' | translate }}</md-tooltip>
-    <md-icon md-svg-src="action:open_in_new"></md-icon>
+    <md-icon>open_in_new</md-icon>
 </md-button>

--- a/src/app/ui/panels/content-pane.html
+++ b/src/app/ui/panels/content-pane.html
@@ -22,18 +22,16 @@
 
         <!-- show close button if there is a closePanel function -->
         <md-button
-            translate
             translate-attr-aria-label="contentPane.aria.close"
             class="rv-close md-icon-button black rv-button-24"
             ng-click="self.closePanel()"
             ng-if="self.closePanel"
             rv-close-button>
             <md-tooltip>{{'contentPane.tooltip.close' | translate}}</md-tooltip>
-            <md-icon class="rv-lt-lg" md-svg-src="navigation:arrow_back"></md-icon>
-            <md-icon class="rv-lg" md-svg-src="navigation:close"></md-icon>
+            <md-icon class="rv-lt-lg">arrow_back</md-icon>
+            <md-icon class="rv-lg">close</md-icon>
         </md-button>
     </div>
-
     <!-- floating header is deprecated -->
     <div class="rv-header-float" ng-show="self.floatingHeader && self.closePanel">
 
@@ -47,8 +45,8 @@
             ng-if="self.closePanel"
             rv-close-button>
             <md-tooltip>Close</md-tooltip>
-            <md-icon class="rv-show-single" md-svg-src="navigation:arrow_back"></md-icon>
-            <md-icon class="rv-hide-single" md-svg-src="navigation:close"></md-icon>
+            <md-icon class="rv-show-single">arrow_back</md-icon>
+            <md-icon class="rv-hide-single">close</md-icon>
         </md-button>
     </div>
 

--- a/src/app/ui/settings/settings.html
+++ b/src/app/ui/settings/settings.html
@@ -11,7 +11,7 @@
                 <div class="rv-setting-option" ng-if="self.tocEntry.options.opacity">
                     {{'settings.label.opacity' | translate}}
                     <div class="rv-icon-20 rv-slider-setting">
-                        <md-icon md-svg-icon="action:opacity"></md-icon>
+                        <md-icon>opacity</md-icon>
                         <div class="rv-slider-setting-body">
                             <md-slider class="md-primary" max="1" min="0" step="0.01" ng-model="self.opacityValue"></md-slider>
                         </div>

--- a/src/app/ui/sidenav/menulink.html
+++ b/src/app/ui/sidenav/menulink.html
@@ -4,18 +4,17 @@
     class="rv-button-square">
 
     <div layout="row">
-        <md-icon md-svg-src="{{ ::self.control.icon }}"></md-icon>
+        <md-icon>{{ ::self.control.icon }}</md-icon>
 
         {{ self.control.label | translate }}
         <span flex></span>
-        <md-icon md-svg-src="navigation:check" ng-if="self.control.isChecked(self.control)"></md-icon>
+        <md-icon ng-if="self.control.isChecked(self.control)">check</md-icon>
     </div>
 
 </md-button>
 
 <div layout="row" ng-if="self.control.type === 'group'" class="rv-menulink-header md-subhead">
-    <md-icon md-svg-src="{{ ::self.control.icon }}"></md-icon>
-
+    <md-icon>{{ ::self.control.icon }}</md-icon>
     {{ self.control.label | translate }}
     <span flex></span>
 </div>

--- a/src/app/ui/sidenav/sidenav.html
+++ b/src/app/ui/sidenav/sidenav.html
@@ -4,8 +4,7 @@
             <div ng-if="self.service.config.logo">
 
                 <img ng-src="{{ self.service.config.logoUrl }}" ng-if="self.service.config.logoUrl" alt="">
-
-                <md-icon md-svg-src="logo" ng-if="!self.service.config.logoUrl"></md-icon>
+                <md-icon>logo</md-icon>
             </div>
 
             <h1 translate class="app-logotype md-heading">sidenav.title</h1>
@@ -13,7 +12,7 @@
     </header>
 
     <md-button class="md-icon-button black rv-button-32 minimize-button" ng-click="self.service.close()">
-        <md-icon md-svg-src="community:chevron-double-left"></md-icon>
+        <md-icon>community:chevron-double-left</md-icon>
     </md-button>
 
     <md-content role="navigation">
@@ -37,7 +36,8 @@
             <span class="rv-version-timestamp">{{ self.version.timestamp }}</span>
             <div class="rv-version-github">
                 <a href="https://github.com/fgpv-vpgf/fgpv-vpgf" class="rv-icon-24">
-                    <md-icon md-svg-src="community:github"></md-icon>fgpv-vpgf/fgpv-vpgf</a>
+                    <md-icon>community:github-circle</md-icon> fgpv-vpgf/fgpv-vpgf</a>
+
             </div>
         </div>
 

--- a/src/app/ui/sidenav/sidenav.service.js
+++ b/src/app/ui/sidenav/sidenav.service.js
@@ -63,7 +63,7 @@
             layers: {
                 type: 'link',
                 label: 'appbar.tooltip.layers',
-                icon: 'maps:layers',
+                icon: 'layers',
                 isChecked: () => stateManager.state.mainToc.active,
                 action: () => {
                     service.close();
@@ -73,7 +73,7 @@
             basemap: {
                 type: 'link',
                 label: 'nav.label.basemap',
-                icon: 'maps:map',
+                icon: 'map',
                 action: () => {
                     service.close();
                     basemapService.open();
@@ -91,7 +91,7 @@
             share: {
                 type: 'link',
                 label: 'sidenav.label.share',
-                icon: 'social:share',
+                icon: 'share',
                 action: () => {
                     service.close();
 
@@ -110,7 +110,7 @@
             about: {
                 type: 'link',
                 label: 'sidenav.label.about',
-                icon: 'action:info_outline',
+                icon: 'info_outline',
                 action: () => {
                     service.close();
 
@@ -128,7 +128,7 @@
             fullscreen: {
                 type: 'link',
                 label: 'sidenav.label.fullscreen',
-                icon: 'navigation:fullscreen',
+                icon: 'fullscreen',
                 isHidden: false,
                 isChecked: fullScreenService.isExpanded,
                 action: () => {
@@ -139,7 +139,7 @@
             touch: {
                 type: 'link',
                 label: 'sidenav.label.touch',
-                icon: 'action:touch_app',
+                icon: 'touch_app',
                 isChecked: () => $rootElement.hasClass('rv-touch'),
                 action: () => $rootElement.toggleClass('rv-touch')
             },
@@ -155,13 +155,13 @@
             language: {
                 type: 'group',
                 label: 'sidenav.label.language',
-                icon: 'action:translate',
+                icon: 'translate',
                 children: []
             },
             plugins: {
                 type: 'group',
                 label: 'sidenav.menu.plugin',
-                icon: 'action:settings_input_svideo',
+                icon: 'settings_input_svideo',
                 children: []
             }
         };

--- a/src/app/ui/toc/templates/entry-control-button.html
+++ b/src/app/ui/toc/templates/entry-control-button.html
@@ -10,6 +10,6 @@
     <!-- the terrible hack below (testing for .call) is due to angular not having typeof available in $Parse
          https://github.com/angular/angular.js/pull/6886
     -->
-    <md-icon md-svg-src="{{ self.isFunction(self.template.icon) ? self.template.icon(self.control.value) : self.template.icon }}"></md-icon>
+    <md-icon>{{ self.isFunction(self.template.icon) ? self.template.icon(self.control.value) : self.template.icon }}</md-icon>
 
 </md-button>

--- a/src/app/ui/toc/templates/entry-control-menu-item.html
+++ b/src/app/ui/toc/templates/entry-control-menu-item.html
@@ -4,7 +4,7 @@
         ng-class="{ selected: self.control.selected }"
         ng-disabled="!self.control.enabled"
         aria-label="{{ self.template.label[self.control.value] || self.template.label | translate }}">
-        <md-icon md-svg-icon="{{ self.template.icon[self.control.value] || self.template.icon }}"></md-icon>
+        <md-icon>{{ self.template.icon[self.control.value] || self.template.icon }}</md-icon>
         {{ self.template.label[self.control.value] || self.template.label | translate }}
     </md-button>
 </md-menu-item>

--- a/src/app/ui/toc/templates/entry-flag.html
+++ b/src/app/ui/toc/templates/entry-flag.html
@@ -9,6 +9,5 @@
         {{ self.template.tooltip[self.control.value] || self.template.tooltip | translate:self.data }}
     </md-tooltip>
 
-    <md-icon md-svg-src="{{ self.isFunction(self.template.icon[self.control.value]) ? self.template.icon[self.control.value](self.data.type) : self.template.icon[self.control.value] || self.template.icon }}"></md-icon>
-
+    <md-icon>{{ self.isFunction(self.template.icon[self.control.value]) ? self.template.icon[self.control.value](self.data.type) : self.template.icon[self.control.value] || self.template.icon }}</md-icon>
 </div>

--- a/src/app/ui/toc/templates/entry-symbology.html
+++ b/src/app/ui/toc/templates/entry-symbology.html
@@ -18,7 +18,7 @@
         ng-mouseover="self.wiggleSymbology(true)"
         ng-mouseout="self.wiggleSymbology(false)">
         <md-tooltip md-direction="top">{{ self.expanded ? 'toc.layer.label.symbologyHide' : 'toc.layer.label.symbologyShow' | translate }}</md-tooltip>
-        <md-icon md-svg-src="navigation:close"></md-icon>
+        <md-icon>close</md-icon>
     </md-button>
 
 </div>

--- a/src/app/ui/toc/templates/expand-menu.html
+++ b/src/app/ui/toc/templates/expand-menu.html
@@ -3,12 +3,12 @@
     <!-- TODO: add translate filters -->
 
     <md-button
-        translate translate-attr-aria-label="toc.menu.expand.title"
+        translate-attr-aria-label="toc.menu.expand.title"
         class="md-icon-button primary rv-icon-20"
         ng-click="$mdOpenMenu($event)"
         ng-disabled="self.disabled">
         <md-tooltip>{{ 'toc.menu.expand.title' | translate }}</md-tooltip>
-        <md-icon md-svg-src="hardware:keyboard_arrow_down"></md-icon>
+        <md-icon>keyboard_arrow_down</md-icon>
     </md-button>
 
     <md-menu-content rv-trap-focus="{{ ::self.appID }}" class="rv-menu rv-dense" width="4">
@@ -16,8 +16,8 @@
             <md-button
                 ng-click="self.expandAllLegendEntries()"
                 ng-disabled="self.isAllLegendEntriesExpanded()"
-                translate translate-attr-aria-label="toc.menu.expand.allon">
-                <md-icon md-svg-icon="hardware:keyboard_arrow_down"></md-icon>
+                translate-attr-aria-label="toc.menu.expand.allon">
+                <md-icon>keyboard_arrow_down</md-icon>
                 {{ 'toc.menu.expand.allon' | translate }}
             </md-button>
         </md-menu-item>
@@ -26,8 +26,8 @@
             <md-button
                 ng-click="self.collapseAllLegendEntries()"
                 ng-disabled="self.isAllLegendEntriesCollapsed()"
-                translate translate-attr-aria-label="toc.menu.expand.alloff">
-                <md-icon md-svg-icon="hardware:keyboard_arrow_up"></md-icon>
+                translate-attr-aria-label="toc.menu.expand.alloff">
+                <md-icon>keyboard_arrow_up</md-icon>
                 {{ 'toc.menu.expand.alloff' | translate }}
             </md-button>
         </md-menu-item>

--- a/src/app/ui/toc/templates/group-entry.html
+++ b/src/app/ui/toc/templates/group-entry.html
@@ -9,8 +9,9 @@
 <div class="rv-icon-24 rv-group-toggle-icon">
     <md-icon
         class="md-toggle-icon"
-        ng-class="{ 'rv-toggled' : self.entry.expanded && !self.isReorder }"
-        md-svg-src="hardware:keyboard_arrow_down"></md-icon>
+        ng-class="{ 'rv-toggled' : self.entry.expanded && !self.isReorder }">
+        keyboard_arrow_down
+    </md-icon>
 </div>
 
 <span class="rv-group-name" rv-truncate-title="self.entry.name"></span>
@@ -26,7 +27,7 @@
             aria-label="{{ 'toc.layer.aria.openData' | translate }}"
             class="md-icon-button rv-button-40 rv-icon-20"
             ng-click="$mdOpenMenu($event)">
-            <md-icon md-svg-src="navigation:more_horiz"></md-icon>
+            <md-icon>more_horiz</md-icon>
         </md-button>
 
         <md-menu-content rv-trap-focus="{{::self.appID}}" class="rv-menu rv-dense" width="4">

--- a/src/app/ui/toc/templates/layer-entry.html
+++ b/src/app/ui/toc/templates/layer-entry.html
@@ -51,7 +51,7 @@
             aria-label="{{ 'toc.entry.aria.openData' | translate }}"
             class="md-icon-button rv-button-40 rv-icon-20"
             ng-click="$mdOpenMenu($event)">
-            <md-icon md-svg-src="navigation:more_horiz"></md-icon>
+            <md-icon>more_horiz</md-icon>
         </md-button>
 
         <md-menu-content rv-trap-focus="{{::self.appID}}" class="rv-menu rv-dense" width="4">

--- a/src/app/ui/toc/templates/placeholder-entry.html
+++ b/src/app/ui/toc/templates/placeholder-entry.html
@@ -3,7 +3,7 @@
 </div>
 
 <div class="rv-icon-32" ng-if-start="self.entry.state === 'rv-error'">
-    <md-icon md-svg-src="community:emoticon-sad"></md-icon>
+    <md-icon>community:emoticon-sad</md-icon>
 </div>
 
 <div class="rv-toc-entry-content">
@@ -27,7 +27,7 @@
 </div>
 
 <div class="rv-icon-32" ng-if-start="self.entry.state !== 'rv-error'">
-    <md-icon md-svg-src="community:emoticon-happy"></md-icon>
+    <md-icon>community:emoticon-happy</md-icon>
 </div>
 
 <div class="rv-toc-entry-content">

--- a/src/app/ui/toc/templates/visibility-menu.html
+++ b/src/app/ui/toc/templates/visibility-menu.html
@@ -3,12 +3,12 @@
     <!-- TODO: add translate filters -->
 
     <md-button
-        translate translate-attr-aria-label="toc.menu.visibility.title"
+        translate-attr-aria-label="toc.menu.visibility.title"
         class="md-icon-button primary rv-icon-20"
         ng-click="$mdOpenMenu($event)"
         ng-disabled="self.disabled">
         <md-tooltip>{{ 'toc.menu.visibility.title' | translate }}</md-tooltip>
-        <md-icon md-svg-src="action:visibility"></md-icon>
+        <md-icon>visibility</md-icon>
     </md-button>
 
     <md-menu-content rv-trap-focus="{{ ::self.appID }}" class="rv-menu rv-dense" width="4">
@@ -16,8 +16,8 @@
             <md-button
                 ng-click="self.showAllLegendEntries()"
                 ng-disabled="self.isAllLegendEntriesVisible()"
-                translate translate-attr-aria-label="toc.menu.visibility.allon">
-                <md-icon md-svg-icon="action:visibility"></md-icon>
+                translate-attr-aria-label="toc.menu.visibility.allon">
+                <md-icon>visibility</md-icon>
                 {{ 'toc.menu.visibility.allon' | translate }}
             </md-button>
         </md-menu-item>
@@ -26,8 +26,8 @@
             <md-button
                 ng-click="self.hideAllLegendEntries()"
                 ng-disabled="self.isAllLegendEntriesHidden()"
-                translate translate-attr-aria-label="toc.menu.visibility.alloff">
-                <md-icon md-svg-icon="action:visibility_off"></md-icon>
+                translate-attr-aria-label="toc.menu.visibility.alloff">
+                <md-icon>visibility_off</md-icon>
                 {{ 'toc.menu.visibility.alloff' | translate }}
             </md-button>
         </md-menu-item>

--- a/src/app/ui/toc/toc.html
+++ b/src/app/ui/toc/toc.html
@@ -6,12 +6,12 @@
             <rv-loader-menu></rv-loader-menu>
 
             <md-button
-                translate translate-attr-aria-label="toc.menu.reorder.title"
+                translate-attr-aria-label="toc.menu.reorder.title"
                 class="md-icon-button primary rv-icon-20"
                 ng-class="{ selected: self.isReorder }"
                 ng-click="self.toggleReorderMode()">
                 <md-tooltip>{{ 'toc.menu.reorder.title' | translate }}</md-tooltip>
-                <md-icon md-svg-src="action:swap_vert"></md-icon>
+                <md-icon>swap_vert</md-icon>
             </md-button>
 
             <h4 class="md-subhead" ng-if="self.isReorder">{{ 'toc.menu.reorder.title' | translate }}</h4>
@@ -19,13 +19,12 @@
             <span flex></span>
 
             <md-button
-                translate
                 translate-attr-aria-label="toc.menu.reorder.close"
                 class="rv-close md-icon-button black rv-icon-20"
                 ng-click="self.toggleReorderMode(false)"
                 ng-if="self.isReorder">
                 <md-tooltip>{{ 'toc.menu.reorder.close' | translate }}</md-tooltip>
-                <md-icon md-svg-src="navigation:close"></md-icon>
+                <md-icon>close</md-icon>
             </md-button>
 
             <rv-toc-expand-menu ng-if="!self.isReorder"></rv-toc-expand-menu>

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -32,54 +32,54 @@
             groupOptions: {
                 visibility: {
                     action: null,
-                    icon: vis => `action:visibility${vis ? '' : '_off'}`,
+                    icon: vis => `visibility${vis ? '' : '_off'}`,
                     label: 'toc.label.toggleGroupViz',
                     tooltip: 'toc.tooltip.toggleGroupViz'
                 }
             },
             options: {
                 extra: {
-                    icon: 'navigation:more_horiz',
+                    icon: 'more_horiz',
                     label: 'toc.label.extraMenu',
                     tooltip: 'toc.tooltip.extraMenu'
                 },
                 metadata: {
-                    icon: 'action:description',
+                    icon: 'description',
                     label: 'toc.label.metadata',
                     tooltip: 'toc.tooltip.metadata',
                     action: toggleMetadata
                 },
                 query: {
-                    icon: 'communication:location_on',
+                    icon: 'community:location_on',
                     label: 'toc.label.query',
                     tooltip: 'toc.tooltip.query'
                 },
                 settings: {
-                    icon: 'image:tune',
+                    icon: 'tune',
                     label: 'toc.label.settings',
                     tooltip: 'toc.tooltip.settings',
                     action: toggleSettings
                 },
                 visibility: {
-                    icon: vis => `action:visibility${vis ? '' : '_off'}`,
+                    icon: vis => `visibility${vis ? '' : '_off'}`,
                     label: vis => `toc.label.visibility.${vis ? 'on' : 'off'}`,
                     tooltip: vis => `toc.tooltip.visibility.${vis ? 'on' : 'off'}`,
                     action: toggleVisiblity
                 },
                 offscale: {
-                    icon: zoom => `action:zoom_${zoom ? 'in' : 'out'}`,
+                    icon: zoom => `zoom_${zoom ? 'in' : 'out'}`,
                     label: zoom => `toc.label.visibility.zoom${zoom ? 'In' : 'Out'}`,
                     tooltip: zoom => `toc.tooltip.visibility.zoom${zoom ? 'In' : 'Out'}`,
                     action: zoomLayerScale
                 },
                 reload: {
-                    icon: 'navigation:refresh',
+                    icon: 'refresh',
                     label: 'toc.label.reload',
                     tooltip: 'toc.tooltip.reload',
                     action: entry => geoService.reloadLayer(entry)
                 },
                 boundaryZoom: {
-                    icon: `action:zoom_in`,
+                    icon: `zoom_in`,
                     label: 'toc.label.boundaryZoom',
                     tooltip: 'toc.tooltip.boundaryZoom',
                     action: zoomToBoundary
@@ -91,7 +91,7 @@
                     action: service.actions.toggleLayerFiltersPanel
                 },
                 remove: {
-                    icon: 'action:delete',
+                    icon: 'delete',
                     label: 'toc.label.remove',
                     tooltip: 'toc.tooltip.remove',
                     action: removeLayer
@@ -102,12 +102,12 @@
                     tooltip: 'toc.tooltip.filters'
                 },
                 reorder: {
-                    icon: 'editor:drag_handle',
+                    icon: 'drag_handle',
                     label: 'toc.tooltip.reorder',
                     tooltip: 'toc.tooltip.reorder'
                 },
                 symbologyStack: {
-                    icon: 'maps:layers',
+                    icon: 'layers',
                     label: 'toc.menu.symbology',
                     tooltip: 'toc.menu.symbology',
                     action: entry => {
@@ -126,12 +126,12 @@
                                 esriGeometryPolyline: 'community:vector-polyline'
                             }[type];
                         },
-                        esriDynamic: 'action:settings',
-                        esriDynamicLayerEntry: 'image:photo',
-                        ogcWms: 'image:photo',
-                        ogcWmsLayerEntry: 'image:photo',
-                        esriImage: 'image:photo',
-                        esriTile: 'image:photo'
+                        esriDynamic: 'settings',
+                        esriDynamicLayerEntry: 'photo',
+                        ogcWms: 'photo',
+                        ogcWmsLayerEntry: 'photo',
+                        esriImage: 'photo',
+                        esriTile: 'photo'
                     },
                     label: {
                         esriFeature: 'toc.label.flag.feature',
@@ -153,7 +153,7 @@
                     }
                 },
                 scale: {
-                    icon: 'maps:layers_clear',
+                    icon: 'layers_clear',
                     label: 'toc.label.flag.scale',
                     tooltip: 'toc.tooltip.flag.scale'
                 },
@@ -168,7 +168,7 @@
                     tooltip: 'toc.tooltip.flag.query'
                 },
                 user: {
-                    icon: 'social:person',
+                    icon: 'person',
                     label: 'toc.label.flag.user',
                     tooltip: 'toc.tooltip.flag.user'
                 },
@@ -178,15 +178,15 @@
                     tooltip: 'toc.tooltip.flag.filter'
                 },
                 wrongprojection: {
-                    icon: 'alert:warning',
+                    icon: 'warning',
                     label: 'toc.label.flag.wrongprojection',
                     tooltip: 'toc.tooltip.flag.wrongprojection'
                 }
             },
             state: {
                 icon: {
-                    error: 'alert:error',
-                    reloading: 'navigation:refresh'
+                    error: 'error',
+                    reloading: 'refresh'
                 },
                 label: {
                     error: 'toc.label.state.error',

--- a/src/content/styles/main.scss
+++ b/src/content/styles/main.scss
@@ -17,3 +17,11 @@
 }
 
 @import "vendor/_special.scss";
+
+.mdi:before, .mdi-set {
+    width: inherit;
+    height: inherit;
+    vertical-align: super;
+    line-height: normal !important;
+    font-size: 24px !important;
+}

--- a/src/content/styles/modules/_buttons.scss
+++ b/src/content/styles/modules/_buttons.scss
@@ -141,10 +141,15 @@
 
 
 @mixin icon-size($size) {
+    .mdi:before, .mdi-set {
+        font-size: $size !important;
+    }
+
     &md-icon,
     > md-icon,
     &.md-button > md-icon,
     > .md-button > md-icon {
+        font-size: $size;
         height: $size;
         width: $size;
     }


### PR DESCRIPTION
Got carried away with #1839, somehow I ended up experimenting with icons as fonts instead of svg. This PR should not be merged. 

- Updated `angular-translate` to v2.15.1 which fixes an issue where `translate` needed to be added for `translate-attr-aria-label` to work. This might be opened as a separate issue since `translate` tries to translate the entire contents of the element. This was causing issues with md-icon inside a button with `translate`

- AM allows icons in the form `<md-icon>iconname</md-icon>`. Prefixes such as `map` or `action` are not needed.

- Most file chanes are just `md-icon` formatting. `icon.decorator.js` and `bootstrap.js` contain the changes.

- This would eliminate `makesvgcache` - but we would still require a static svg file(s) to be injected into `core.js` for the cases where we want to use custom svg images.

We most likely won't want to change the way we handle icons this drastically, but I figured I'd show my work none the less. Enjoy!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1846)
<!-- Reviewable:end -->
