### PR TITLE
fix(core): ignore non-layer legend blocks when synchronizing layer order

### DIFF
--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -259,7 +259,7 @@ function layerRegistryFactory($rootScope, $timeout, $filter, events, gapiService
         // an array of layer records ordered as visible to the user in the layer selector UI component
         const orderedLayerRecords = configService.getSync.map.legendBlocks
             .walk(lb => lb.layerRecordId) // get a flat list of layer record ids as they appear in UI
-            .filter(id => id !== null) // filter out artificial groups
+            .filter(id => id) // this will strip all falsy values like `undefined` and `null` since ids should be strings; filter out artificial groups that don't have ids set to null and legend info elements
             .reduce((a, b) =>
                 a.concat(a.indexOf(b) < 0 ? b : []), []) // remove duplicates (dynamic group and its children with have the same layer id)
             .map(getLayerRecord); // get appropriate layer records


### PR DESCRIPTION
## Description
Ignores non-layer legend blocks (like text and images blocks) when synchronizing layer order.

Relates #2178

## Testing
Almost none.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2184)
<!-- Reviewable:end -->
