### PR TITLE
Hide help when the corresponding folder name is absent

### DIFF
--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1841,7 +1841,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             this._source = source;
             this._logo = source.logo === true;
 
-            const sideMenuitems = [
+            const ITEMS_DEFAULT = [
                 [
                     'layers',
                     'basemap'
@@ -1862,14 +1862,14 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                 ]
             ];
 
-            //remove help if help or its folderName is absent
-            if (! helpSource || ! helpSource.folderName) {
-                sideMenuitems[1].splice(sideMenuitems[1].indexOf('help'));
-            }
-
             this._items = angular.isArray(source.items) ?
                 source.items.map(subItems =>
-                    common.intersect(source.items, SideMenu.ITEMS)) : sideMenuitems;
+                    common.intersect(source.items, SideMenu.AVAILABLE_ITEMS)) : ITEMS_DEFAULT;
+
+            //remove help if help or its folderName is absent
+            if (! helpSource || ! helpSource.folderName) {
+                ITEMS_DEFAULT[1].splice(ITEMS_DEFAULT[1].indexOf('help'));
+            }
         }
 
 

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1864,11 +1864,11 @@ function ConfigObjectFactory(Geo, gapiService, common) {
 
             this._items = angular.isArray(source.items) ?
                 source.items.map(subItems =>
-                    common.intersect(source.items, SideMenu.AVAILABLE_ITEMS)) : ITEMS_DEFAULT;
+                    common.intersect(source.items, SideMenu.AVAILABLE_ITEMS)) : angular.copy(ITEMS_DEFAULT);
 
             //remove help if help or its folderName is absent
             if (! helpSource || ! helpSource.folderName) {
-                ITEMS_DEFAULT[1].splice(ITEMS_DEFAULT[1].indexOf('help'));
+                this._items[1].splice(this._items[1].indexOf('help'));
             }
         }
 

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1810,11 +1810,15 @@ function ConfigObjectFactory(Geo, gapiService, common) {
      * @class NavBar
      */
     class NavBar {
-        constructor(source = {}) {
+        constructor(source = {}, helpSource) {
             this._source = source;
-
             this._zoom = source.zoom || 'buttons';
             this._extra = source.extra || [];
+
+            // remove help if help or its folderName is absent
+            if (! helpSource || ! helpSource.folderName) {
+                this._extra.splice(this._extra.indexOf('help'));
+            }
         }
 
         get zoom () { return this._zoom; }
@@ -1833,48 +1837,41 @@ function ConfigObjectFactory(Geo, gapiService, common) {
      * @class SideMenu
      */
     class SideMenu {
-        constructor(source = {}) {
+        constructor(source = {}, helpSource) {
             this._source = source;
-
             this._logo = source.logo === true;
+
+            const sideMenuitems = [
+                [
+                    'layers',
+                    'basemap'
+                ],
+                [
+                    'fullscreen',
+                    'export',
+                    'share',
+                    'touch',
+                    'help',
+                    'about'
+                ],
+                [
+                    'language'
+                ],
+                [
+                    'plugins'
+                ]
+            ];
+
+            //remove help if help or its folderName is absent
+            if (! helpSource || ! helpSource.folderName) {
+                sideMenuitems[1].splice(sideMenuitems[1].indexOf('help'));
+            }
+
             this._items = angular.isArray(source.items) ?
                 source.items.map(subItems =>
-                    common.intersect(source.items, SideMenu.ITEMS)) :
-                SideMenu.ITEMS_DEFAULT;
+                    common.intersect(source.items, SideMenu.ITEMS)) : sideMenuitems;
         }
 
-        static AVAILABLE_ITEMS = [
-            'layers',
-            'basemap',
-            'about',
-            'fullscreen',
-            'export',
-            'share',
-            'touch',
-            'help',
-            'language'
-        ];
-
-        static ITEMS_DEFAULT = [
-            [
-                'layers',
-                'basemap'
-            ],
-            [
-                'fullscreen',
-                'export',
-                'share',
-                'touch',
-                'help',
-                'about'
-            ],
-            [
-                'language'
-            ],
-            [
-                'plugins'
-            ]
-        ];
 
         get source () { return this._source; }
 
@@ -1951,8 +1948,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
     class Help {
         constructor(helpSource = {}) {
             this._source = helpSource;
-
-            this._folderName = helpSource.folderName || 'default';
+            this._folderName = helpSource.folderName;
         }
 
         get folderName () { return this._folderName; }
@@ -2023,11 +2019,11 @@ function ConfigObjectFactory(Geo, gapiService, common) {
         constructor(uiSource) {
             this._source = uiSource;
 
-            this._navBar = new NavBar(uiSource.navBar);
+            this._navBar = new NavBar(uiSource.navBar, uiSource.help);
             this._logoUrl = uiSource.logoUrl || null;
             this._title = uiSource.title || null;
             this._restrictNavigation = uiSource.restrictNavigation === true;
-            this._sideMenu = new SideMenu(uiSource.sideMenu);
+            this._sideMenu = new SideMenu(uiSource.sideMenu, uiSource.help);
             this._legend = new UILegend(uiSource.legend);
             this._help = new Help(uiSource.help);
             this._fullscreen = uiSource.fullscreen;

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1872,6 +1872,17 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             }
         }
 
+        static AVAILABLE_ITEMS = [
+            'layers',
+            'basemap',
+            'about',
+            'fullscreen',
+            'export',
+            'share',
+            'touch',
+            'help',
+            'language'
+        ];
 
         get source () { return this._source; }
 

--- a/src/content/samples/config/config-sample-01-structured-visibility-sets.json
+++ b/src/content/samples/config/config-sample-01-structured-visibility-sets.json
@@ -13,6 +13,9 @@
     "sideMenu": {
       "logo": true
     },
+    "help": {
+      "folderName": "default"
+    },
     "legendIsOpen": {
       "large": true,
       "medium": true,

--- a/src/content/samples/config/config-sample-02-structured-legend-controlled-layers.json
+++ b/src/content/samples/config/config-sample-02-structured-legend-controlled-layers.json
@@ -12,6 +12,8 @@
     "sideMenu": {
       "logo": true
     },
+    "help": {
+    },
     "legendIsOpen": {
       "large": true,
       "medium": true,

--- a/src/content/samples/schema.json
+++ b/src/content/samples/schema.json
@@ -693,7 +693,7 @@
                     "type": "object",
                     "description": "Help properties",
                     "properties": {
-                        "folderName": { "type": "string", "default": "default", "description": "Help folder name who contain the help description and images" }
+                        "folderName": { "type": "string", "description": "Help folder name who contain the help description and images" }
                     },
                     "required": [ "folderName" ],
                     "additionalProperties": false


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2048
Hide the help button in both nav bar and side bar when the folder name for it is absent

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Tested in `samples-index`

- sample 1: with `ui.help.folderName`
- sample 2: with `ui.help` but not `ui.help.folderName`
- sample 3: `ui.help` is absent

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
config files for sample 1 and 2
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2146)
<!-- Reviewable:end -->
