### PR TITLE
Bugfest: 2071, 2104, 2107

### DIFF
--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -829,7 +829,7 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
                     entry.blockType === TYPES.NODE);
         }
         get _observableEntries () {
-            // obserbale entrise are a subset of active entries which are not controlled blocks and are rendered in the UI
+            // observable entries are a subset of active entries which are not controlled blocks and are rendered in the UI
             // when calculating group opacity or visibility, exclude controlled layers as they might have locked opacity specified in the config
             return this._activeEntries.filter(entry =>
                 !entry.controlled);

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -760,6 +760,28 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
         }
 
         /**
+         * @return {Boolean} `true` is all observed legend blocks are set to be queriable; `false` otherwise;
+         */
+        get query () {
+            return this._observableEntries.some(entry =>
+                entry.query);
+        }
+        /**
+         * @param {Boolean} value zxxzcs
+         * @return {LegendGroup} this for chaining
+         */
+        set query (value) {
+            if (this.isControlSystemDisabled('query')) {
+                return;
+            }
+
+            this._activeEntries.forEach(entry =>
+                (entry.query = value));
+
+            return this;
+        }
+
+        /**
          * @return {Number} returns opacity of the group;
          * it's equal to the child opacity values if they are the same or 0.5 if not;
          * TODO: might want to add a description what 0.5 value means in such cases;
@@ -797,6 +819,8 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
         }
 
         get entries () {                return this._entries; }
+
+        // active entries are legend blocks that directly or indirectly control map data, namely legend nodes, groups, and sets
         get _activeEntries () {
             return this.entries
                 .filter(entry =>
@@ -805,6 +829,7 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
                     entry.blockType === TYPES.NODE);
         }
         get _observableEntries () {
+            // obserbale entrise are a subset of active entries which are not controlled blocks and are rendered in the UI
             // when calculating group opacity or visibility, exclude controlled layers as they might have locked opacity specified in the config
             return this._activeEntries.filter(entry =>
                 !entry.controlled);

--- a/src/app/ui/loader/loader-file.html
+++ b/src/app/ui/loader/loader-file.html
@@ -61,7 +61,7 @@
                         type="url"
                         ng-focus="self.upload.fileReset(); self.upload.fileUrlResetValidation()"
                         ng-model="self.upload.fileUrl"
-                        ng-model-options="{ updateOn: 'default blur', debounce: { default: 300, blur: 0 } }"
+                        ng-model-options="{ updateOn: 'default blur', debounce: { default: 30, blur: 0 } }"
                         ng-keypress="self.upload.step.onKeypress($event)"
                         required>
 

--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -13,7 +13,7 @@
                     type="url"
                     ng-change="self.connect.serviceUrlResetValidation()"
                     ng-model="self.connect.serviceUrl"
-                    ng-model-options="{ updateOn: 'default blur', debounce: { default: 300, blur: 0 } }"
+                    ng-model-options="{ updateOn: 'default blur', debounce: { default: 30, blur: 0 } }"
                     ng-keypress="self.connect.step.onKeypress($event)"
                     required>
                 <div ng-messages="self.connect.form.serviceUrl.$error">

--- a/src/app/ui/toc/legend-element-factory.class.js
+++ b/src/app/ui/toc/legend-element-factory.class.js
@@ -378,37 +378,37 @@ function LegendElementFactory($translate, Geo, ConfigObject, tocService, debounc
         }
 
         get data () {
-            const { parentLayerType, geometryType, featureCount } = this.block;
+            const { layerType, geometryType, featureCount } = this.block;
 
             const dataObject = {
-                unknown: 'toc.label.flag.unknown',
+                unknown: {},
                 unresolved: {},
-                get _countData() {
-                    let content;
-                    // it's possible to have a layer with geometry defined, but no actual data, which makes it a raster layer?
-                    if (!geometryType || featureCount === -1) {
-                        content = $translate.instant('geometry.type.imagery');
-                    } else {
+                get esriFeature() {
+                    let content = '';
+
+                    // only if there a valid feature count, display it
+                    if (typeof featureCount !== 'undefined' && featureCount !== -1) {
                         // need to translate the substution variable itself; can't think of any other way :(
                         const typeName = $translate
                             .instant(`geometry.type.${geometryType}`)
                             .split('|')[featureCount === 1 ? 0 : 1];
 
-                        content = `${featureCount} ${typeName}`;
+                        content = `(${featureCount} ${typeName})`;
                     }
 
                     return { content };
                 },
-                get esriFeature() { return this._countData; },
-                get esriDynamic() { return this._countData; }
-            }[parentLayerType || TypeFlag.unresolvedType];
+
+                get esriRaster() {  return this.esriDynamic; },
+                get esriDynamic() { return { content: `(${$translate.instant('geometry.type.imagery')})` }; }
+            }[layerType || TypeFlag.unresolvedType];
 
             return dataObject;
         }
 
         get style () {   return this._styles[this.block.parentLayerType || TypeFlag.unresolvedType]; }
         get icon () {    return this._icons[this.block.parentLayerType || TypeFlag.unresolvedType]; }
-        get label () {   return this._labels[this.block.parentLayerType || TypeFlag.unresolvedType]; /* include feature count and feature types ? */ }
+        get label () {   return this._labels[this.block.parentLayerType || TypeFlag.unresolvedType]; }
 
         get isVisible () { return true; }
     }

