### PR TITLE
fix(core): allow loading files from network

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "^1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "^1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v0.0.0-protoLR-77",
+    "geoApi": "github:fgpv-vpgf/geoApi#v0.0.0-protoLR-78",
     "gsap": "^1.19.1",
     "jquery": "^2.2.1",
     "jquery-hoverintent": "^1.8.2",

--- a/src/app/ui/loader/loader-file.html
+++ b/src/app/ui/loader/loader-file.html
@@ -37,7 +37,7 @@
                                 {{ "import.file.upload.choose" | translate }}
                             </md-button>
                         </div>
-                        <span class="md-caption" translate>import.file.upload.drop</span>
+                        <span class="md-caption">{{ 'import.file.upload.drop' | translate }}</span>
                     </div>
 
                     <md-progress-linear
@@ -50,12 +50,13 @@
                     <div ng-messages="self.upload.form.fileSelect.$error">
                         <div ng-message="upload-error">{{ 'import.file.upload.noaccess' | translate }}</div>
                     </div>
+
                 </md-input-container>
 
-                <span class="md-subhead rv-loader-file-upload-or" translate>import.file.upload.or</span>
+                <span class="md-subhead rv-loader-file-upload-or">{{ 'import.file.upload.or' | translate }}</span>
 
                 <md-input-container class="md-block">
-                    <label translate>import.file.upload.fileurl</label>
+                    <label>{{ 'import.file.upload.fileurl' | translate }}</label>
                     <input
                         name="fileUrl"
                         type="url"
@@ -64,6 +65,10 @@
                         ng-model-options="{ updateOn: 'default blur', debounce: { default: 30, blur: 0 } }"
                         ng-keypress="self.upload.step.onKeypress($event)"
                         required>
+
+                    <md-progress-linear
+                        md-mode="indeterminate"
+                        ng-class="{ 'rv-hide': !self.upload.httpProgress }"></md-progress-linear>
 
                     <!-- TODO: decide whether and how to display a hint or error messages -->
                     <div ng-messages="self.upload.form.fileUrl.$error">
@@ -80,7 +85,7 @@
                 summary-value="{{ self.layerSource.type && self.select.step.isCompleted ? 'import.file.type.' + self.layerSource.type : '' }}">
 
                 <md-input-container class="md-block">
-                    <label translate>import.file.select.fileformat</label>
+                    <label>{{ 'import.file.select.fileformat' | translate }}</label>
                     <md-select
                         name="dataType"
                         ng-disabled="self.layerSourceOptions.length === 1"
@@ -110,7 +115,7 @@
             <rv-stepper-item step="self.configure.step" form="self.configure.form" ng-switch on="self.layerSource.type">
 
                 <md-input-container class="md-block">
-                    <label translate>import.file.configure.layername</label>
+                    <label>{{ 'import.file.configure.layername' | translate }}</label>
                     <input name="layerName"
                         ng-change="self.configure.configureResetValidation()"
                         ng-model="self.layerSource.config.name" required>
@@ -122,7 +127,7 @@
                 </md-input-container>
 
                 <md-input-container class="md-block">
-                    <label translate>import.file.configure.primaryfield</label>
+                    <label>{{ 'import.file.configure.primaryfield ' | translate }}</label>
                     <md-select
                         name="primaryField"
                         md-on-open="self.configure.configureResetValidation()"
@@ -140,7 +145,7 @@
 
                 <div layout="row" ng-switch-when="csv">
                     <md-input-container class="md-block" flex>
-                        <label translate>import.file.configure.latitudefield</label>
+                        <label>{{ 'import.file.configure.latitudefield' | translate }}</label>
                         <md-select
                             name="latitude"
                             md-on-open="self.configure.configureResetValidation()"
@@ -156,7 +161,7 @@
                         </div-->
                     </md-input-container>
                     <md-input-container class="md-block" flex>
-                        <label translate>import.file.configure.longitudefield</label>
+                        <label>{{ 'import.file.configure.longitudefield' | translate }}</label>
                         <md-select
                             name="longitude"
                             md-on-open="self.configure.configureResetValidation()"
@@ -176,7 +181,7 @@
 
                 <div layout="row">
                     <md-input-container class="md-block" flex>
-                        <label translate>import.file.configure.colourfield</label>
+                        <label>{{ 'import.file.configure.colourfield' | translate }}</label>
                         <input rv-minicolors options="self.configure.colourPickerSettings"
                             name="layerName"
                             ng-change="self.configure.configureResetValidation()"
@@ -190,7 +195,7 @@
                 </div>
 
                 <div ng-messages="self.configure.form.$error" class="rv-form-error">
-                    <div ng-message="invalid" translate>import.file.configure.invalid</div>
+                    <div ng-message="invalid">{{ 'import.file.configure.invalid' | translate }}</div>
                 </div>
 
                 <p class="md-caption">{{ 'stepper.unresponsive' | translate }}</p>
