### PR TITLE
fix not init collapse mini map

### DIFF
--- a/src/app/geo/overview-toggle.directive.js
+++ b/src/app/geo/overview-toggle.directive.js
@@ -43,14 +43,15 @@ function rvOverviewToggle($compile, $rootScope, geoService, $timeout, animationS
     return directive;
 
     function link(scope, el) {
-         // initializing
-        events.$on(events.rvApiReady, init);
 
+        // events.$on(events.rvApiReady, init);
         // events.$on(events.rvBasemapChange, init);
 
         // TODO: instead of relying on esri event here, listen on it in map service and re-emit as rv-basemapchange event
-        events.$on(events.rvApiReady, () =>
-            configService.getSync.map.instance.basemapGallery.on('selection-change', init));
+        events.$on(events.rvApiReady, () => {
+            init();
+            configService.getSync.map.instance.basemapGallery.on('selection-change', init);
+        });
 
         const self = scope.self;
         self.overviewActive = true;

--- a/src/app/geo/overview-toggle.directive.js
+++ b/src/app/geo/overview-toggle.directive.js
@@ -43,9 +43,10 @@ function rvOverviewToggle($compile, $rootScope, geoService, $timeout, animationS
     return directive;
 
     function link(scope, el) {
+         // initializing
+        events.$on(events.rvApiReady, init);
 
-        // events.$on(events.rvApiReady, init);
-        //events.$on(events.rvBasemapChange, init);
+        // events.$on(events.rvBasemapChange, init);
 
         // TODO: instead of relying on esri event here, listen on it in map service and re-emit as rv-basemapchange event
         events.$on(events.rvApiReady, () =>


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
fixes #1943, the collapse button should appear when first loaded now.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
No, it was a UI bug.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1946)
<!-- Reviewable:end -->
