### PR TITLE
fix(core): correctly synchronize map layer stack with config layer order

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "^1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "^1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v0.0.0-protoLR-80",
+    "geoApi": "github:fgpv-vpgf/geoApi#v0.0.0-protoLR-81",
     "gsap": "^1.19.1",
     "jquery": "^2.2.1",
     "jquery-hoverintent": "^1.8.2",

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -1,4 +1,3 @@
-/* global RV */
 angular
     .module('app.core')
     .run(debugBlock)
@@ -14,7 +13,7 @@ angular
  * The `runBlock` triggers config and locale file loading, sets language of the app.
  */
 function runBlock($rootScope, $rootElement, $q, globalRegistry, reloadService, events, configService,
-        gapiService, appInfo) {
+    gapiService, appInfo) {
 
     const promises = [
         configService.initialize(),
@@ -125,8 +124,9 @@ function runBlock($rootScope, $rootElement, $q, globalRegistry, reloadService, e
      * Adding `{{ ::$root.uid($id) }}` inside a template will return a `{appid}-{scopeid}` string. If this used several times inside a single template, the same id is returned, so you don't have to store it to reuse. Don't forget a one-time binding.
      * @function uid
      * @private
-     * @param {String|Number} id
-     * @return {String|Number} suffix [optional]
+     * @param {String|Number} id ui element id
+     * @param {String|Number} [suffix] an optional suffix to be appended to the resulting id
+     * @return {String} generated template element id
      */
     function uid(id, suffix) {
         suffix = suffix ? `-${suffix}` : '';
@@ -181,8 +181,6 @@ function apiBlock($rootScope, globalRegistry, geoService, configService, events,
     $rootScope.$on(events.rvApiHalt, () => {
         globalRegistry.getMap(appInfo.id)._deregisterMap();
     });
-
-    /**********************/
 
     /**
      * Sets the translation language and reloads the map
@@ -249,8 +247,8 @@ function apiBlock($rootScope, globalRegistry, geoService, configService, events,
      */
     function centerAndZoom(x, y, spatialReference, zoom) {
         const coords = gapiService.gapi.proj.localProjectPoint(
-                            spatialReference, geoService.mapObject.spatialReference, { x: x, y: y }
-                );
+            spatialReference, geoService.mapObject.spatialReference, { x: x, y: y }
+        );
         const zoomPoint = gapiService.gapi.proj.Point(coords.x, coords.y, geoService.mapObject.spatialReference);
 
         // separate zoom and center calls, calling centerAndZoom sets the map to an extent made up of NaN

--- a/src/app/core/graphics.service.js
+++ b/src/app/core/graphics.service.js
@@ -1,4 +1,3 @@
-/* global canvg, SVG */
 /**
  * @name graphicsService
  * @constant
@@ -79,6 +78,8 @@ function graphicsService($q) {
      * Creates an instance of SVG.JS object.
      *
      * @function createSvg
+     * @param {Number} width width of the svg container
+     * @param {Number} height height of the svg container
      * @return {Object} svg object
      */
     function createSvg(width, height) {
@@ -94,7 +95,7 @@ function graphicsService($q) {
      * @function mergeCanvases
      * @param {Array} canvases an array of canvases to mergeCanvases; the first item acts as a base on which all other canvases are rendered in order
      * @param {Array} offsets [optional = []] must be of n-1 length where n is the number of canvases; provides x and y offsets when merging canvases on the base canvas
-     *
+     * @return {Object} merged canvas object
      */
     function mergeCanvases(canvases, offsets = []) {
         canvases = canvases.filter(v => v);

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -66,8 +66,7 @@ function geoService($http, $q, $rootScope, events, mapService, layerRegistry, co
                     console.info(layers);
                     layers.forEach(layer => legendService.addLayerDefinition(layer));
                 });
-            })
-            .catch(error => RV.logger.error('geoService', 'failed to assemble the map with error', error));
+            }).catch(error => RV.logger.error('geoService', 'failed to assemble the map with error', error));
         }
 
         setFullExtent() {
@@ -76,7 +75,7 @@ function geoService($http, $q, $rootScope, events, mapService, layerRegistry, co
             this.map.setExtent(this.map.enhanceConfigExtent(configService.getSync.map.selectedBasemap.full));
         }
 
-         /**
+        /**
          * Check if visible extent is contained in the full extent.
          *
          * @function validateExtent

--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -63,12 +63,13 @@ function rvInitMap($rootScope, geoService, events, layoutService, $rootElement, 
          *
          * @function mouseDownHandler
          * @private
+         * @param {Event} event mouse down event when the user starts dragging the map
          */
         function mouseDownHandler(event) {
             mouseMoveHanlder = mouseMoveHandlerBuilder(event);
             el
-            .off('mousemove')
-            .on('mousemove', mouseMoveHanlder);
+                .off('mousemove')
+                .on('mousemove', mouseMoveHanlder);
         }
 
         /**
@@ -77,6 +78,8 @@ function rvInitMap($rootScope, geoService, events, layoutService, $rootElement, 
          *
          * @function mouseMoveHandlerBuilder
          * @private
+         * @param {Event} startingEvent mouse down event when the user starts dragging the map
+         * @return {Function} a function handling mouse movements when the user pans the map
          */
         function mouseMoveHandlerBuilder(startingEvent) {
             // TODO: IE is not fast enough to sustain this approach as the mousemove event don't start to fire immediately after mouseover event
@@ -163,8 +166,8 @@ function rvInitMap($rootScope, geoService, events, layoutService, $rootElement, 
      * @function animate
      * @param {Object} event     the keydown/keyup browser event
      */
+    // eslint-disable-next-line complexity
     function animate() {
-        /*jshint maxcomplexity:16 */
         stopAnimate();
         if (keyMap.length === 0) {
             return;
@@ -186,51 +189,51 @@ function rvInitMap($rootScope, geoService, events, layoutService, $rootElement, 
         for (let i = 0; i < keyMap.length; i++) {
             switch (keyMap[i]) {
                 // enter key is pressed - trigger identify
-                case 13:
-                    // prevent identify if focus manager is in a waiting state since ENTER key is used to activate the focus manager.
-                    // Also disable if SHIFT key is depressed so identify is not triggered on leaving focus manager
-                    if ($rootElement.attr('rv-focus-status') === globalRegistry.focusStatusTypes.ACTIVE) {
-                        event.mapPoint = mapPntCntr;
-                        event.screenPoint = mapScrnCntr;
-                        geoService.state.identifyService.clickHandler(event);
-                    }
-                    break;
-                // shift key pressed - pan distance increased
-                case 16:
-                    hasShiftMultiplier = 2;
-                    break;
-                // left arrow key pressed
-                case 37:
-                    x -= mapPntHorDiff;
-                    break;
-                // up arrow key pressed
-                case 38:
-                    y += mapPntVertDiff;
-                    break;
-                // right arrow key pressed
-                case 39:
-                    x += mapPntHorDiff;
-                    break;
-                // down arrow key pressed
-                case 40:
-                    y -= mapPntVertDiff;
-                    break;
-                // + (plus) key pressed - zoom in
-                case 187:
-                    geoService.map.shiftZoom(1);
-                    break;
-                // + (plus) key pressed - FF and IE
-                case 61:
-                    geoService.map.shiftZoom(1);
-                    break;
-                // - (minus) key pressed - zoom out
-                case 189:
-                    geoService.map.shiftZoom(-1);
-                    break;
-                // - (minus) key pressed - FF and IE
-                case 173:
-                    geoService.map.shiftZoom(-1);
-                    break;
+            case 13:
+                // prevent identify if focus manager is in a waiting state since ENTER key is used to activate the focus manager.
+                // Also disable if SHIFT key is depressed so identify is not triggered on leaving focus manager
+                if ($rootElement.attr('rv-focus-status') === globalRegistry.focusStatusTypes.ACTIVE) {
+                    event.mapPoint = mapPntCntr;
+                    event.screenPoint = mapScrnCntr;
+                    geoService.state.identifyService.clickHandler(event);
+                }
+                break;
+            // shift key pressed - pan distance increased
+            case 16:
+                hasShiftMultiplier = 2;
+                break;
+            // left arrow key pressed
+            case 37:
+                x -= mapPntHorDiff;
+                break;
+            // up arrow key pressed
+            case 38:
+                y += mapPntVertDiff;
+                break;
+            // right arrow key pressed
+            case 39:
+                x += mapPntHorDiff;
+                break;
+            // down arrow key pressed
+            case 40:
+                y -= mapPntVertDiff;
+                break;
+            // + (plus) key pressed - zoom in
+            case 187:
+                geoService.map.shiftZoom(1);
+                break;
+            // + (plus) key pressed - FF and IE
+            case 61:
+                geoService.map.shiftZoom(1);
+                break;
+            // - (minus) key pressed - zoom out
+            case 189:
+                geoService.map.shiftZoom(-1);
+                break;
+            // - (minus) key pressed - FF and IE
+            case 173:
+                geoService.map.shiftZoom(-1);
+                break;
             }
         }
 

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -338,10 +338,7 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
          * @param {String} value id of the layer bound to this legend block; this will be used in reordering and reloading
          */
         get layerRecordId () {
-            if (this._layerRecordId === null) {
-                console.error('layerRecordId must be set on all LegendBlocks which can be reloaded or reordered');
-            }
-
+            // layerRecordId is null until set in by the legend service;
             return this._layerRecordId;
         }
 
@@ -641,8 +638,8 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
         // collapsed value specifies if the group node will be hidden from UI
         // in such a case, its children will appear to be on the same level as the legend group would have been
         _collapsed = false;
-        get collapsed () {       return this._collapse; }
-        set collapsed (value) {  this._collapse = value; }
+        get collapsed () {       return this._collapsed; }
+        set collapsed (value) {  this._collapsed = value; }
 
         applyInitialStateSettings() {
             // this will ensure all the controlled layers settings in this group match settings of the observable entries

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -1,4 +1,3 @@
-/* global RV */
 /**
  * @module legendService
  * @memberof app.geo
@@ -69,7 +68,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
      *
      * @function addLayerDefinition
      * @param {LayerDefinition} layerDefinition a layer definition from the config file or RCS snippets
-     * @returns {LayerBlueprint}
+     * @returns {LayerBlueprint} generated layer blueprint
      */
     function createBlueprint(layerDefinition) {
         const blueprint = new LayerBlueprint.service(layerDefinition);
@@ -199,6 +198,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
             .filter(a => a !== null)[0];
 
         // TODO: instead of removing the legend block form the selector, just hide it with some css
+        // FIXME: when removing a single child of a collapsed dynamic group or a single child from a dynamic group, need to remove the group itself since it no longer serves any purpose
         const index = legendBlockParent.removeEntry(legendBlock);
 
         return [_resolve, _reject];
@@ -815,6 +815,5 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
             // TODO: this should return something meaningful for info sections and maybe sets?
             return blueprint;
         }
-
     }
 }

--- a/src/app/ui/common/truncate.directive.js
+++ b/src/app/ui/common/truncate.directive.js
@@ -133,7 +133,7 @@ function rvTruncateTitle(graphicsService) {
          */
         function splitString(string, widthToFit) {
 
-            // TODO: use [getComputerStyles](https://developer.mozilla.org/en/docs/Web/API/Window/getComputedStyle) to get the actual font name and font size instead of this hardcoded font
+            // TODO: use [getComputedStyles](https://developer.mozilla.org/en/docs/Web/API/Window/getComputedStyle) to get the actual font name and font size instead of this hardcoded font
             const stringWidth = graphicsService.getTextWidth(canvas, string, 'normal 16px Roboto');
 
             if (stringWidth < widthToFit) {

--- a/src/app/ui/panels/content-pane.directive.js
+++ b/src/app/ui/panels/content-pane.directive.js
@@ -47,12 +47,6 @@ angular
     .module('app.ui')
     .directive('rvContentPane', rvContentPane);
 
-/**
- * `rvContentPane` directive body.
- *
- * @function rvContentPane
- * @return {object} directive body
- */
 function rvContentPane($compile) {
     const directive = {
         restrict: 'E',
@@ -73,7 +67,7 @@ function rvContentPane($compile) {
         },
         transclude: true,
         link: link,
-        controller: Controller,
+        controller: () => {},
         controllerAs: 'self',
         bindToController: true
     };
@@ -152,18 +146,5 @@ function rvContentPane($compile) {
                 footer.append(footerElement);
             }
         }
-    }
-}
-
-/**
- * Skeleton controller function.
- */
-function Controller() {
-    // const self = this;
-
-    activate();
-
-    function activate() {
-
     }
 }

--- a/src/app/ui/toc/templates/expand-menu.directive.js
+++ b/src/app/ui/toc/templates/expand-menu.directive.js
@@ -90,7 +90,7 @@ function Controller(LegendBlock, geoService, appInfo, configService) {
         return isAllExpanded;
     }
 
-        /**
+    /**
      * Checks if the legendBlocks hierarchy is initialized; false otherwise
      *
      * @function _legendBlocksReadyCheck

--- a/src/app/ui/toc/toc.directive.js
+++ b/src/app/ui/toc/toc.directive.js
@@ -16,11 +16,6 @@ angular
     .module('app.ui')
     .directive('rvToc', rvToc);
 
-/**
- * `rvToc` directive body.
- *
- * @return {object} directive body
- */
 function rvToc($timeout, layoutService, layerRegistry, dragulaService, geoService, animationService, configService) {
     const directive = {
         restrict: 'E',
@@ -110,12 +105,7 @@ function rvToc($timeout, layoutService, layerRegistry, dragulaService, geoServic
             },
 
             rvDragDropModel() {
-                const legendBlocks = configService.getSync.map.legendBlocks;
-
-                const layerRecords = legendBlocks.entries.map(legendBlock =>
-                    layerRegistry.getLayerRecord(legendBlock.layerRecordId));
-
-                layerRegistry.synchronizeLayerOrder(layerRecords);
+                layerRegistry.synchronizeLayerOrder();
             },
 
             rvDragCancel(evt, elem, target, source) {
@@ -160,7 +150,7 @@ function rvToc($timeout, layoutService, layerRegistry, dragulaService, geoServic
 
                         scrollAnimation = animationService.to(scrollElem, scrollDuration,
                             { scrollTo: { y: scrollElem[0].scrollHeight - scrollElem.height() },
-                            ease: 'Linear.easeNone' });
+                                ease: 'Linear.easeNone' });
                     }
 
                 // stop scrolling


### PR DESCRIPTION
## Description
Layer sorting function used a wrong condition that somehow managed to work correctly for a relatively small number of layers, but failed for a larger sample. Now, the map layer order should map layer order in the UI (barring mixing vector and image based layers of course).

To test, check out the branch, `npm install`, grab [this config](http://geoappext.nrcan.gc.ca/fgpv/map/egs/en/config.en-CA.json), and then load it in `index-mobile` page. The `Today's Smoke Forecast` layer should be under the `Active Fires` layer.

Closes #2178 

## Testing
![](https://camo.githubusercontent.com/05a2ef12d143be821500e24220895f35fd4a0ba5/68747470733a2f2f692e696d6775722e636f6d2f56486a445551312e706e67)

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ unreleased bug
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2183)
<!-- Reviewable:end -->
