### PR TITLE
fix(filter): keytable extension slow with huge table

### DIFF
--- a/src/app/bootstrap.js
+++ b/src/app/bootstrap.js
@@ -50,7 +50,7 @@
             get url() { return `//ajax.aspnetcdn.com/ajax/jQuery/jquery-${this.ourVersion}.min.js`; }
         },
         dataTables: {
-            get ourVersion() { return '1.10.11'; },
+            get ourVersion() { return '1.10.15'; },
             get theirVersion() { return $.fn.dataTable.version; },
             get url() { return `//cdn.datatables.net/${this.ourVersion}/js/jquery.dataTables.min.js`; }
         }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
#1842 

From the answer given by datatables developer, we need to migrate to version 1.10.15

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome, Safari

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1851)
<!-- Reviewable:end -->
