### PR TITLE
Bookmark ignores loading children

### DIFF
--- a/src/app/core/bookmark.service.js
+++ b/src/app/core/bookmark.service.js
@@ -209,11 +209,24 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
         };
         const layerCode = typeToCode[layerDefinition.layerType];
 
+        // determines what states we should inspect dynamic children
+        // for bookmark. if not loaded & stable, we ignore children
+        // and let them go back to default when bookmark loads
+        const goodState = state => {
+            switch (state) {
+                case Geo.Layer.States.ERROR:
+                case Geo.Layer.States.LOADING:
+                case Geo.Layer.States.NEW:
+                    return false;
+                default:
+                    return true;
+            }
+        };
+
         // Children Info (calculate first so we have the count when doing layer settings)
         let childItems = [];
-        // errored dynamic layers have no child tree, skip this step
         if (layerCode === typeToCode[types.ESRI_DYNAMIC] && layerDefinition.layerEntries &&
-            layerRecord.state !== Geo.Layer.States.ERROR) {
+            goodState(layerRecord.state)) {
 
             // walk the child tree encoding each child
             // we need to be aware of hierarchy here (at least on the top level).

--- a/src/content/styles/modules/_geosearch.scss
+++ b/src/content/styles/modules/_geosearch.scss
@@ -107,6 +107,7 @@ $result-item-height-touch: rem(4.8);
                         padding: 0 18px;
 
                         .rv-results-item-tooltip {
+                            top: 0;
                             display: flex;
                             position: absolute;
                             background-color:  $divider-color-light;


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2226
Ignores dynamic children of layers in non-stable states (loading, error) when generating bookmark.

Also re-adds lost commit `fix(geoSearch): make hovered results readable`

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Tested against app by generating bookmarks in various stages of layer-load

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2268)
<!-- Reviewable:end -->
