### PR TITLE
fix(focusManager): new attribute and logic changes

### DIFF
--- a/docs/developer/technical/focus_manager.md
+++ b/docs/developer/technical/focus_manager.md
@@ -12,6 +12,7 @@ To be accessible and WCAG 2 compliant, the viewer needs to support keyboard user
 | rv-focus-init         |  Allows the use of focus() on the viewer element with this attribute or any of its children if focus is not current on the element or any of its children. This allows outside libraries to set initial focus normally, yet restricts them on subsequent movement attempts.
 | rv-focus-member | Declares an element and all its children are a part of the viewer. Unlike rv-focus-trap, focus is not trapped inside these elements. The most common use case is for elements rendered outside the viewers DOM structure where we do not want to control focus - we only wish to recognize that it is a part of the viewer so that action taken within it do not deactivate the focus manager.  |
 | rv-focus-exempt | Declares an element and all its children to be exempt from setting their own focus. This has no effect on the normal flow of focus by the FM.  |
+| rv-focus | **Available within md-dialog elements only.** Default behaviour when a dialog opens is to focus on the close button. When `rv-focus` is present on an element, focus is instead moved to that element.|
 
 
 #### Important concepts you should know

--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -616,6 +616,11 @@ HTMLElement.prototype.rvFocus = $.fn.rvFocus = function (opts = {}) {
         return;
     }
 
+    // Calling rvFocus implies the viewer should be active
+    viewerGroup
+        .contains(jqueryElem)
+        .setStatus(statuses.ACTIVE);
+
     // clear any delayed focus movements
     clearTimeout(focusoutTimerCancel);
 

--- a/src/app/ui/common/dialog.decorator.js
+++ b/src/app/ui/common/dialog.decorator.js
@@ -41,9 +41,13 @@ function mdDialog($delegate, $q) {
                     .attr('rv-trap-focus', '')
                     .removeAttr('tabindex');
 
-                // if an element with property rv-close-button exists we set focus on it. Sometimes the close button is
-                // not the first focusable element, but in most cases it should be the first focused element
-                if (opts.focusOnOpen) {
+                // rv-focus attribute in dialogs bypasses default focus to close behaviour
+                const rvFocus = element.find('rv-focus');
+                if (rvFocus) {
+                    rvFocus.first().rvFocus();
+                } else if (opts.focusOnOpen) {
+                    // if an element with property rv-close-button exists we set focus on it. Sometimes the close button is
+                    // not the first focusable element, but in most cases it should be the first focused element
                     const closeBtn = $(element).find('[rv-close-button]');
                     if (closeBtn.length === 0) {
                         element.nextFocus();

--- a/src/app/ui/sidenav/share-dialog.html
+++ b/src/app/ui/sidenav/share-dialog.html
@@ -6,7 +6,7 @@
         </md-switch>
 
             <md-input-container class="md-block" flex-gt-xs>
-                <input class="rv-shareLink" type="text" ng-model="self.url" readonly md-select-on-focus/>
+                <input class="rv-shareLink" type="text" ng-model="self.url" readonly md-select-on-focus rv-focus />
                 <span>{{'sidenav.label.copy' | translate}}</span>
           </md-input-container>
 


### PR DESCRIPTION
## Description
- Calling rvFocus sets the viewer to ACTIVE state.
- New rv-focus attribute now available to children of md-dialog. Focus moves to rv-focus element instead of close button. If needed this attribute can be expanded to other element types in the future as an alternative to manual rvFocus invocations.

Closes #2170, #2186

## Testing
![Eagle Eyes](https://thumb7.shutterstock.com/display_pic_with_logo/825202/825202,1321678172,1/stock-vector-cartoon-vector-mascot-image-of-an-eagle-eyes-89100340.jpg)

## Documentation
jsdocs, inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2219)
<!-- Reviewable:end -->
