### PR TITLE
fix(ui): make singleentrycollapse checkbox undefined if no layers

### DIFF
--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -119,6 +119,7 @@
                 ng-switch-when="dynamicservice">
                 <md-checkbox
                     ng-model="self.layerSource.config.singleEntryCollapse"
+                    md-indeterminate="self.layerSource.config.layerEntries.length === 0"
                     ng-true-value="false"
                     ng-false-value="true"
                     ng-disabled="self.layerSource.config.layerEntries.length !== 1"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -12,10 +12,10 @@ const HtmlWebpackPlugin     = require('html-webpack-plugin');
 module.exports = function (env) {
 
     const geoPath = env.geoLocal ?
-                        env.geoLocal.length > 0 ?
-                            env.geoLocal :
-                            path.resolve(__dirname, '../', 'geoApi') :
-                        path.resolve(__dirname, 'node_modules/geoApi');
+        env.geoLocal.length > 0 ?
+            env.geoLocal :
+            path.resolve(__dirname, '../', 'geoApi') :
+        path.resolve(__dirname, 'node_modules/geoApi');
 
     const config = {
         entry: {
@@ -81,7 +81,7 @@ module.exports = function (env) {
                 from: '**/*.json',
                 to: 'samples/config'
             },{
-            context: 'src/content/samples',
+                context: 'src/content/samples',
                 from: '**/*.json',
                 to: 'samples'
             },{


### PR DESCRIPTION
## Description
Makes the "display as a group" checkbox undefined when no layers are selected as requested by QA:
![unknown](https://user-images.githubusercontent.com/2285779/27927214-0a97e966-6259-11e7-8025-0ae4dfd5d24d.gif)


## Testing
Eyeballs.

## Documentation
Nope.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2122)
<!-- Reviewable:end -->
