### PR TITLE
fix(legend): safari svg symbol doesn't render

### DIFF
--- a/src/app/common/graphics.service.js
+++ b/src/app/common/graphics.service.js
@@ -20,7 +20,8 @@
             createSvg,
             createCanvas,
             mergeCanvases,
-            getTextWidth
+            getTextWidth,
+            setSvgHref
         };
 
         return service;
@@ -127,6 +128,18 @@
             // measure text width on the canvas: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/measureText
             const metrics = context.measureText(text);
             return metrics.width;
+        }
+
+        /**
+         * Returns svg with proper href value. for Safari, xlink:href element is named ns1:href. Rename the element xlink:href to show symbology.
+         * it seems to be a bug from svg.js library.
+         * @function setSvgHref
+         * @param  {String} link link to reset the href for
+         * @return {String}        reseted href
+         */
+        function setSvgHref(link) {
+            // TODO: send issue to svg library
+            return link.replace(/ns1:href/gi, 'xlink:href');
         }
     }
 })();

--- a/src/app/ui/common/svg.directive.js
+++ b/src/app/ui/common/svg.directive.js
@@ -21,7 +21,7 @@
         .module('app.ui.common')
         .directive('rvSvg', rvSvg);
 
-    function rvSvg() {
+    function rvSvg(graphicsService) {
         const directive = {
             restrict: 'E',
             scope: {
@@ -47,12 +47,8 @@
                     const node = angular.element(scope.src);
                     const img = node.find('image');
                     if (node.is('svg') && img.length > 0) {
-                        // for Safari, xlink:href element is named href. Rename the element xlink:href to show symbology
-                        // it seems to be a bug from svg.js library
-                        // TODO: send issue to svg library
-                        if (typeof img.attr('href') !== 'undefined') {
-                            scope.src = scope.src.replace('href', 'xlink:href');
-                        }
+                        // for Safari, rename the element xlink:href to show symbology
+                        scope.src = graphicsService.setSvgHref(scope.src);
                     }
 
                     el.empty().append(scope.src);

--- a/src/app/ui/toc/entry-control.directive.spec.js
+++ b/src/app/ui/toc/entry-control.directive.spec.js
@@ -56,11 +56,15 @@ describe('rvTocEntryControl', () => {
         $provide.service('storageService', $q => () => $q.resolve());
     }
 
+    function mockGraphicsService($provide) {
+        $provide.service('graphicsService', $q => () => $q.resolve());
+    }
+
     beforeEach(() => {
         // mock the module with bardjs; include templates modules
         bard.appModule('app.ui.toc', 'app.templates', 'app.common.router', 'app.geo',
             'pascalprecht.translate', mockConfigService, mockLayoutService, mockGeoService,
-            mockToast, mockErrorService, mockDebounceService, mockStorageService);
+            mockToast, mockErrorService, mockDebounceService, mockStorageService, mockGraphicsService);
 
         // inject angular services
         bard.inject('$compile', '$rootScope', '$httpBackend', 'tocService');

--- a/src/app/ui/toc/entry-flag.directive.spec.js
+++ b/src/app/ui/toc/entry-flag.directive.spec.js
@@ -55,11 +55,15 @@ describe('rvLayerItemFlag', () => {
         $provide.service('storageService', $q => () => $q.resolve());
     }
 
+    function mockGraphicsService($provide) {
+        $provide.service('graphicsService', $q => () => $q.resolve());
+    }
+
     beforeEach(() => {
         // mock the module with bardjs; include templates modules
         bard.appModule('app.ui.toc', 'app.templates', 'app.common.router', 'app.geo',
             'pascalprecht.translate', mockConfigService, mockLayoutService, mockGeoService,
-            mockToast, mockErrorService, mockDebounceService, mockStorageService);
+            mockToast, mockErrorService, mockDebounceService, mockStorageService, mockGraphicsService);
 
         // inject angular services
         bard.inject('$compile', '$rootScope');

--- a/src/app/ui/toc/entry.directive.spec.js
+++ b/src/app/ui/toc/entry.directive.spec.js
@@ -82,12 +82,16 @@ describe('rvTocEntry', () => {
         $provide.service('storageService', $q => () => $q.resolve());
     }
 
+    function mockGraphicsService($provide) {
+        $provide.service('graphicsService', $q => () => $q.resolve());
+    }
+
     beforeEach(() => {
         // mock the module with bardjs; include templates modules
         bard.appModule('app.ui.toc', 'app.templates', 'app.common.router', 'app.geo',
             'pascalprecht.translate', mockConfigService, mockLayoutService, mockGeoService,
             mockToast, mockReverseFilter, mockErrorService, mockDebounceService, mockAppInfo,
-            mockAnimationService, mockStorageService);
+            mockAnimationService, mockStorageService, mockGraphicsService);
 
         // inject angular services
         bard.inject('$compile', '$rootScope', '$httpBackend', 'tocService');

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -15,8 +15,9 @@
         .module('app.ui.toc')
         .factory('tocService', tocService);
 
+    // jshint maxparams:11
     function tocService($q, $rootScope, $mdToast, $translate, layoutService, stateManager,
-                        geoService, metadataService, errorService, debounceService) {
+                        geoService, metadataService, errorService, debounceService, graphicsService) {
 
         const service = {
             // method called by the options and flags set on the layer item
@@ -382,9 +383,10 @@
                     // add symbol as the first column
                     // check if the symbol column already exists
                     if (!attributes.columns.find(({ data }) => data === rvSymbolColumnName)) {
-
                         attributes.rows.forEach(row => {
-                            row.rvSymbol = geoService.retrieveSymbol(row, attributes.renderer);
+                            // reset href to solve problem in Safari with svg not rendered
+                            row.rvSymbol =
+                                graphicsService.setSvgHref(geoService.retrieveSymbol(row, attributes.renderer));
                             row.rvInteractive = '';
                         });
 


### PR DESCRIPTION
Closes #1671

## Description
<!-- Link to an issue or include a description -->
The problem append again because now safari use NS1:href not just href

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Safari and Chrome

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1854)
<!-- Reviewable:end -->
