### PR TITLE
fix(datatable): loading for layers with date columns

### DIFF
--- a/src/app/ui/filters/filters-definition.directive.js
+++ b/src/app/ui/filters/filters-definition.directive.js
@@ -314,7 +314,12 @@ function rvFiltersDefinition(stateManager, events, $compile, filterService, layo
             $.fn.dataTable.ext.searchTemp.push((settings, data) => {
                 // check if it is a valid date and remove leading 0 because it doesn't set the date properly
                 const i = settings._colReorder.fnTranspose(index); // get the real index if columns have been reordered
-                if (i === -1) { return; }
+                if (i === -1) { return false; }
+
+                // Date value is null, only show row if there are no filters
+                if (data[i] === '') {
+                    return !filter.min && !filter.max;
+                }
 
                 const date = data[i].split('-');
                 const val = (date.length === 3) ?
@@ -326,13 +331,9 @@ function rvFiltersDefinition(stateManager, events, $compile, filterService, layo
                     const max = (filter.max !== null) ? filter.max : new Date(8640000000000000);
 
                     // check date
-                    if (val >= min && val <= max) {
-                        return true;
-                    } else {
-                        return false;
-                    }
+                    return (val >= min && val <= max)
                 } else {
-                    return true;
+                    return false;
                 }
             });
         }

--- a/src/app/ui/filters/filters-definition.directive.js
+++ b/src/app/ui/filters/filters-definition.directive.js
@@ -313,23 +313,27 @@ function rvFiltersDefinition(stateManager, events, $compile, filterService, layo
         function setDateFilter(filter, index) {
             $.fn.dataTable.ext.searchTemp.push((settings, data) => {
                 // check if it is a valid date and remove leading 0 because it doesn't set the date properly
-                let flag = false;
                 const i = settings._colReorder.fnTranspose(index); // get the real index if columns have been reordered
+                if (i === -1) { return; }
+
                 const date = data[i].split('-');
                 const val = (date.length === 3) ?
                     new Date(`${date[0]}-${parseInt(date[1])}-${parseInt(date[2])}`) : false;
 
                 if (val) {
+                    // set date to filter values or minimum / maximum date value
+                    const min = (filter.min !== null) ? filter.min : new Date(-8640000000000000);
+                    const max = (filter.max !== null) ? filter.max : new Date(8640000000000000);
+
                     // check date
-                    const min = (filter.min !== null) ? filter.min : false;
-                    const max = (filter.max !== null) ? filter.max : false;
-
-                    if ((val >= min && !max) || (!min && val <= max) || (val >= min && val <= max)) {
-                        flag = true;
+                    if (val >= min && val <= max) {
+                        return true;
+                    } else {
+                        return false;
                     }
+                } else {
+                    return true;
                 }
-
-                return flag;
             });
         }
     }


### PR DESCRIPTION
## Description
Fixes:
* Bug #1998: Datatable not populated for layers with date columns
* Undocumented bug: Datatable not populated after switching layers from layer with date column to other layers

## Testing
Visually tested

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] commits messages follow the guidelines
- [ ] code passes unit tests
- [ ] release notes have been updated
- [ ] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2031)
<!-- Reviewable:end -->
