### PR TITLE
fix(layout): hide esri default zoom options

### DIFF
--- a/src/content/styles/vendor/_esri.scss
+++ b/src/content/styles/vendor/_esri.scss
@@ -36,6 +36,10 @@
                 opacity: 1 !important;
             }
         }
+
+        > .esriMapContainer > .esriSimpleSlider {
+            display: none;
+        }
     }
 }
 


### PR DESCRIPTION
## Description
Closes #1925 
Hide the default esri zoom commands previously shown in the top left

## Testing
Visually tested

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] commits messages follow the guidelines
- [ ] code passes unit tests
- [ ] release notes have been updated
- [ ] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1941)
<!-- Reviewable:end -->
