### PR TITLE
chore(build): move sri checks on prod only

### DIFF
--- a/src/content/samples/blank.tpl
+++ b/src/content/samples/blank.tpl
@@ -6,13 +6,21 @@
         <title>Blank Test Page</title>
 
         <% for (var index in htmlWebpackPlugin.files.css) { %>
-        <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+            <% if (webpackConfig.output.crossOriginLoading) { %>
+                <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+            <% } else { %>
+                <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" />
+            <% } %>
         <% } %>
     </head>
-
+s
     <body>
     <% for (var index in htmlWebpackPlugin.files.js) { %>
-    <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+        <% } else { %>
+            <script src="<%= htmlWebpackPlugin.files.js[index] %>"></script>
+        <% } %>
     <% } %>
     </body>
 </html>

--- a/src/content/samples/index-fgp-en.tpl
+++ b/src/content/samples/index-fgp-en.tpl
@@ -8,7 +8,11 @@
     <link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css">
 
     <% for (var index in htmlWebpackPlugin.files.css) { %>
-    <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+        <% } else { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" />
+        <% } %>
     <% } %>
 
     <style>
@@ -548,9 +552,13 @@
             document.write('<script src="../ie-polyfills.js"><\/script>');
         }
 
-        <% for (var index in htmlWebpackPlugin.files.js) { %>
-        <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
-        <% } %>
+            <% for (var index in htmlWebpackPlugin.files.js) { %>
+                <% if (webpackConfig.output.crossOriginLoading) { %>
+                    <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+                <% } else { %>
+                    <script src="<%= htmlWebpackPlugin.files.js[index] %>"></script>
+                <% } %>
+            <% } %>
 
         function init() {
             const baseUrl = window.location.href.split('?')[0] + '?keys={RV_LAYER_LIST}';

--- a/src/content/samples/index-fgp-fr.tpl
+++ b/src/content/samples/index-fgp-fr.tpl
@@ -8,7 +8,11 @@
     <link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css">
 
     <% for (var index in htmlWebpackPlugin.files.css) { %>
-    <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+        <% } else { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" />
+        <% } %>
     <% } %>
 
     <style>
@@ -550,7 +554,11 @@
     }
 
     <% for (var index in htmlWebpackPlugin.files.js) { %>
-    <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+        <% } else { %>
+            <script src="<%= htmlWebpackPlugin.files.js[index] %>"></script>
+        <% } %>
     <% } %>
 
 

--- a/src/content/samples/index-mobile.tpl
+++ b/src/content/samples/index-mobile.tpl
@@ -17,7 +17,11 @@
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.5.11/angular.min.js"></script>
 
     <% for (var index in htmlWebpackPlugin.files.css) { %>
-    <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+        <% } else { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" />
+        <% } %>
     <% } %>
 </head>
 
@@ -55,7 +59,11 @@
     </script>
 
     <% for (var index in htmlWebpackPlugin.files.js) { %>
-    <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+        <% } else { %>
+            <script src="<%= htmlWebpackPlugin.files.js[index] %>"></script>
+        <% } %>
     <% } %>
 
     <script>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,7 +1,6 @@
 const webpack   = require('webpack');
 const path      = require('path');
 const fs        = require('fs');
-const SriPlugin = require('webpack-subresource-integrity');
 const ExtractTextPlugin     = require('extract-text-webpack-plugin');
 const TranslationPlugin     = require('./scripts/translations_plugin.js');
 const CopyWebpackPlugin     = require('copy-webpack-plugin');
@@ -20,8 +19,7 @@ module.exports = function (env) {
 
         output: {
             path: path.resolve(__dirname, 'build'),
-            filename: '[name].js',
-            crossOriginLoading: 'anonymous'
+            filename: '[name].js'
         },
 
         module: {
@@ -99,12 +97,7 @@ module.exports = function (env) {
 
             new VersionPlugin(),
 
-            new CleanWebpackPlugin(['build']),
-
-            new SriPlugin({
-                hashFuncNames: ['sha256', 'sha384'],
-                enabled: true
-            })
+            new CleanWebpackPlugin(['build'])
         ],
 
         externals: { 'TweenLite': 'TweenLite' },

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -2,12 +2,17 @@ const path          = require('path');
 const Merge         = require('webpack-merge');
 const webpack       = require('webpack');
 const CommonConfig  = require('./webpack.common.js');
+const SriPlugin     = require('webpack-subresource-integrity');
 
 const pkg                   = require('./package.json');
 const ZipPlugin             = require('zip-webpack-plugin');
 
 module.exports = function(env) {
     return Merge(CommonConfig(env), {
+        output: {
+            crossOriginLoading: 'anonymous'
+        },
+
         plugins: [
             new webpack.optimize.UglifyJsPlugin({
                 compress: {
@@ -29,6 +34,11 @@ module.exports = function(env) {
                 'process.env': {
                     'NODE_ENV': JSON.stringify('production')
                 }
+            }),
+
+            new SriPlugin({
+                hashFuncNames: ['sha256', 'sha384'],
+                enabled: true
             })
         ]
     });


### PR DESCRIPTION
## Description
Hot reloading not yet supported by sri plugin. Dev serve/builds no
longer use sri checks.

Production serve/builds will fail if hot swapping is enabled.

## Testing
:eyes: 

## Documentation
nope

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] ~~release notes have been updated~~
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/1986)
<!-- Reviewable:end -->
