### PR TITLE
fix(datatable): debounce when closing twice

### DIFF
--- a/src/app/ui/panels/panel.directive.js
+++ b/src/app/ui/panels/panel.directive.js
@@ -55,13 +55,13 @@ function rvPanel(layoutService) {
  * Skeleton controller function.
  * @function Controller
  */
-function Controller($attrs, stateManager, layoutService, $element) {
+function Controller($attrs, stateManager, layoutService, $element, debounceService) {
     'ngInject';
     const self = this;
 
     layoutService.panels[$attrs.type] = $element;
 
-    self.closePanel = self.closeButton !== 'false' ? closePanel : undefined;
+    self.closePanel = self.closeButton !== 'false' ? closePanel() : undefined;
 
     /**
      * Temporary function to close the panel.
@@ -69,6 +69,8 @@ function Controller($attrs, stateManager, layoutService, $element) {
      * FIXME: this should be handled in the shatehelper
      */
     function closePanel() {
-        stateManager.setActive($attrs.type);
+        return debounceService.registerDebounce(() => {
+            stateManager.setActive($attrs.type);
+        });
     }
 }

--- a/src/app/ui/table/table-default.directive.js
+++ b/src/app/ui/table/table-default.directive.js
@@ -548,53 +548,55 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
             function onTableInit() {
                 // turn off loading indicator after the table initialized or the forced delay whichever takes longer; cancel loading timeout as well
                 forcedDelay.then(() => {
-                    // TODO: these ought to be moved to a helper function in displayManager
-                    stateManager.display.table.isLoading = false;
-                    $timeout.cancel(stateManager.display.table.loadingTimeout);
+                    if (self.tableBody) {
+                        // TODO: these ought to be moved to a helper function in displayManager
+                        stateManager.display.table.isLoading = false;
+                        $timeout.cancel(stateManager.display.table.loadingTimeout);
 
-                    // set header focusable
-                    const header = el.find('.dataTables_scrollHead th');
-                    header.slice(2, header.length).attr('tabindex', '-2');
+                        // set header focusable
+                        const header = el.find('.dataTables_scrollHead th');
+                        header.slice(2, header.length).attr('tabindex', '-2');
 
-                    // blur the focused cell on scroll so focus manager/datatables doesn't try to go back to the row
-                    // DOMMouseScroll (FF), mousewheel (Chrome, Safari and IE)
-                    self.tableBody.on('mousewheel DOMMouseScroll', () => {
-                        if (typeof index !== 'undefined') {
-                            self.table.cell(index.row, index.column).node().blur();
-                            index = undefined;
-                        }
-                    });
+                        // blur the focused cell on scroll so focus manager/datatables doesn't try to go back to the row
+                        // DOMMouseScroll (FF), mousewheel (Chrome, Safari and IE)
+                        self.tableBody.on('mousewheel DOMMouseScroll', () => {
+                            if (typeof index !== 'undefined') {
+                                self.table.cell(index.row, index.column).node().blur();
+                                index = undefined;
+                            }
+                        });
 
-                    // focus on close button when table open (wcag requirement)
-                    // at the same time it solve a problem because when focus is on menu button, even if focus is on the
-                    // table cell it goes inside the menu and loop through it at the same time as we navigate the table
-                    $rootElement.find('[type=\'table\'] button.rv-close').rvFocus({ delay: 100 });
+                        // focus on close button when table open (wcag requirement)
+                        // at the same time it solve a problem because when focus is on menu button, even if focus is on the
+                        // table cell it goes inside the menu and loop through it at the same time as we navigate the table
+                        $rootElement.find('[type=\'table\'] button.rv-close').rvFocus({ delay: 100 });
 
-                    // set table is initialize. Things that need to be done only once will be avoid at the next creation
-                    displayData.filter.isInit = true;
+                        // set table is initialize. Things that need to be done only once will be avoid at the next creation
+                        displayData.filter.isInit = true;
 
-                    // set colReorder extension
-                    setColumnReorder();
+                        // set colReorder extension
+                        setColumnReorder();
 
-                    // initialize a temporary array to store all the custom filters so they don't fire every time we add new one
-                    $.fn.dataTable.ext.searchTemp = [];
+                        // initialize a temporary array to store all the custom filters so they don't fire every time we add new one
+                        $.fn.dataTable.ext.searchTemp = [];
 
-                    // set active table so it can be accessed in filter-search.directive for global table search
-                    tableService.setTable(self.table, displayData.filter.globalSearch);
+                        // set active table so it can be accessed in filter-search.directive for global table search
+                        tableService.setTable(self.table, displayData.filter.globalSearch);
 
-                    // recalculate scroller space on table init because if the preopen table was maximized in setting view
-                    // the scroller is still in split view
-                    self.table.scroller.measure();
+                        // recalculate scroller space on table init because if the preopen table was maximized in setting view
+                        // the scroller is still in split view
+                        self.table.scroller.measure();
 
-                    // wrap the title inside a span so when we need to change it when global search is focused, there is no impact on the filters
-                    angular.element(tableService.getTable().header()).find('th').each((i, el) => {
-                        const title = el.innerHTML;
-                        el.innerHTML = '';
-                        el.append(angular.element(`<span title="${title}" data-rv-column="${title}">${title}</span>`)[0]);
-                    });
+                        // wrap the title inside a span so when we need to change it when global search is focused, there is no impact on the filters
+                        angular.element(tableService.getTable().header()).find('th').each((i, el) => {
+                            const title = el.innerHTML;
+                            el.innerHTML = '';
+                            el.append(angular.element(`<span title="${title}" data-rv-column="${title}">${title}</span>`)[0]);
+                        });
 
-                    // fired event to create filters
-                    events.$broadcast(events.rvTableReady);
+                        // fired event to create filters
+                        events.$broadcast(events.rvTableReady);
+                    }
                 });
             }
 


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2040 Fixes the issues when close button on the data table was clicked twice quickly when the table was still loading

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Manually, using all the muscle power I had to click the closing button twice on time
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2194)
<!-- Reviewable:end -->
