### PR TITLE
fix(ui): es6 strings don't work in templates

### DIFF
--- a/src/app/ui/basemap/basemap-item.html
+++ b/src/app/ui/basemap/basemap-item.html
@@ -24,7 +24,7 @@
     <span flex></span>
 
     <md-button
-        aria-label="{{ `basemap.${self.isDescriptionVisible ? 'hide' : 'show' }description` | translate}}"
+        aria-label="{{ 'basemap.' + (self.isDescriptionVisible ? 'hide' : 'show') + 'description' | translate }}"
         class="md-icon-button rv-button-32 rv-icon-20"
         ng-class="{ selected: self.isDescriptionVisible }"
         ng-click="self.toggleDescription()">


### PR DESCRIPTION
## Description
es6 string substitution doesn't work in templates;

Closes #1860

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

## Documentation
Not needed.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~[ ] release notes have been updated~ unreleased bug
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1861)
<!-- Reviewable:end -->
