### PR TITLE
fix(ui): open initial datatable specified in the config

### DIFF
--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1922,10 +1922,10 @@ function ConfigObjectFactory(Geo, gapiService, common) {
         constructor(source = {}) {
             this._source = source;
 
-            this.id = source.id;
-            this._large = source.large;
-            this._medium = source.medium;
-            this._small = source.small;
+            this._id = source.id;
+            this._large = this._id ? source.large : false;
+            this._medium = this._id ? source.medium : false;
+            this._small = this._id ? source.small : false ;
         }
 
         get id () { return this._id; }
@@ -2007,6 +2007,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             this._legend = new UILegend(uiSource.legend);
             this._help = new Help(uiSource.help);
             this._fullscreen = uiSource.fullscreen;
+            this._filterIsOpen = new FilterIsOpen(uiSource.filterIsOpen);
         }
 
         get source () {                 return this._source; }
@@ -2018,6 +2019,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
         get legend () {                 return this._legend; }
         get help () {                   return this._help; }
         get fullscreen () {             return this._fullscreen; }
+        get filterIsOpen () {           return this._filterIsOpen; }
 
         get JSON () {
             return {
@@ -2027,7 +2029,8 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                 sideMenu: this.sideMenu.JSON,
                 legend: this.legend.JSON,
                 help: this.help.JSON,
-                fullscreen: this.fullscreen
+                fullscreen: this.fullscreen,
+                filterIsOpen: this.filterIsOpen.JSON
             }
         }
     }

--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -30,9 +30,11 @@ function events($rootScope) {
     return {
         /**
          * A shorthand for $rootScope.$on; no need to inject `$rootScope` separately;
+         *
          * @function $on
          * @param {String} eventName event name to listen once
          * @param {Function} listener a callback function to execute
+         * @return {Function} a deregister function
          */
         $on: (...args) =>
             $rootScope.$on(...args),
@@ -54,6 +56,7 @@ function events($rootScope) {
         rvCfgUpdated: 'rvCfgUpdated',
         // TODO find a better name for this one:  rvCfgUpdating: 'rvCfgUpdating',
 
+        rvLayerRecordLoaded: 'rvLayerRecordLoaded',
         rvMapLoaded: 'rvMapLoaded',
         rvMapPan: 'rvMapPan',
         rvExtentChange: 'extentChange', // TODO: rename event to `rvExtentChange` and all the instances that use hardcoded `extentChange` instance

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -18,7 +18,7 @@ angular
     .module('app.geo')
     .factory('layerRegistry', layerRegistryFactory);
 
-function layerRegistryFactory($rootScope, $timeout, gapiService, Geo, configService, tooltipService, $filter) {
+function layerRegistryFactory($rootScope, $timeout, $filter, events, gapiService, Geo, configService, tooltipService) {
     const service = {
         getLayerRecord,
         makeLayerRecord,
@@ -204,6 +204,7 @@ function layerRegistryFactory($rootScope, $timeout, gapiService, Geo, configServ
             ) {
                 layerRecord.removeStateListener(_onLayerRecordLoad);
 
+                events.$broadcast(events.rvLayerRecordLoaded, layerRecord.config.id);
                 $timeout.cancel(throttleTimeoutHandle);
                 _setHoverTips(layerRecord);
                 _advanceLoadingQueue();


### PR DESCRIPTION
## Description

Properly opens the datatable by default is specified in the config.

Close #2088

## Testing
![](https://i.imgur.com/ytfMknU.png)

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ unreleased bug
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2090)
<!-- Reviewable:end -->
