### PR TITLE
fix(ui): remove full screen option if not supported

### DIFF
--- a/src/app/core/common.service.js
+++ b/src/app/core/common.service.js
@@ -38,9 +38,15 @@ function common($timeout, $q) {
      */
     function intersect(array1 = [], array2 = []) {
         return array1.filter(item =>
-                array2.indexOf(item) !== -1);
+            array2.indexOf(item) !== -1);
     }
 
+    /**
+     * Removes an item from an array if found
+     *
+     * @param {Array} array an array to remove the item from
+     * @param {String|Number|Object} name a string|number|object to remove from the provided array
+     */
     function removeFromArray(array, name) {
         let index = array.indexOf(name);
         if (index !== -1) {

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1,3 +1,5 @@
+import screenfull from 'screenfull';
+
 /**
  * @module ConfigObject
  * @memberof app.core
@@ -1820,7 +1822,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
 
             // remove help if help or its folderName is absent
             if (! helpSource || ! helpSource.folderName) {
-                this._extra.splice(this._extra.indexOf('help'));
+                common.removeFromArray(this._extra, 'help');
             }
         }
 
@@ -1869,9 +1871,9 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                 source.items.map(subItems =>
                     common.intersect(source.items, SideMenu.AVAILABLE_ITEMS)) : angular.copy(ITEMS_DEFAULT);
 
-            //remove help if help or its folderName is absent
+            // remove help if help or its folderName is absent
             if (! helpSource || ! helpSource.folderName) {
-                this._items[1].splice(this._items[1].indexOf('help'), 1);
+                common.removeFromArray(this.items[1], 'help');
             }
         }
 
@@ -2101,6 +2103,16 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             // set geoSearch.enable to false if it was false initialy or does not have all services
             this.map.components.geoSearch.enabled = this.map.components.geoSearch.enabled
                 && hasAllSearchServices(this.services.search);
+
+            // remove fullscreenoption if fullscreen functionality is not available
+            if (!screenfull.enabled) {
+                const optionName = 'fullscreen';
+
+                this.ui.sideMenu.items.forEach(section =>
+                    common.removeFromArray(section, optionName));
+
+                common.removeFromArray(this.ui.navBar.extra, optionName);
+            }
 
             /**
              * Return true if all search services are included in the config file, false otherwise

--- a/src/app/ui/common/full-screen.service.js
+++ b/src/app/ui/common/full-screen.service.js
@@ -48,7 +48,11 @@ function fullScreenService($rootElement, $timeout, layoutService, gapiService, a
         isFullPageApp: configService.getAsync.then(conf => conf.fullscreen)
     };
 
-    screenfull.onchange(() => toggle(true));
+    if (screenfull.enabled) {
+        screenfull.onchange(() => toggle(true));
+    } else {
+        service.toggle = angular.noop;
+    }
 
     return service;
 

--- a/src/app/ui/mapnav/mapnav.service.js
+++ b/src/app/ui/mapnav/mapnav.service.js
@@ -18,7 +18,7 @@ angular
  * @return {object} service object
  */
 function mapNavigationService(stateManager, geoService, $rootScope, locateService,
-helpService, basemapService, events, fullScreenService) {
+    helpService, basemapService, events, fullScreenService) {
 
     const service = {
         controls: {}
@@ -30,7 +30,6 @@ helpService, basemapService, events, fullScreenService) {
             label: 'sidenav.label.fullscreen',
             icon: 'navigation:fullscreen',
             tooltip: 'sidenav.label.fullscreen',
-            visible: fullScreenService.isFullPageApp,
             action: () => fullScreenService.toggle(false)
         },
         zoomIn: {

--- a/src/app/ui/sidenav/sidenav.service.js
+++ b/src/app/ui/sidenav/sidenav.service.js
@@ -127,7 +127,6 @@ function sideNavigationService($mdSidenav, $rootScope, $rootElement, globalRegis
             type: 'link',
             label: 'sidenav.label.fullscreen',
             icon: 'navigation:fullscreen',
-            isHidden: false,
             isChecked: fullScreenService.isExpanded,
             action: () => fullScreenService.toggle(false)
         },


### PR DESCRIPTION
## Description
Safair iOS doesn't not support full-screen; the library fails when invoked somehow causing all md-icons to fail.

Closes #2187

## Testing
Eyeballs on browserstack.

## Documentation
Nope.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2191)
<!-- Reviewable:end -->
