### PR TITLE
Fix upload progress bar and drag / drop functionality

### DIFF
--- a/src/app/ui/loader/loader-file.directive.js
+++ b/src/app/ui/loader/loader-file.directive.js
@@ -48,8 +48,10 @@ function Controller($scope, $q, $timeout, stateManager, Stepper, LayerBlueprint,
             isActive: false,
             isCompleted: false,
             onContinue: uploadOnContinue,
-            onCancel: () =>
-                onCancel(self.upload.step),
+            onCancel: () => {
+                uploadReset();  // reset upload progress bar
+                onCancel(self.upload.step);
+            },
             onKeypress: event =>
                 { if (event.keyCode === keyNames.ENTER) { uploadOnContinue(); } }, // check if enter key have been pressed and call the next step if so
             reset: uploadReset,
@@ -305,6 +307,8 @@ function Controller($scope, $q, $timeout, stateManager, Stepper, LayerBlueprint,
 
         // TODO: generalize resetting custom form validation
         select.selectResetValidation();
+
+        uploadReset();  // reset the upload progress bar
     }
 
     /**


### PR DESCRIPTION
## Description
Closes #1926 and #1927 
Reset progress bar on cancellation of step 2
Allows for drag and drop after cancellation of step 2

## Testing
Visually tested

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] commits messages follow the guidelines
- [ ] code passes unit tests
- [ ] release notes have been updated
- [ ] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1945)
<!-- Reviewable:end -->
