### PR TITLE
fix(scale): scale wont move after projection switch

### DIFF
--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1312,7 +1312,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             super(source);
         }
 
-        get attachTo () { return 'bottom-left'; }
+        get attachTo () { return 'bottom-right'; }
         get scalebarUnit () { return 'dual'; }
 
         get JSON() {

--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -1,7 +1,3 @@
-import {Power1} from 'gsap';
-
-const RV_SWIFT_IN_OUT_EASE = Power1;
-
 /**
  * @restrict A
  * @module rvInitMap
@@ -57,47 +53,6 @@ function rvInitMap($rootScope, geoService, events, storageService, mapService, g
 
                 el.on('mousedown', mouseDownHandler);
                 el.on('mouseup', mouseUpHandler);
-
-                // scale animation
-                let scaleAnimation = animationService.timeLineLite();
-                const scaleTween = scaleAnimation
-                    .to(el.find('.esriScalebar'), 0.3, {
-                        left: 425,
-                        ease: RV_SWIFT_IN_OUT_EASE
-                    }, 0);
-
-                // coordinates animation
-                const coordAnimation = animationService.timeLineLite();
-                coordAnimation
-                    .to(el.parent().find('.rv-map-coordinates'), 0.3, {
-                        left: 575,
-                        ease: RV_SWIFT_IN_OUT_EASE
-                    }, 0);
-
-                // on basemap change, if projection is different, map is recreated with a new scalebar.
-                // when this is done, the reference to the scale is lost and the animation break.
-                $rootScope.$on('rvBasemapChange', () => {
-                    // remove the tween (reference is lost) and recreate it
-                    scaleAnimation.remove(scaleTween);
-                    scaleAnimation.to(el.find('.esriScalebar'), 0.3, {
-                        left: 425,
-                        ease: RV_SWIFT_IN_OUT_EASE
-                    }, 0);
-
-                    // if main panel is active, run the animation
-                    if (stateManager.state.main.active) { scaleAnimation.play(); }
-                });
-
-                // watch main panel open to move scalebar and map coordinates
-                $rootScope.$watch(() => stateManager.state.main.active, (val) => {
-                    if (val) {
-                        scaleAnimation.play();
-                        coordAnimation.play();
-                    } else {
-                        scaleAnimation.reverse();
-                        coordAnimation.reverse();
-                    }
-                });
             }
         });
 

--- a/src/content/samples/config-mobile-2.json
+++ b/src/content/samples/config-mobile-2.json
@@ -49,7 +49,7 @@
       "mouseInfo": {
         "enabled": true,
         "spatialReference": {
-          "wkid": 102100
+          "wkid": 4326
         }
       },
       "northArrow": {

--- a/src/content/styles/modules/_shell.scss
+++ b/src/content/styles/modules/_shell.scss
@@ -35,18 +35,18 @@
 
         .rv-map-coordinates {
             position: absolute;
-            left: rem(17.5);
-            bottom: rem(0.5);
+            right: rem(15.5);
+            bottom: rem(0.1);
             padding: rem(0.2);
             display: flex;
             flex-direction: column;
-            font-size: rem(1.2);
-            font-weight: 500;
-            line-height: 1.5;
+            font-size: rem(1.1);
+            font-weight: 600;
+            height: rem(4);
             background-color: rgba(255, 255, 255, 0.62);
 
             span {
-                width: rem(16);
+                width: rem(17);
                 text-align: center;
             }
         }

--- a/src/content/styles/vendor/_esri.scss
+++ b/src/content/styles/vendor/_esri.scss
@@ -70,8 +70,8 @@
     }
 
     .scalebar_bottom-right {
-        right: 100px;
-        bottom: 25px;
+        right: 5px;
+        bottom: 1px;
     }
 
     .esriScalebar {
@@ -79,7 +79,7 @@
         position: absolute;
         width: 150px;
         height: 40px;
-        padding: 2px;
+        padding-left: 2px;
         background-color: rgba(255, 255, 255, 0.62);
     }
 
@@ -358,10 +358,11 @@
     .esriControlsBR {
         pointer-events: none; // €$₨¥
         position: absolute;
-        right: 5px;
+        left: 5px;
         bottom: 5px;
         z-index: 30;
-        text-align: right;
+        text-align: left;
+        transform: scaleX(-1);
 
         .esriAttribution {
             font-size: 13px;
@@ -376,6 +377,7 @@
             padding: 0 4px;
             margin: 0 5px 0 0;
             background: rgba(255,255,255,0.7);
+            transform: scaleX(-1);
 
             .esriAttributionLastItem span.esriAttributionDelim {
                 display: none;
@@ -384,6 +386,7 @@
     }
 
     .map .logo-med {
+        transform: scaleX(-1);
         display: inline-block;
         vertical-align: bottom;
         min-width: 65px;


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Scale bar is not at the right place after switching basemap. To achieve this it was not easy because there something wrong when the scalebar is on the left side. Application always force it back to the left. I we use bottom-right inside the scalebar init, there is no need for almost 2/3 of the code from this PR.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome, FF

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1872)
<!-- Reviewable:end -->
