### PR TITLE
feat(ui): handle external geoSearch api errors gracefully

### DIFF
--- a/src/app/geo/geo-search.service.js
+++ b/src/app/geo/geo-search.service.js
@@ -30,7 +30,8 @@ function geoSearch($http, $q, configService, geoService, mapService, gapiService
         getTypes,
         isEnabled,
         zoomSearchExtent,
-        zoomScale
+        zoomScale,
+        externalApiError: false
     };
 
     init();
@@ -139,7 +140,9 @@ function geoSearch($http, $q, configService, geoService, mapService, gapiService
                     provinceList.push({ code: -1, abbr: '...', name: '...' });
 
                     resolve(provinceList);
-                }, reject);
+                }, response => {
+                    service.externalApiError = true;
+                });
             }
         });
     }
@@ -176,7 +179,9 @@ function geoSearch($http, $q, configService, geoService, mapService, gapiService
                     typeList.push({ code: -1, name: '...' });
 
                     resolve(typeList);
-                }, reject);
+                }, response => {
+                    service.externalApiError = true;
+                });
             }
         });
     }

--- a/src/app/ui/appbar/appbar.directive.js
+++ b/src/app/ui/appbar/appbar.directive.js
@@ -37,7 +37,7 @@ function rvAppbar(layoutService) {
     return directive;
 }
 
-function Controller(sideNavigationService, stateManager, debounceService, basemapService, geosearchService, configService) {
+function Controller(sideNavigationService, stateManager, debounceService, basemapService, geosearchService, configService, geoSearch) {
     'ngInject';
     const self = this;
     self.sideNavigationService = sideNavigationService;
@@ -48,6 +48,8 @@ function Controller(sideNavigationService, stateManager, debounceService, basema
     self.toggleToolbox = toggleToolbox;
     self.openBasemapSelector = basemapService.open;
     self.toggleGeosearch = geosearchService.toggle;
+
+    self.geoSearch = geoSearch;
 
     configService.onEveryConfigLoad(cfg =>
         (self.config = cfg));

--- a/src/app/ui/appbar/appbar.html
+++ b/src/app/ui/appbar/appbar.html
@@ -23,10 +23,21 @@
         aria-label="{{ 'appbar.aria.geosearch' | translate }}"
         class="md-icon-button primary rv-app-geosearch"
         ng-click="self.toggleGeosearch()"
-        ng-if="self.config.map.components.geoSearch.enabled">
+        ng-if="self.config.map.components.geoSearch.enabled && !self.geoSearch.externalApiError">
         <md-tooltip>{{ 'appbar.tooltip.geosearch' | translate }}</md-tooltip>
         <md-icon md-svg-src="action:search"></md-icon>
     </md-button>
+
+    <!-- workaround for AM issue where tooltips are not shown when inside a disabled element, see https://github.com/angular/material/issues/1667 -->
+    <div
+        class="md-icon-button primary rv-app-geosearch"
+        disabled="disabled"
+        ng-if="self.geoSearch.externalApiError"
+        aria-label="{{ 'appbar.aria.geosearch' | translate }}">
+        <md-tooltip>{{ 'appbar.aria.geoApiError' | translate }}</md-tooltip>
+        <md-icon md-svg-src="action:search"></md-icon>
+    </div>
+
 
     <md-button
         aria-label="{{ 'nav.tooltip.basemap' | translate }}"

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -12,6 +12,8 @@ Appbar tooltip for geosearch icon,appbar.tooltip.geosearch,Geolocation Search,1,
 Appbar tooltip for geosearch close icon,appbar.tooltip.geosearchclose,Close Geolocation Search,1, Fermer la recherche géolocalisée,1
 Appbar tooltip for tools icon,appbar.tooltip.tools,Tools,1,Outils,1
 Appbar aria label for layers icon,appbar.aria.layers,Sets,1,Séries,1
+Appbar aria label for layers icon,appbar.aria.geoApiError,Geolocation search is unavailable,1,
+La recherche de géolocalisation n'est pas disponible,1
 Appbar aria label for point info icon,appbar.aria.pointInfo,Feature Details,1,Détails sur l'élément,1
 Appbar aria label for menu  icon,appbar.aria.menu,Open Sidenav,1,Ouvrir le menu de navigation,1
 Appbar aria for geosearch close icon,appbar.aria.geosearchclose,Close Geolocation Search,1, Fermer la recherche géolocalisée,1


### PR DESCRIPTION
## Description
Disables geoSearch icon and displays tooltip indicating geoSearch is not
available when either province.json or concise.json fail to load

Closes #1976

## Testing
:eye: 's on chrome

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2035)
<!-- Reviewable:end -->