@@ -200,7 +205,7 @@
 
         <div class="rv-file-drop-container" flow-drop>
             <div class="rv-file-drop-title">
-                <span class="md-display-2" translate>import.file.upload.drop</span>
+                <span class="md-display-2">{{ 'import.file.upload.drop' | translate }}</span>
                 <md-icon md-svg-src="file:file_upload"></md-icon>
             </div>
         </div>

--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -7,7 +7,7 @@
             summary-value="{{ self.connect.step.isCompleted ? self.connect.serviceUrl : '' }}">
 
             <md-input-container class="md-block">
-                <label translate>import.service.connect.serviceurl</label>
+                <label>{{ 'import.service.connect.serviceurl' | translate }}</label>
                 <input
                     name="serviceUrl"
                     type="url"
@@ -28,7 +28,7 @@
         <rv-stepper-item step="self.select.step" form="self.select.form"
             summary-value="{{ self.select.step.isCompleted ? 'import.service.type.' + self.layerSource.type : '' }}">
             <md-input-container class="md-block">
-                <label translate>import.service.select.servicetype</label>
+                <label>{{ 'import.service.select.servicetype' | translate }}</label>
                 <md-select
                     name="serviceType"
                     ng-disabled="self.layerSourceOptions.length === 1"
@@ -56,7 +56,7 @@
             <md-input-container class="md-block"
                 ng-switch-when="featurelayer|wms"
                 ng-switch-when-separator="|">
-                <label translate>import.service.configure.layername</label>
+                <label>{{ 'import.service.configure.layername' | translate }}</label>
                 <input name="layerServiceName" ng-model="self.layerSource.config.name" required>
                 <!-- TODO: decide whether and how to display a hint or error messages -->
                 <!--div ng-messages="self.configure.form.layerName.$error">
@@ -66,7 +66,7 @@
             </md-input-container>
 
             <md-input-container class="md-block" ng-switch-when="featurelayer">
-                <label translate>import.service.configure.primaryfield</label>
+                <label>{{ 'import.service.configure.primaryfield' | translate }}</label>
                 <md-select
                     name="primaryField"
                     ng-model="self.layerSource.config.nameField"
@@ -82,7 +82,7 @@
             </md-input-container>
 
             <md-input-container class="md-block" ng-switch-when="dynamicservice">
-                <label translate>import.service.configure.layers</label>
+                <label>{{ 'import.service.configure.layers' | translate }}</label>
                 <md-select
                     name="dynamicLayers"
                     ng-model="self.layerSource.config.layerEntries"
@@ -107,7 +107,7 @@
                         {{ layer.indent + ' ' + layer.name }}
                     </md-option>
                 </md-select>
-                <div class="rv-hint" translate>import.service.configure.multipleselection</div>
+                <div class="rv-hint">{{ 'import.service.configure.multipleselection' | translate }}</div>
                 <!-- TODO: decide whether and how to display a hint or error messages -->
                 <!--div class="errors" ng-messages="self.configure.form.primaryField.$error">
                         <div ng-message="required">Required</div>
@@ -131,7 +131,7 @@
             <md-input-container class="md-block"
                 ng-if="!self.layerSource.config.singleEntryCollapse"
                 ng-switch-when="dynamicservice">
-                <label translate>import.service.configure.groupname</label>
+                <label>{{ 'import.service.configure.groupname' | translate }}</label>
                 <input name="layerServiceName"
                     ng-model="self.layerSource.config.name" required>
                 <!-- TODO: decide whether and how to display a hint or error messages -->
@@ -142,7 +142,7 @@
             </md-input-container>
 
             <md-input-container class="md-block" ng-switch-when="wms">
-                <label translate>import.service.configure.layers</label>
+                <label>{{ 'import.service.configure.layers' | translate }}</label>
                 <md-select
                     name="wmsLayers"
                     ng-model="self.layerSource.config.layerEntries"
@@ -167,7 +167,7 @@
                         {{ layer.indent + ' ' + layer.desc }}
                     </md-option>
                 </md-select>
-                <div class="rv-hint" translate>import.service.configure.multipleselection</div>
+                <div class="rv-hint">{{ 'import.service.configure.multipleselection' | translate }}</div>
                 <!-- TODO: decide whether and how to display a hint or error messages -->
                 <!--div class="errors" ng-messages="self.configure.form.layers.$error">
                     <div ng-message="required">Required</div>


### PR DESCRIPTION
## Description
Allows to load files from the network using the Angular $http service instead of the esri loader library.
Loading files from a source without proper CORS settings will fail.

Sample data for testing is here: http://fgpv.cloudapp.net/demo/__assets__/Sample%20Data/

Closes #2061

## Testing
Eyeballs.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2156)
<!-- Reviewable:end -->
