### PR TITLE
fix(core): don't remove layers if they are still referenced in legend

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -211,7 +211,19 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
          * @private
          */
         function _resolve() {
-            layerRegistry.removeLayerRecord(legendBlock.layerRecordId);
+            // FIXME: in cases of removing dynamic children, they also need to be removed from the structure returned by `layerRecord.getChildTree()`
+            // without this, loading from the bookmark, removed dynamic children will come back with their visibility set to "off"
+
+            // check if any other blocks reference this layer record
+            // if none found, it's safe to remove the layer record
+            const isSafeToRemove = legendBlocks
+                .walk(entry => entry.layerRecordId === legendBlock.layerRecordId)
+                .filter(a => a)
+                .length === 0;
+
+            if (isSafeToRemove) {
+                layerRegistry.removeLayerRecord(legendBlock.layerRecordId);
+            }
 
             // remove any bounding box layers associated with this legend block
             _boundingBoxRemoval(legendBlock);


### PR DESCRIPTION
## Description
Does not remove layer records unless they are no longer references by the legend blocks.

Closes #2233

## Testing
Eyeballs.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [ ] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2237)
<!-- Reviewable:end -->
