### PR TITLE
fix(datatable): date columns are now sortable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ before_install:
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
 
-script:
-  - npm run protractor
-
 after_success:
   - source ./scripts/devdeploy.sh
   - source ./scripts/docdeploy.sh

--- a/src/app/ui/table/table-default.directive.js
+++ b/src/app/ui/table/table-default.directive.js
@@ -110,7 +110,7 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
             number: {
                 init: () => ({ min: '', max: '', static: false })
             },
-            date: {
+            'rv-date': {
                 init: () => ({ min: null, max: null, static: false })
             }
         };
@@ -165,6 +165,9 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
 
             // initialize columns
             const order = initColumns();
+
+            // define pre-deformatting function for date columns
+            $.fn.dataTable.ext.order['rv-date-pre'] = d => parseInt(d.replace(/\D/g,''));
 
             // ~~I hate DataTables~~ Datatables are cool!
             self.table = tableNode
@@ -294,7 +297,7 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
                                 displayData.rows.forEach(r => { r[field.name] = $filter('dateTimeZone')(r[field.name]) });
                                 const width = getColumnWidth(column.title, 0, 400, 375);
                                 column.width =  `${width}px`;
-                                column.type = 'date';
+                                column.type = 'rv-date';
                             } else {
                                 const width = getColumnWidth(column.title, 0, 250, 120);
                                 column.width = `${width}px`;

--- a/src/app/ui/table/table-definition.directive.js
+++ b/src/app/ui/table/table-definition.directive.js
@@ -36,7 +36,7 @@ const FILTERS = {
             prevent: angular.noop
         }
     },
-    date: {
+    'rv-date': {
         name: 'rv-filter-date',
         scope: null,
         self: {
@@ -99,7 +99,7 @@ const FILTERS_TEMPLATE = {
                         ng-disabled="self.${column}.static" />
             </md-input-container>
         </div>`,
-    date: column =>
+    'rv-date': column =>
         `<div class="rv-filter-date" ng-show="self.${column}.filtersVisible">
             <md-datepicker
                 ng-click="self.prevent($event)"
@@ -166,7 +166,7 @@ function rvTableDefinition(stateManager, events, $compile, tableService, layoutS
             number: {
                 callback: 'onFilterNumberChange'
             },
-            date: {
+            'rv-date': {
                 callback: 'onFilterDateChange'
             }
         };
@@ -221,7 +221,7 @@ function rvTableDefinition(stateManager, events, $compile, tableService, layoutS
                         // set string filter from existing value
                         if (column.type === 'number') {
                             setNumberFilter(filterInfo.scope, i);
-                        } else if (column.type === 'date') {
+                        } else if (column.type === 'rv-date') {
                             setDateFilter(filterInfo.scope, i);
                         } else if (column.type === 'string') {
                             const val = `^${column.filter.value.replace(/\*/g, '.*')}.*$`;

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -179,7 +179,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
                     } else if (column.type === 'number') {
                         column.filter.min = '';
                         column.filter.max = '';
-                    } else if (column.type === 'date') {
+                    } else if (column.type === 'rv-date') {
                         column.filter.min = null;
                         column.filter.max = null;
                     }
@@ -277,7 +277,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
             if (max !== '') {
                 defs.push(`${column.name} <= ${max}`);
             }
-        } else if (column.type === 'date') {
+        } else if (column.type === 'rv-date') {
             const min = column.filter.min;
             const max = column.filter.max;
 


### PR DESCRIPTION
## Description
Note that `column.type` changed from `date` to `rv-date` as `date` type has built-in sorting (which does not work for our date format)

Closes #2200

## Testing
![eagle eyes](https://user-images.githubusercontent.com/10187181/28522408-ec80ab84-7045-11e7-8898-f65c2c8daf25.png)

## Documentation
inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] commits messages follow the guidelines
- [x] code passes unit tests
- [x] release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2242)
<!-- Reviewable:end -->
