### PR TITLE
fix(filter): replace Keytable by our own keyboard navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "datatables.net-buttons": "^1.3.1",
     "datatables.net-colreorder": "^1.3.3",
     "datatables.net-dt": "^1.10.15",
-    "datatables.net-keytable": "^2.2.1",
     "datatables.net-scroller": "^1.4.2",
     "datatables.net-select": "^1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",

--- a/src/app/app-loader.js
+++ b/src/app/app-loader.js
@@ -19,7 +19,6 @@ import 'datatables.net-buttons';
 import 'datatables.net-buttons/js/buttons.html5.js';
 import 'datatables.net-buttons/js/buttons.print.js';
 import 'datatables.net-colreorder';
-import 'datatables.net-keytable';
 import 'datatables.net-scroller';
 import 'datatables.net-select';
 

--- a/src/content/styles/modules/_filters.scss
+++ b/src/content/styles/modules/_filters.scss
@@ -48,7 +48,7 @@
                         width: 100% !important;
 
                         tbody {
-                            // for datatable KeyTable extension
+                            // for keyTable navigation
                             td:focus {
                                 outline: 1px solid $focus-color;
                                 outline-offset: -1px;


### PR DESCRIPTION
Closes #1896

## Description
<!-- Link to an issue or include a description -->
There is a lot of bugs between Keytable and Scroller extention and Focus manager.  Build our own keyboard navigation will solve this.
 
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Chrome, FF and Safari

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1898)
<!-- Reviewable:end -->
