### PR TITLE
fix(boundingbox): remove permanent bounding box on reload

### DIFF
--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -375,17 +375,18 @@ function layerRegistryFactory($rootScope, $timeout, gapiService, Geo, configServ
      * @param {Number} id id of the bounding box record to be removed
      */
     function removeBoundingBoxRecord(id) {
-        let boundingBoxRecord = getBoundingBoxRecord(id);
-        if (boundingBoxRecord) {
-            let boundingBoxRecords = configService.getSync.map.boundingBoxRecords;
-            const index = boundingBoxRecords.indexOf(boundingBoxRecord);
-
-            // Do not need to check if index is valid because getBoundingBoxRecord does not return undefined
-            boundingBoxRecords.splice(index, 1);
-            const mapBody = configService.getSync.map.instance;
-            mapBody.removeLayer(boundingBoxRecord);
+        const boundingBoxRecord = getBoundingBoxRecord(id);
+        if (!boundingBoxRecord) {
             return;
         }
+
+        const boundingBoxRecords = configService.getSync.map.boundingBoxRecords;
+        const index = boundingBoxRecords.indexOf(boundingBoxRecord);
+
+        // Do not need to check if index is valid because getBoundingBoxRecord does not return undefined
+        boundingBoxRecords.splice(index, 1);
+        const mapBody = configService.getSync.map.instance;
+        mapBody.removeLayer(boundingBoxRecord);
     }
 
     /**

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -372,7 +372,7 @@ function layerRegistryFactory($rootScope, $timeout, gapiService, Geo, configServ
      * Remove bounding box with the id specified.
      *
      * @function removeBoundingBoxRecord
-     * @param {Number} id id of the bounding box record to be assigned to the created bounding box layer record
+     * @param {Number} id id of the bounding box record to be removed
      */
     function removeBoundingBoxRecord(id) {
         let boundingBoxRecord = getBoundingBoxRecord(id);

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -29,6 +29,7 @@ function layerRegistryFactory($rootScope, $timeout, gapiService, Geo, configServ
 
         getBoundingBoxRecord,
         makeBoundingBoxRecord,
+        removeBoundingBoxRecord,
 
         synchronizeLayerOrder
     };
@@ -340,7 +341,7 @@ function layerRegistryFactory($rootScope, $timeout, gapiService, Geo, configServ
         const boundingBoxRecords = configService.getSync.map.boundingBoxRecords;
 
         return boundingBoxRecords.find(boundingBoxRecord =>
-            boundingBoxRecord.layerId === id);
+            boundingBoxRecord.id === id);
     }
 
     /**
@@ -365,6 +366,26 @@ function layerRegistryFactory($rootScope, $timeout, gapiService, Geo, configServ
         }
 
         return boundingBoxRecord;
+    }
+
+    /**
+     * Remove bounding box with the id specified.
+     *
+     * @function removeBoundingBoxRecord
+     * @param {Number} id id of the bounding box record to be assigned to the created bounding box layer record
+     */
+    function removeBoundingBoxRecord(id) {
+        let boundingBoxRecord = getBoundingBoxRecord(id);
+        if (boundingBoxRecord) {
+            let boundingBoxRecords = configService.getSync.map.boundingBoxRecords;
+            const index = boundingBoxRecords.indexOf(boundingBoxRecord);
+
+            // Do not need to check if index is valid because getBoundingBoxRecord does not return undefined
+            boundingBoxRecords.splice(index, 1);
+            const mapBody = configService.getSync.map.instance;
+            mapBody.removeLayer(boundingBoxRecord);
+            return;
+        }
     }
 
     /**

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -100,7 +100,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
         const legendMappings = configService.getSync.map.legendMappings;
         const mappings = legendMappings[layerRecordId];
         legendMappings[layerRecordId] = [];
-
+        
         // create a new record from its layer blueprint
         const layerBlueprintsCollection = configService.getSync.map.layerBlueprints;
         const layerBlueprint = layerBlueprintsCollection.find(blueprint =>
@@ -134,6 +134,15 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
             const reloadedLegendBlock = _makeLegendBlock(legendBlockConfig, layerBlueprintsCollection);
 
             const index = legendBlockParent.removeEntry(legendBlock);
+
+            if (legendBlock.blockType === LegendBlock.TYPES.NODE) {
+                layerRegistry.removeBoundingBoxRecord(`${legendBlock.id}_bbox`);
+            } else if (legendBlock.blockType === LegendBlock.TYPES.GROUP) {
+                legendBlock.entries.forEach(entries => {
+                    layerRegistry.removeBoundingBoxRecord(`${entries.id}_bbox`);
+                });
+            }
+
             legendBlockParent.addEntry(reloadedLegendBlock, index);
         });
     }

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -135,13 +135,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
 
             const index = legendBlockParent.removeEntry(legendBlock);
 
-            if (legendBlock.blockType === LegendBlock.TYPES.NODE) {
-                layerRegistry.removeBoundingBoxRecord(`${legendBlock.id}_bbox`);
-            } else if (legendBlock.blockType === LegendBlock.TYPES.GROUP) {
-                legendBlock.entries.forEach(entries => {
-                    layerRegistry.removeBoundingBoxRecord(`${entries.id}_bbox`);
-                });
-            }
+            _boundingBoxRemoval(legendBlock);
 
             legendBlockParent.addEntry(reloadedLegendBlock, index);
         });
@@ -174,12 +168,28 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
         function _resolve() {
             layerRegistry.removeLayerRecord(legendBlock.layerRecordId);
 
-            // TODO: remove any bounding box layers associated with this legend block
+            // remove any bounding box layers associated with this legend block
+            _boundingBoxRemoval(legendBlock);
         }
 
         function _reject() {
             legendBlockParent.addEntry(legendBlock, index);
             legendBlock.visibility = cachedVisibility;
+        }
+    }
+
+    /**
+     * Remove the bounding box associated with the node or group
+     * 
+     * @function _boundingBoxRemoval
+     * @private
+     * @param {LegendBlock} legendBlock legend block with bounding box to be removed from the map
+     */
+    function _boundingBoxRemoval(legendBlock) {
+        if (legendBlock.blockType === LegendBlock.TYPES.NODE) {
+            layerRegistry.removeBoundingBoxRecord(`${legendBlock.id}_bbox`);
+        } else if (legendBlock.blockType === LegendBlock.TYPES.GROUP) {
+            legendBlock.entries.forEach(entry => layerRegistry.removeBoundingBoxRecord(`${entry.id}_bbox`));
         }
     }
 

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -100,7 +100,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
         const legendMappings = configService.getSync.map.legendMappings;
         const mappings = legendMappings[layerRecordId];
         legendMappings[layerRecordId] = [];
-        
+
         // create a new record from its layer blueprint
         const layerBlueprintsCollection = configService.getSync.map.layerBlueprints;
         const layerBlueprint = layerBlueprintsCollection.find(blueprint =>


### PR DESCRIPTION
## Description
Closes #1956.
Removes permanent bounding box on reload of a layer.

## Testing
Visually tested

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] commits messages follow the guidelines
- [ ] code passes unit tests
- [ ] release notes have been updated
- [ ] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1978)
<!-- Reviewable:end -->
