### PR TITLE
chore(build): added env.geoLocal

### DIFF
--- a/src/content/samples/blank.tpl
+++ b/src/content/samples/blank.tpl
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta content="width=device-width,initial-scale=1" name="viewport">
+        <title>Blank Test Page</title>
+    </head>
+
+    <body></body>
+</html>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -99,6 +99,10 @@ module.exports = function (env) {
 
         externals: { 'TweenLite': 'TweenLite' },
 
+        resolve: {
+            alias: {}
+        },
+
         watchOptions: {
             aggregateTimeout: 300,
             poll: 1000,
@@ -116,6 +120,10 @@ module.exports = function (env) {
     };
 
     config.plugins.push(...htmlInjectPlugins());
+
+    if (env.geoLocal) {
+        config.resolve.alias['geoApi$'] = path.resolve(__dirname, '../', env.geoLocal.length > 0 ? env.geoLocal : 'geoApi');
+    }
 
     if (env.inspect) {
         const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,9 @@
+/* Webpack command line options
+    env.useMap                      -   Enable source maps on develop (increases build time)
+    env.geoLocal                    -   Replaces geoApi from npm node_module with a local geoApi repo folder located by ../geoApi
+    env.geoLocal="path/to/geoApi"   -   same as no argument env.geoLocal but uses provided path to local folder
+    env.inspect                     -   Bundle analysis for use with build debugging and optimization
+*/
 module.exports = function(env = {}) {
     env.inspect = env.inspect ? true : false;  // displays interactive bundle analyzer
     return require(`./webpack.${env.prod ? 'prod' : 'dev'}.js`)(env);

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -2,9 +2,11 @@ const Merge         = require('webpack-merge');
 const CommonConfig  = require('./webpack.common.js');
 
 module.exports = function (env) {
-    const config = Merge(CommonConfig(env), {
-        devtool: 'source-map'
-    });
+    const config = Merge(CommonConfig(env), {});
+
+    if (env.useMap) {
+        config.devtool = 'source-map';
+    }
 
     return config;
 }


### PR DESCRIPTION
Replaces geoApi from node_modules with a local copy on disk. Works with
live reload.

Source maps no longer generate for develop automatically (faster builds). Use env.useMap
to enable.

Must merge geoApi PR #217 first

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1916)
<!-- Reviewable:end -->
