### PR TITLE
Restore switching to basemaps with different proejctions

### DIFF
--- a/src/app/core/reload.service.js
+++ b/src/app/core/reload.service.js
@@ -10,18 +10,28 @@ angular
     .module('app.core')
     .factory('reloadService', reloadService);
 
-function reloadService($translate, $rootScope, events, bookmarkService, geoService, configService) {
+function reloadService($translate, $rootScope, events, bookmarkService, mapService, geoService, configService) {
     const service = {
         loadNewProjection,
         loadNewLang,
         loadWithBookmark,
         loadWithExtraKeys,
-        bookmarkBlocking: false
+        bookmarkBlocking: false,
+
+        changeProjection
     };
 
     return service;
 
     /************************/
+
+    function changeProjection(startPoint) {
+        events.$broadcast(events.rvApiHalt);
+        const bookmark = bookmarkService.getBookmark(startPoint);
+        bookmarkService.parseBookmark(bookmark);
+
+        geoService.assembleMap();
+    }
 
     /**
      * Maintains state over projection switch. Updates the config to the current state,
@@ -31,7 +41,7 @@ function reloadService($translate, $rootScope, events, bookmarkService, geoServi
      * @param {String} basemapId     The id of the basemap to switch to
      */
     function loadNewProjection(basemapId) {
-        $rootScope.$broadcast(events.rvApiHalt);
+        events.$broadcast(events.rvApiHalt);
         const bookmark = bookmarkService.getBookmark();
 
         // get original config and add bookmark to it

--- a/src/app/geo/layer-blueprint.class.js
+++ b/src/app/geo/layer-blueprint.class.js
@@ -13,8 +13,7 @@ angular
     .module('app.geo')
     .factory('LayerBlueprint', LayerBlueprintFactory);
 
-function LayerBlueprintFactory($q, $http, LayerBlueprintUserOptions, gapiService, Geo,
-    layerDefaults, LayerRecordFactory, ConfigObject, common) {
+function LayerBlueprintFactory($q, $http, gapiService, Geo, ConfigObject, bookmarkService) {
 
     let idCounter = 0; // layer counter for generating layer ids
 
@@ -34,6 +33,17 @@ function LayerBlueprintFactory($q, $http, LayerBlueprintUserOptions, gapiService
                 console.warn('config is already set');
                 return;
             }
+
+            // check if there is a parsed and stored bookmark for this layer and apply if any
+            if (bookmarkService.storedBookmark) {
+                const bookmarkedLayer = bookmarkService.storedBookmark.bookmarkLayers.find(layer =>
+                    layer.id === value.id);
+
+                if (bookmarkedLayer) {
+                    value.applyBookmark(bookmarkedLayer);
+                }
+            }
+
             this._config = value;
         }
         get config() { return this._config; }

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -103,6 +103,9 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
             }
 
             this._proxy.setOpacity(value);
+
+            // store opacity value in the layer config; will be used by full state restore
+            this._layerConfig.state.opacity = value;
         }
         set visibility (value) {
             if (this.isControlSystemDisabled('visibility')) {
@@ -110,6 +113,9 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
             }
 
             this._proxy.setVisibility(value);
+
+            // store visibility value in the layer config; will be used by full state restore
+            this._layerConfig.state.visibility = value;
         }
         set query (value) {
             if (this.isControlSystemDisabled('query')) {
@@ -120,6 +126,9 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
             // so, setting boundingBox value doesn't call the proxy object,
             // it just stores the value in the layer config state for future bookmark use
             this._proxy.setQuery(value);
+
+            // store query value in the layer config; will be used by full state restore
+            this._layerConfig.state.query = value;
         }
         set boundingBox (value) {
             if (this.isControlSystemDisabled('boundingBox')) {

--- a/src/app/ui/sidenav/sidenav.service.js
+++ b/src/app/ui/sidenav/sidenav.service.js
@@ -92,7 +92,12 @@ function sideNavigationService($mdSidenav, $rootScope, $rootElement, globalRegis
             label: 'sidenav.label.share',
             icon: 'social:share',
             action: () => {
-                service.close();
+                // FIXME: bookmark share is turned off for the moment; need to PR some changes first
+
+                //reloadService.funReload();
+
+                return;
+                /*service.close();
 
                 $mdDialog.show({
                     controller: service.ShareController,
@@ -103,7 +108,7 @@ function sideNavigationService($mdSidenav, $rootScope, $rootElement, globalRegis
                     clickOutsideToClose: true,
                     fullscreen: false,
                     onShowing: (scope, element) => (scope.element = element.find('.side-nav-summary'))
-                }).then(() => ($rootElement.find('.rv-shareLink').select()));
+                }).then(() => ($rootElement.find('.rv-shareLink').select()));*/
             }
         },
         about: {

--- a/src/app/ui/toc/templates/expand-menu.directive.js
+++ b/src/app/ui/toc/templates/expand-menu.directive.js
@@ -54,11 +54,12 @@ function Controller(LegendBlock, geoService, appInfo, configService) {
      * @param {Boolean} value [optional = true] if true, expands all the groups and subgroups; if false, collapses them
      */
     function toggleLegendGroupEntries(value = true) {
-        if (!geoService.isMapReady) {
+        if (!_legendBlocksReadyCheck()) {
             return;
         }
 
-        configService.getSync.map.legendBlocks.walk(block => {
+        const mapConfig = configService.getSync.map;
+        mapConfig.legendBlocks.walk(block => {
             if (block.blockType === LegendBlock.TYPES.GROUP) {
                 (block.expanded = value);
             }
@@ -73,10 +74,11 @@ function Controller(LegendBlock, geoService, appInfo, configService) {
      * @return {Boolean} value indicating if the check passed (all either expanded or collapsed)
      */
     function getLegendGroupEntriesExpandState(value = true) {
-        if (!geoService.isMapReady) {
+        if (!_legendBlocksReadyCheck()) {
             return;
         }
 
+        const mapConfig = configService.getSync.map;
         const isAllExpanded = configService.getSync.map.legendBlocks
             .walk(block =>
                 block.blockType === LegendBlock.TYPES.GROUP ? block.expanded : null)
@@ -86,5 +88,25 @@ function Controller(LegendBlock, geoService, appInfo, configService) {
                 expanded === value);
 
         return isAllExpanded;
+    }
+
+        /**
+     * Checks if the legendBlocks hierarchy is initialized; false otherwise
+     *
+     * @function _legendBlocksReadyCheck
+     * @private
+     * @return {Boolean} true if the legendBlocks hierarchy is initialized; false otherwise
+     */
+    function _legendBlocksReadyCheck() {
+        if (!geoService.isMapReady) {
+            return false;
+        }
+
+        const mapConfig = configService.getSync.map;
+        if (mapConfig.legendBlocks === null) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/content/samples/index-mobile.tpl
+++ b/src/content/samples/index-mobile.tpl
@@ -17,9 +17,11 @@
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.11/angular.min.js"></script>
 </head>
 
+<!-- rv-service-endpoint="http://section917.cloudapp.net:8000/" rv-keys='["Airports"]' -->
+
 <body>
     <div class="myMap" is="rv-map" rv-config="config-mobile-2.json" rv-langs='["en-CA", "fr-CA"]'
-         rv-service-endpoint="http://section917.cloudapp.net:8000/" rv-keys='["Airports"]'
+
          rv-restore-bookmark="bookmark">
          <noscript>
             <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>


### PR DESCRIPTION
## Description
When switching to a basemap with a different projection, it actually works, and layers settings are remembered correctly. Bookmark V2 is used.
Some work is done towards full state restore.
At this point, projection change can be done without a bookmark.

## Testing
Some eyeballing.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ not needed
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1931)
<!-- Reviewable:end -->
