### PR TITLE
fix(bug): RV.logger is now initialized as console

### DIFF
--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -11,6 +11,10 @@
     // check if the global RV registry object already exists and store a reference
     const RV = window.RV = typeof window.RV === 'undefined' ? {} : window.RV;
 
+    // fixes logger issue where it can be called before it is loaded, this reverts it to console
+    // TODO: load logger lib before app starts
+    RV.logger = console;
+
     // test user browser, true if IE false otherwise
     RV.isIE = /Edge\/|Trident\/|MSIE /.test(window.navigator.userAgent);
 


### PR DESCRIPTION
## Description
Prevents loading order conflicts by first initializing RV.logger as
console then later switching it to logger library when ready

## Testing
Yes

## Documentation
inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1849)
<!-- Reviewable:end -->
