### PR TITLE
Fix the issue when contents is not loading in the datatable in IE

### DIFF
--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1868,7 +1868,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
 
             //remove help if help or its folderName is absent
             if (! helpSource || ! helpSource.folderName) {
-                this._items[1].splice(this._items[1].indexOf('help'));
+                this._items[1].splice(this._items[1].indexOf('help'), 1);
             }
         }
 

--- a/src/app/ui/filters/filters-default.directive.js
+++ b/src/app/ui/filters/filters-default.directive.js
@@ -592,7 +592,7 @@ function rvFiltersDefault($timeout, $q, stateManager, $compile, geoService, $tra
                     angular.element(filterService.getTable().header()).find('th').each((i, el) => {
                         const title = el.innerHTML;
                         el.innerHTML = '';
-                        el.append(angular.element(`<span data-rv-column="${title}">${title}</span>`)[0]);
+                        el.appendChild(angular.element(`<span data-rv-column="${title}">${title}</span>`)[0]);
                     });
 
                     // fired event to create filters


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2084 Fix the issue when contents is not loading in the datatable in IE and fix a bug with the `about` entry not being load when `help` is no in the config file.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Manually
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
None
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2171)
<!-- Reviewable:end -->
