### PR TITLE
chore(build): add source maps on prod builds (always)

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -13,6 +13,8 @@ module.exports = function(env) {
             crossOriginLoading: 'anonymous'
         },
 
+        devtool: 'source-map',
+
         plugins: [
             new webpack.optimize.UglifyJsPlugin({
                 compress: {
@@ -21,7 +23,8 @@ module.exports = function(env) {
                 },
                 mangle: {
                     screw_ie8 : true
-                }
+                },
+                sourceMap: true
             }),
 
             new ZipPlugin({


### PR DESCRIPTION
## Description
env.useMap is optional on develop, source maps are always generated for
production.

Closes #293

## Testing
:eyes: 

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] ~~release notes have been updated~~
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2008)
<!-- Reviewable:end -->
