### PR TITLE
fix(core): remove identify result watchs

### DIFF
--- a/src/app/ui/details/details.directive.js
+++ b/src/app/ui/details/details.directive.js
@@ -74,7 +74,11 @@ function Controller($scope, $element, events, stateManager, mapService, detailSe
         self.display.selectedItem = self.selectedItem;
     }
 
+    let deRegisterFirstResultWatch = angular.noop;
+
     $scope.$watch('self.display.data', (newValue, oldValue) => {
+        deRegisterFirstResultWatch();
+
         // if multiple points added to the details panel ...
         if (newValue && newValue.length > 0) {
 
@@ -87,12 +91,12 @@ function Controller($scope, $element, events, stateManager, mapService, detailSe
                 selectItem(newValue[0]);
             } else {
                 // otherwise, wait for the first item to get results and select that
-                const deRegister = $scope.$watch(_waitForFirstResult, item => {
+                deRegisterFirstResultWatch = $scope.$watch(_waitForFirstResult, item => {
                     if (!item) {
                         return;
                     }
 
-                    deRegister();
+                    deRegisterFirstResultWatch();
                     // if the user alreayd selected an item, do not override the selection
                     if (self.selectedItem) {
                         return;


### PR DESCRIPTION
## Description
A watch for the first identify result to be resolved wasn't removed correctly, causing endless errors.

Closes #2225

## Testing
:beholder:

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- ~~[ ] release notes have been updated~~ unreleased bug
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2227)
<!-- Reviewable:end -->
