### PR TITLE
fix(ui): md-input-container no longer throws multiple input error

### DIFF
--- a/src/app/ui/common/select-header.html
+++ b/src/app/ui/common/select-header.html
@@ -1,3 +1,0 @@
-<md-select-header class="demo-select-header">
-    <ng-transclude></ng-transclude>
-</md-select-header>

--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -89,16 +89,18 @@
                     ng-model-options="{ trackBy: '$value.index' }"
                     ng-change="self.common.onDynamicLayerSection()"
                     required multiple>
-                    <rv-select-header>
-                        <md-checkbox
-                            ng-checked="self.common.isAllLayersSelected()"
-                            md-indeterminate="self.common.isSomeLayersSelected()"
-                            ng-click="self.common.toggleLayers(); self.common.onDynamicLayerSection();"
-                            class="md-primary rv-select-header-all">
-                            {{ 'import.service.configure.selectall' | translate }}
-                        </md-checkbox>
-                        <md-divider class="rv-layer-list-divider"></md-divider>
-                    </rv-select-header>
+                    <md-select-header>
+                        <md-input-container>
+                            <md-checkbox
+                                ng-checked="self.common.isAllLayersSelected()"
+                                md-indeterminate="self.common.isSomeLayersSelected()"
+                                ng-click="self.common.toggleLayers(); self.common.onDynamicLayerSection();"
+                                class="md-primary rv-select-header-all">
+                                {{ 'import.service.configure.selectall' | translate }}
+                            </md-checkbox>
+                            <md-divider class="rv-layer-list-divider"></md-divider>
+                        </md-input-container>
+                    </md-select-header>
                     <md-option
                         ng-repeat="layer in self.layerSource.layers"
                         ng-value="layer">
@@ -145,17 +147,20 @@
                     ng-model="self.layerSource.config.layerEntries"
                     ng-model-options="{ trackBy: '$value.index' }"
                     required multiple>
-                    <rv-select-header>
-                        <md-checkbox
-                            ng-checked="self.common.isAllLayersSelected()"
-                            md-indeterminate="self.common.isSomeLayersSelected()"
-                            ng-click="self.common.toggleLayers()"
-                            class="md-primary rv-select-header-all">
-                            {{ 'import.service.configure.selectall' | translate }}
-                        </md-checkbox>
-                        <md-divider class="rv-layer-list-divider"></md-divider>
-                    </rv-select-header>
-
+                    <md-input-container class="md-block">
+                        <md-select-header>
+                            <md-input-container>
+                                <md-checkbox
+                                    ng-checked="self.common.isAllLayersSelected()"
+                                    md-indeterminate="self.common.isSomeLayersSelected()"
+                                    ng-click="self.common.toggleLayers()"
+                                    class="md-primary rv-select-header-all">
+                                    {{ 'import.service.configure.selectall' | translate }}
+                                </md-checkbox>
+                                <md-divider class="rv-layer-list-divider"></md-divider>
+                            </md-input-container>
+                        </md-select-header>
+                    </md-input-container>
                     <md-option ng-repeat="layer in self.layerSource.layers"
                         ng-value="layer">
                         {{ layer.indent + ' ' + layer.desc }}

--- a/src/app/ui/ui-loader.js
+++ b/src/app/ui/ui-loader.js
@@ -21,7 +21,6 @@ import './common/resize.directive.js';
 import './common/reverse.filter.js';
 import './common/select-menu.decorator.js';
 import './common/select.decorator.js';
-import './common/select-header.directive.js';
 import './common/state.directive.js';
 import './common/svg.directive.js';
 import './common/toggle-slide.animation.js';

--- a/src/content/styles/vendor/_special.scss
+++ b/src/content/styles/vendor/_special.scss
@@ -171,7 +171,14 @@ md-select-menu {
 
 // special option in the md-select header to preselect all the items
 .md-select-menu-container {
-    rv-select-header {
+    md-select-header {
+        md-input-container {
+            height: rem(4.8);
+            padding: 0;
+            margin: 0;
+            width: 100%;
+        }
+
         .rv-select-header-all {
             height: rem(4.8);
             padding: 0;


### PR DESCRIPTION
## Description

[See discussion here](https://github.com/angular/material/issues/10342#issuecomment-308568524)

As a workaround, nestle:

```html
<md-select-header>
    <md-input-container>
        // stuff here . . .
    </md-input-container>
<md-select-header>
```

Caused by parent controller scoping, [see material/select.js](https://github.com/angular/material/blob/93c29175c897136463aad248494fccfc4dc080a2/src/components/select/select.js#L277)

Closes #1990

## Testing
womm

## Documentation
none

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] ~~release notes have been updated~~
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2000)
<!-- Reviewable:end -->
