### PR TITLE
fix(ui): column reordering only enabled from settings

### DIFF
--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -188,7 +188,7 @@ function rvFiltersDefault($timeout, $q, stateManager, $compile, geoService, $tra
                         // see key-focus event to see why we put 10
                     }, // turn on virtual scroller extension
                     colReorder: {
-                        fixedColumnsLeft: 2, // fix symbol and interactive columns
+                        fixedColumnsLeft: displayData.columns.length, // disable drag and drop for all columns, only allow reordering from settings
                         realtime: false// we need this to know when reorder is done
                     },
                     /*select: true,*/ // allow row select,


### PR DESCRIPTION
## Description
Closes #2082.
Column reordering for datatables is now only accessible through the datatable settings panel and not by way of drag-and-drop.

## Testing
Visually tested.

## Documentation
In-line comment.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] commits messages follow the guidelines
- [ ] code passes unit tests
- [ ] release notes have been updated
- [ ] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2117)
<!-- Reviewable:end -->
