### PR TITLE
fix(ui): prevent feature highlight from blocking hovertips

### DIFF
--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -2104,7 +2104,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             this.map.components.geoSearch.enabled = this.map.components.geoSearch.enabled
                 && hasAllSearchServices(this.services.search);
 
-            // remove fullscreenoption if fullscreen functionality is not available
+            // remove fullscreen option if fullscreen functionality is not available
             if (!screenfull.enabled) {
                 const optionName = 'fullscreen';
 

--- a/src/app/ui/geosearch/geosearch-bar.html
+++ b/src/app/ui/geosearch/geosearch-bar.html
@@ -36,4 +36,9 @@
         <md-tooltip>{{ 'appbar.aria.geosearchclose' | translate }}</md-tooltip>
         <md-icon md-svg-src="navigation:close"></md-icon>
     </md-button>
+
+    <md-progress-linear
+            class="rv-progress-bottom"
+            md-mode="indeterminate"
+            ng-show="self.service.isLoading"></md-progress-linear>
 </div>

--- a/src/app/ui/geosearch/geosearch.html
+++ b/src/app/ui/geosearch/geosearch.html
@@ -6,11 +6,6 @@
 
     <div class="rv-geosearch-results">
 
-        <md-progress-linear
-            class="rv-progress-top"
-            md-mode="indeterminate"
-            ng-show="self.service.isLoading"></md-progress-linear>
-
         <span class="rv-no-results" ng-if="self.service.noResultsSearchValue">{{ 'geosearch.nomatches.label' | translate:self.service }}</span>
 
         <ul class="rv-results-list">

--- a/src/content/styles/vendor/_esri.scss
+++ b/src/content/styles/vendor/_esri.scss
@@ -10,8 +10,11 @@
 @mixin map {
     // makes bounding box ignore any mouse events and allow for hover tips to be triggered on feature layers underneath the bbox    .rv-esri-map.map {
     // it seems that in 3.20 `layersDiv` class was changed to `esriMapLayers`
-    .esriMapLayers g[id$="bbox_layer"] {
-        pointer-events: none;
+    // allow mouse events through feature highlights: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2189
+    .esriMapLayers g {
+        &[id$="bbox_layer"], &[id="rv_hilight_layer"] {
+            pointer-events: none;
+        }
     }
 
     // no idea what this is, but it seems we don't need this


### PR DESCRIPTION
## Description
- [bug #2189] Allow mouse events through feature highlights.
- [undocumented enhancement] move geosearch progress bar from the results panel to the search bar itself

Closes #2189 

## Testing
Eyeballs.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2198)
<!-- Reviewable:end -->
