### PR TITLE
fix(ui): datatable and help section fixes

### DIFF
--- a/src/app/ui/help/help.service.js
+++ b/src/app/ui/help/help.service.js
@@ -214,7 +214,7 @@ function helpService($mdDialog, $translate, translations, layoutService) {
                 // followed by the section header, exactly 2 spaces, then up to but not including a double space
                 // note that the {2,} below is used as the double line deparator since each double new line is actually 6
                 // but we'll also accept more than a double space
-                const reg = /^#\s(.*)\n{2}(?:.*|\n(?!\n{2,}))*/gm;
+                const reg = /^#\s(.*)\n{2}(?:.+|\n(?!\n{2,}))*/gm;
                 let mdStr = r.data; // markdown file contents
                 let section; // used for storing individual section groupings
                 self.sections = []; // used in template for rendering help sections

--- a/src/content/styles/vendor/_angularmaterial.scss
+++ b/src/content/styles/vendor/_angularmaterial.scss
@@ -10,3 +10,10 @@
         }
     }
 }
+
+md-input-container {
+    &.rv-filters-search {
+        display: flex;
+        align-items: center;
+    }
+}


### PR DESCRIPTION
## Description
- Corrected help regex where ie failed to match valid groups of text.
- CSS update to prevent datatable search field from displacing

Closes #1973, #1876

## Testing
Yes, in IE and chrome

## Documentation
None needed

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2069)
<!-- Reviewable:end -->
