### PR TITLE
fix(datatable): loading for numeric columns

### DIFF
--- a/src/app/core/core.config.js
+++ b/src/app/core/core.config.js
@@ -55,7 +55,8 @@ function configBlock($translateProvider, $mdThemingProvider, $mdIconProvider, $p
                     '_' === ch || ch === '$' ||
                     'à' <= ch && ch <= 'ÿ' ||
                     'À' <= ch && ch <= 'Ÿ' ||
-                    'Ç' === ch || ch === 'ç');
+                    'Ç' === ch || ch === 'ç' ||
+                    '0' <= ch && ch <= '9');
         }
     }
 


### PR DESCRIPTION
## Description
Closes #2047.
Fixes datatable record loading for layers with columns containing numbers in title.

## Testing
Visually tested.

## Documentation
None.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] commits messages follow the guidelines
- [ ] code passes unit tests
- [ ] release notes have been updated
- [ ] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2065)
<!-- Reviewable:end -->
