### PR TITLE
fix(IE): remove extra clear button in filter

### DIFF
--- a/src/content/styles/vendor/_angularmaterial.scss
+++ b/src/content/styles/vendor/_angularmaterial.scss
@@ -19,5 +19,10 @@ md-input-container {
     &.rv-table-search {
         display: flex;
         align-items: center;
+
+        // remove clear button rendered by IE;
+        input::-ms-clear {
+            display: none;
+        }
     }
 }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2181 Remove the extra clear button in the filter on the data table.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Manually
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2218)
<!-- Reviewable:end -->
