### PR TITLE
2092 dont bookmark broken layers

### DIFF
--- a/src/app/core/bookmark.service.js
+++ b/src/app/core/bookmark.service.js
@@ -53,16 +53,12 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
             };
         }
 
-        // loop through layers in legend, remove user added layers and "removed" layer which are in the "undo" time frame
-        // const legend = geoService.legend.items.filter(legendEntry =>
-        //     !legendEntry.flags.user.visible && !legendEntry.removed);
-
-        // const layerBookmarks = legend.map(legendEntry =>
-        //     encode64(makeLayerBookmark(legendEntry)));
-
+        // removes layers in the "undo" time frame will be bookmarked
         const layerRecords = mapConfig.layerRecords;
-        const layerBookmarks = layerRecords.map(layerRecord =>
-            encode64(makeLayerBookmark(layerRecord)));
+        const layerBookmarks = layerRecords
+            // bookmarking layer records that are errored or still loading will break during subsequent loading of this bookmark
+            .filter(layerRecord => layerRecord.state === 'rv-loaded')
+            .map(layerRecord => encode64(makeLayerBookmark(layerRecord)));
 
         // bookmarkVersions.? is the version. update this accordingly whenever the structure of the bookmark changes
         const bookmark = `${bookmarkVersions.B},${basemap},${encode64(startPoint.x)},${encode64(startPoint.y)},${encode64(startPoint.scale)}` +
@@ -183,7 +179,6 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
      * @returns {String}            Layer information encoded in bookmark format.
      */
     function makeLayerBookmark(layerRecord) {
-        // FIXME: remove use of accessing info via _layerRecord
         // returning <Layer Code><Layer Settings><Children Info><Layer Id>
 
         let legendEntry = null;

--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -196,27 +196,27 @@ function configService($q, $rootElement, $timeout, $http, $translate, $mdToast, 
         const keys = rcsInit(svcAttr, keysAttr, languages);
         languages.forEach(lang => {
             $q.all([startupRcsLayers[lang], initialPromises[lang]])
-            .then(configParts => {
-                // generate a blank config, merge in all the stuff we have loaded
-                // the merged config is our promise result for all to use
-                const newConfig = {
-                    layers: []
-                };
-                mergeConfigParts(newConfig, configParts);
-                // configs[lang] = newConfig;
-                events.$broadcast(events.rvCfgUpdated, keys);
-            })
-            .catch(() => {
-                // TODO: possibly retry rcsLoad?
-                console.warn('RCS failed, starting app with file-only config.');
-                const toast = $mdToast.simple()
-                    .textContent($translate.instant('config.service.rcs.error'))
-                    .action($translate.instant('config.service.rcs.action'))
-                    .highlightAction(true)
-                    .hideDelay(0)
-                    .position('bottom rv-flex-global');
-                $mdToast.show(toast);
-            });
+                .then(configParts => {
+                    // generate a blank config, merge in all the stuff we have loaded
+                    // the merged config is our promise result for all to use
+                    const newConfig = {
+                        layers: []
+                    };
+                    mergeConfigParts(newConfig, configParts);
+                    // configs[lang] = newConfig;
+                    events.$broadcast(events.rvCfgUpdated, keys);
+                })
+                .catch(() => {
+                    // TODO: possibly retry rcsLoad?
+                    console.warn('RCS failed, starting app with file-only config.');
+                    const toast = $mdToast.simple()
+                        .textContent($translate.instant('config.service.rcs.error'))
+                        .action($translate.instant('config.service.rcs.action'))
+                        .highlightAction(true)
+                        .hideDelay(0)
+                        .position('bottom rv-flex-global');
+                    $mdToast.show(toast);
+                });
         });
     }
 

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -359,7 +359,7 @@ function layerRegistryFactory($rootScope, $timeout, $filter, events, gapiService
         let boundingBoxRecord = getBoundingBoxRecord(id);
         if (!boundingBoxRecord) {
             boundingBoxRecord = gapiService.gapi.layer.bbox.makeBoundingBox(
-                    id, bbExtent, mapBody.extent.spatialReference);
+                id, bbExtent, mapBody.extent.spatialReference);
 
             boundingBoxRecords.push(boundingBoxRecord);
             mapBody.addLayer(boundingBoxRecord);

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -98,7 +98,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
         // add the new legend block to the legend block (always to the root group)
         legendBlocks.addEntry(importedLegendBlock, position);
 
-        // add the new block config to the legend config (always to the root group)
+        // add the new block config to the legend config (always to the root group), so it will be preserved when map is rebuilt
         configService.getSync.map.legend.addChild(importedBlockConfig, position);
 
         return importedLegendBlock;
@@ -176,12 +176,18 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
                 entry === legendBlock ? parentEntry : null)
             .filter(a => a !== null)[0];
 
-        // TODO: instead of removing the legen block form the selector, just hide it with some css
+        // TODO: instead of removing the legend block form the selector, just hide it with some css
         const index = legendBlockParent.removeEntry(legendBlock);
 
         return [_resolve, _reject];
 
         // FIXME: need to remove the enty from the legend config as well, or it will be recreated on the full state restore
+        /**
+         * A helper function that remove remaining layer elements from config.
+         *
+         * @function _resolve
+         * @private
+         */
         function _resolve() {
             layerRegistry.removeLayerRecord(legendBlock.layerRecordId);
 
@@ -189,6 +195,12 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
             _boundingBoxRemoval(legendBlock);
         }
 
+        /**
+         * A helper function that restored layer elements.
+         *
+         * @function _reject
+         * @private
+         */
         function _reject() {
             legendBlockParent.addEntry(legendBlock, index);
             legendBlock.visibility = cachedVisibility;


### PR DESCRIPTION
## Description
- [bug #2092] prevents bookmarking of errored and still loading layers
- [bug #2095] user-added layers were breaking bookmark
- [bug #1983] bookmark preserves user-change layer order (autolegend only)
- [bug #1983] bookmark preserves user-remove layers (autolegend only)

Closes #2092, #2095, #1983

## Testing
Eyeballs.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ unreleased bugs
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2094)
<!-- Reviewable:end -->
