### PR TITLE
Make the tool tip readable when it exceeds the length of small screen

### DIFF
--- a/src/content/styles/vendor/_special.scss
+++ b/src/content/styles/vendor/_special.scss
@@ -7,6 +7,12 @@ html, body {
     -ms-overflow-style: scrollbar;
 }
 
+md-tooltip {
+    white-space: normal !important;
+    height: auto !important;
+    margin-top: auto !important;
+}
+
 .rv-hide {
     visibility: hidden !important;
     opacity: 0 !important;

--- a/src/content/styles/vendor/_special.scss
+++ b/src/content/styles/vendor/_special.scss
@@ -11,6 +11,7 @@ md-tooltip {
     white-space: normal !important;
     height: auto !important;
     margin-top: auto !important;
+    line-height: 130% !important;
 }
 
 .rv-hide {

--- a/src/content/styles/vendor/_special.scss
+++ b/src/content/styles/vendor/_special.scss
@@ -11,7 +11,7 @@ md-tooltip {
     white-space: normal !important;
     height: auto !important;
     margin-top: auto !important;
-    line-height: 130% !important;
+    line-height: rem(2) !important;
 }
 
 .rv-hide {


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
fixes #1749 
Make the tool tip wrap instead of being cut off when it exceeds the length of small screen
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
No, because it is an UI issue.
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1937)
<!-- Reviewable:end -->