--- a/src/app/ui/toc/legend-element-factory.class.js
+++ b/src/app/ui/toc/legend-element-factory.class.js
@@ -14,7 +14,7 @@ angular
     .module('app.ui')
     .factory('LegendElementFactory', LegendElementFactory);
 
-function LegendElementFactory($translate, ConfigObject, tocService, debounceService, configService) {
+function LegendElementFactory($translate, Geo, ConfigObject, tocService, debounceService, configService) {
     const ref = {
         autoLegendEh: configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE
     };
@@ -241,9 +241,11 @@ function LegendElementFactory($translate, ConfigObject, tocService, debounceServ
 
         action () {     this._debouncedAction(); }
 
-        // control is only visible if the layer has data that is not disabled
         get isVisible () {
-            return super.isVisible && this.block.featureCount !== -1;
+            // data control is visible for all feature layers unless the controls is disallowed or disabled in the config
+            return super.isVisible &&
+                !this.block.isControlDisabled(this._controlName) &&
+                this.block.layerType === Geo.Layer.Types.ESRI_FEATURE;
         }
 
         _debouncedAction = debounceService.registerDebounce(
@@ -383,7 +385,8 @@ function LegendElementFactory($translate, ConfigObject, tocService, debounceServ
                 unresolved: {},
                 get _countData() {
                     let content;
-                    if (!geometryType) {
+                    // it's possible to have a layer with geometry defined, but no actual data, which makes it a raster layer?
+                    if (!geometryType || featureCount === -1) {
                         content = $translate.instant('geometry.type.imagery');
                     } else {
                         // need to translate the substution variable itself; can't think of any other way :(
@@ -433,10 +436,11 @@ function LegendElementFactory($translate, ConfigObject, tocService, debounceServ
         get icon () {    return 'community:table-large'; }
         get label () {   return 'toc.label.flag.data.table'; }
 
-        // flag is only visible if the layer has data that is not disabled
         get isVisible () {
-            return this.block.isControlVisible(this._controlName) &&
-                !this.block.isControlDisabled(this._controlName) && this.block.featureCount !== -1;
+            // data flag is visible for all feature layers unless the controls is disallowed or disabled in the config
+            return super.isVisible &&
+                !this.block.isControlDisabled(this._controlName) &&
+                this.block.layerType === Geo.Layer.Types.ESRI_FEATURE;
         }
     }
 

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -184,13 +184,13 @@ Table of Content remove state label,toc.label.state.remove,Layer removed,1,Couch
 Table of Content remove action label,toc.label.action.remove,undo,1,annuler,1
 Table of Content filters label,toc.label.filters,,1,,1
 Table of Content filters tootlip,toc.tooltip.filters,,1,,1
-Table of Content feature layer flag label,toc.label.flag.feature,ESRI Feature Layer ({{content}}),1,Couche d'éléments d'ESRI ({{content}}),1
+Table of Content feature layer flag label,toc.label.flag.feature,ESRI Feature Layer {{content}},1,Couche d'éléments d'ESRI {{content}},1
 ,toc.label.flag.unresolved,Detecting layer type...,1,[fr] Detecting layer type...,0
 ,toc.label.flag.unresolved,Cannot determine layer type,1,[fr] Cannot determine layer type,0
 ,toc.label.flag.unsupportedprojection,Cannot display layer in the current projection,1,[fr]Cannot display layer in current projection,0
-Table of Content feature layer flag tootlip,toc.tooltip.flag.feature,ESRI Feature Layer ({{content}}),1,Couche d'éléments d'ESRI ({{content}}),1
-Table of Content dynamic layer flag label,toc.label.flag.dynamic,ESRI Dynamic Layer ({{content}}),1,Couche dynamique d'ESRI ({{content}}),1
-Table of Content dynamic layer flag tootlip,toc.tooltip.flag.dynamic,ESRI Dynamic Layer ({{content}}),1,Couche dynamique d'ESRI ({{content}}),1
+Table of Content feature layer flag tootlip,toc.tooltip.flag.feature,ESRI Feature Layer {{content}},1,Couche d'éléments d'ESRI {{content}},1
+Table of Content dynamic layer flag label,toc.label.flag.dynamic,ESRI Dynamic Layer {{content}},1,Couche dynamique d'ESRI {{content}},1
+Table of Content dynamic layer flag tootlip,toc.tooltip.flag.dynamic,ESRI Dynamic Layer {{content}},1,Couche dynamique d'ESRI {{content}},1
 Table of Content wms layer flag label,toc.label.flag.wms,OGC WMS Layer,1,Couche WMS de l'OGC,1
 Table of Content wms layer flag tootlip,toc.tooltip.flag.wms,OGC WMS Layer,1,Couche WMS de l'OGC,1
 Table of Content tile layer flag label,toc.label.flag.tile,ESRI Tile Layer,1,Couche de tuiles d'ESRI,1


### PR DESCRIPTION
## Description
- [bug #2071] query values now propagate to children when set on the group
- [bug #2104] raster layers no longer display data flags or data controls
- [bug #2107] invalid feature counts (like -1) will not be shown anymore
- [undocumented enhancement] layer import wizard less likely to miss service url value changes

Close #2071, #2104, #2107

## Testing
Eyeballs.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ unreleased bugs
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2113)
<!-- Reviewable:end -->
