### PR TITLE
Moving hovertip template

### DIFF
--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -247,12 +247,20 @@
                 // TODO: decide if we want to preserve any settings (apart from snapshot) through the layer reload
             }
 
-            get opacity () {        return this._opacity; }
-            get visibility () {     return this._visibility; }
-            get boundingBox () {    return this._boundingBox; }
-            get query () {          return this._query; }
-            get snapshot () {       return this._snapshot; }
-            set snapshot (value) {  this._snapshot = value; }
+            get opacity () {            return this._opacity; }
+            set opacity (value) {       this._opacity = value; }
+
+            get visibility () {         return this._visibility; }
+            set visibility (value) {    this._visibility = value; }
+
+            get boundingBox () {        return this._boundingBox; }
+            set boundingBox (value) {   this._boundingBox = value; }
+
+            get query () {              return this._query; }
+            set query (value) {         this._query = value; }
+
+            get snapshot () {           return this._snapshot; }
+            set snapshot (value) {      this._snapshot = value; }
 
             get JSON() {
                 return {
@@ -398,18 +406,22 @@
                 }
             }
 
-            get source () { return this._source; }
+            get source () {                 return this._source; }
 
-            get id () { return this._id; }
-            get layerType () { return this._layerType; }
+            get id () {                     return this._id; }
+            get layerType () {              return this._layerType; }
 
-            get name () { return this._name; }
-            set name (value) { this._name = value; }
+            get name () {                   return this._name; }
+            set name (value) {              this._name = value; }
 
-            get url () { return this._url; }
-            get metadataUrl () { return this._metadataUrl; }
-            get catalogueUrl () { return this._catalogueUrl; }
-            get extent () { return this._extent; }
+            get url () {                    return this._url; }
+            get metadataUrl () {            return this._metadataUrl; }
+            get catalogueUrl () {           return this._catalogueUrl; }
+            get extent () {                 return this._extent; }
+
+            _hovertipEnabled = false;
+            get hovertipEnabled () {        return this._hovertipEnabled; }
+            set hovertipEnabled (value) {   this._hovertipEnabled = value; }
 
             /**
              * @return {Array} an array of control names which are visible in UI;
@@ -465,6 +477,8 @@
                 this._nameField = source.nameField;
                 this._tolerance = source.tolerance || 5;
             }
+
+            _hovertipEnabled = true;
 
             get nameField () { return this._nameField; }
             set nameField (value) { this._nameField = value; }

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -334,6 +334,13 @@
             return boundingBoxRecord;
         }
 
+        /**
+         * Binds onHover event (for feature layers) and displays a hover tooltip if allowed in the layer config.
+         *
+         * @function _setHoverTips
+         * @private
+         * @param {LayerRecord} layerRecord a layer record to set the hovertips on
+         */
         function _setHoverTips(layerRecord) {
             // TODO: layerRecord returns a promise on layerType to be consistent with dynamic children which don't know their type upfront
             // to not wait on promise, check the layerRecord config
@@ -341,23 +348,9 @@
                 return;
             }
 
-            // TODO: reenable when this option is added to the config
-            /*
-            if (!layerRecord.config.tooltipEnabled) {
+            if (!layerRecord.config.hovertipEnabled) {
                 return;
-            }*/
-
-            // TODO: where to put the template? it shouldn't be in layer registry
-            const tooltipTemplate = `
-                <div class="rv-tooltip-content" ng-if="self.name !== null">
-                    <rv-svg once="false" class="rv-tooltip-graphic" src="self.svgcode"></rv-svg>
-                    <span class="rv-tooltip-text" ng-if="self.name">{{ self.name }}</span>
-                </div>
-
-                <div class="rv-tooltip-content" ng-if="self.name === null">
-                    <span class="rv-tooltip-text">{{ 'maptip.hover.label.loading' | translate }}</span>
-                </div>
-            `;
+            }
 
             let tipContent;
 
@@ -378,7 +371,7 @@
                             graphic: e.target
                         };
 
