### PR TITLE
fix(ui): bind wms results as html

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "^1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "^1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v0.0.0-protoLR-81",
+    "geoApi": "github:fgpv-vpgf/geoApi#v0.0.0-protoLR-82",
     "gsap": "^1.19.1",
     "jquery": "^2.2.1",
     "jquery-hoverintent": "^1.8.2",

--- a/src/app/ui/details/details-record-html.html
+++ b/src/app/ui/details/details-record-html.html
@@ -1,1 +1,1 @@
-<rv-svg class="rv-details-html" src="self.item.data[0]" once="false"></rv-svg>
+<div class="rv-details-text" ng-bind-html="self.item.data[0]"></div>


### PR DESCRIPTION
## Description
WMS results are directly bind into the template.

Test layer: http://geo.weather.gc.ca/geomet/
Expected result:
![](https://i.imgur.com/7ozJDfz.png)

Test layer: http://maps.geogratis.gc.ca/wms/railway_en
Expected result:
![](https://i.imgur.com/JqoKE5u.png)

Closes #2196

## Testing
Eyeballs.

## Documentation
Nope.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ unreleased bug
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2197)
<!-- Reviewable:end -->