-                        const tipRef = tooltipService.addHoverTooltip(e.point, tooltipTemplate, tipContent);
+                        const tipRef = tooltipService.addHoverTooltip(e.point, tipContent);
                     },
                     tipLoaded: e => {
                         // update the content of the tip with real data.

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -126,7 +126,7 @@
 
             /**
              * Layer config object persists through layer reload (corresponding layer record and legend blocks are destroyed),
-             * the changed snapshot value will be processed in geoApi on the subsequent generation of layer records.             *
+             * the changed snapshot value will be processed in geoApi on the subsequent generation of layer records.
              *
              * @param {Boolean} value stores the snapshot value on the layer config object
              */
@@ -749,24 +749,24 @@
         }
 
         /**
-         * Checks if the specified control is locked to modification by the system and user.
+         * Checks if the specified control is locked from modification by the system and user.
          *
          * @function isControlSystemDisabled
          * @private
          * @param {String} controlName the name of the control to be checked
-         * @return {Boolean} true if the control specified is locked to modifications by the system and user
+         * @return {Boolean} true if the control specified is locked from modifications by the system and user
          */
         function isControlSystemDisabled(controlName) {
             return this.isControlDisabled(controlName);
         }
 
         /**
-         * Checks if the specified control is locked to modification by the user.
+         * Checks if the specified control is locked from modification by the user.
          *
          * @function isControlUserDisabled
          * @private
          * @param {String} controlName the name of the control to be checked
-         * @return {Boolean} true if the control specified is locked to modifications by user but can be changed by the system
+         * @return {Boolean} true if the control specified is locked from modifications by user but can be changed by the system
          */
         function isControlUserDisabled(controlName) {
             return this.userDisabledControls.indexOf(controlName) !== -1;

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -83,7 +83,7 @@
 
             const blockConfig = new ConfigObject.legend.Entry(entryConfigObject);
 
-            // FIXME: this seems to alwyas insert a new layer at the bottom of the legend regardless of it's sorting group; needs fixing
+            // FIXME: this seems to always insert a new layer at the bottom of the legend regardless of it's sorting group; needs fixing
             const legendBlock = _makeLegendBlock(blockConfig, [layerBlueprint]);
             configService.getSync.map.legendBlocks.addEntry(legendBlock);
 

--- a/src/app/ui/tooltip/tooltip.service.js
+++ b/src/app/ui/tooltip/tooltip.service.js
@@ -1,5 +1,16 @@
 (() => {
 
+    const DEFAULT_HOVERTIP_TEMPLATE = `
+        <div class="rv-tooltip-content" ng-if="self.name !== null">
+            <rv-svg once="false" class="rv-tooltip-graphic" src="self.svgcode"></rv-svg>
+            <span class="rv-tooltip-text" ng-if="self.name">{{ self.name }}</span>
+        </div>
+
+        <div class="rv-tooltip-content" ng-if="self.name === null">
+            <span class="rv-tooltip-text">{{ 'maptip.hover.label.loading' | translate }}</span>
+        </div>
+    `;
+
     /**
      * @module tooltipService
      * @memberof app.ui
@@ -417,11 +428,11 @@
         /**
          * @function addHoverTooltip
          * @param {Object} point tooltip origin point ({ x: <Number>, y: <Number> } in pixels relative to the map node)
-         * @param {String} content tooltips content that will be transcluded by the tooltip directive; should be valid HTML
          * @param {Object} self a self object that will be available on the tooltip directive scope
-         * @return {Object} a Tooltip instance
+         * @param {String} content tooltips content template that will be transcluded by the tooltip directive; should be valid HTML
+         * @return {Tooltip} a Tooltip instance
          */
-        function addHoverTooltip(point, content, self) {
+        function addHoverTooltip(point, self, content = DEFAULT_HOVERTIP_TEMPLATE) {
             const tooltipScope = $rootScope.$new();
             tooltipScope.self = self;
 


### PR DESCRIPTION
## Description
- move hovertip template to tootlip service as the default template
- prevent controlled layers from being queried (even if specified in the config)
- prevent controlled layers from having enabled bounding boxes (even if specified in the config)
- prevent controlled layers from having hovertips

## Testing
Nope.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ not needed
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1895)
<!-- Reviewable:end -->
