### PR TITLE
feat(ui): add opt description to legend blocks

### DIFF
--- a/schemas/fgpv_schema_v2_0_0.json
+++ b/schemas/fgpv_schema_v2_0_0.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "FGPV Config Schema",
     "type": "object",
-    "version": 2.1,
+    "version": 2.0,
     "comments": "FIXME: when draft 05 is release redo schema inheritance with patching / merging if they are accepted",
     "additionalProperties": false,
 
@@ -125,8 +125,7 @@
                 "id": { "type": "string", "description": "A unique id identifying a tile schema (combination of an extent set and a zoom scale)" },
                 "name": { "type": "string", "description": "The name to display in the basemap selector for the set of basemaps referencing this schema" },
                 "extentSetId": { "type": "string", "description": "The extent set to be used for this basemap (should reference map.extentSets.id)" },
-                "lodSetId": { "type": "string", "description": "Optional.  The level of details set to be used for this basemap (should reference map.lod.id)" },
-                "overviewUrl": { "$ref": "#/definitions/basicLayerNode", "description": "Optional. If set, the overview map will use this layer instead of the active basemap" }
+                "lodSetId": { "type": "string", "description": "Optional.  The level of details set to be used for this basemap (should reference map.lod.id)" }
             },
             "required": ["extentSetId", "lodSetId", "id", "name"],
             "additionalProperties": false
@@ -309,7 +308,6 @@
                 "entryIndex": {"type": "integer", "description": "Index of the 'sublayer' in the case of an ESRI dynamic layer.  This cannot point to an entry with stateOnly:true ."},
                 "entryId": {"type": "string", "description": "Id of the 'sublayer' in the case of an OGC WMS layer"},
                 "coverIcon": {"type": "string", "description": "An optional icon, if present it will be used to primarily represent the layer"},
-                "description": {"type": "string", "default": "", "description": "Optional description displayed above the symbology stack."},
                 "symbologyStack": { "$ref": "#/definitions/symbologyStack" },
                 "symbologyRenderStyle": {"type":"string", "enum": [ "icons", "images" ], "description": "An optional style, describes how the symbology stack should be rendered"}
             },
@@ -339,7 +337,6 @@
                     "properties": {
                         "infoType": { "type": "string", "enum": [ "unboundLayer" ] },
                         "layerName": {"type": "string", "description": "Name to display in legend"},
-                        "description": {"type": "string", "default": "", "description": "Optional description displayed above the symbology stack."},
                         "symbologyStack": { "$ref": "#/definitions/symbologyStack" },
                         "symbologyRenderStyle": {"type":"string", "enum": [ "icons", "images" ], "description": "An optional style, describes how the symbology stack should be rendered"}
                     },
@@ -670,10 +667,10 @@
         "mapComponentsNode": {
             "type": "object",
             "properties": {
-                "geoSearch": { "type": "object", "properties": { "enabled": { "type": "boolean" }, "showGraphic": { "type": "boolean" }, "showInfo": { "type": "boolean" }}},
+                "geoSearch": { "type": "object", "properties": { "enabled": {"type": "boolean" }, "showGraphic": { "type": "boolean" }, "showInfo": { "type": "boolean" }}},
                 "mouseInfo": { "type": "object", "properties": { "spatialReference": { "$ref": "#/definitions/spatialReferenceNode" } }},
                 "northArrow": { "type": "object" },
-                "overviewMap": { "type": "object", "properties": { "enabled": { "type": "boolean" }, "expandFactor": { "type": "number", "default": 2 }}},
+                "overviewMap": { "type": "object" },
                 "scaleBar": { "type": "object" },
                 "basemap": { "type": "object" }
             },

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1124,6 +1124,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             this._entryIndex = entrySource.entryIndex;
             this._entryId = entrySource.entryId;
             this._coverIcon = entrySource.coverIcon;
+            this._description = entrySource.description || '';
             this._symbologyStack = entrySource.symbologyStack || [];
             this._symbologyRenderStyle = entrySource.symbologyRenderStyle || Entry.ICONS;
             this._hidden = entrySource.hidden === true;
@@ -1133,11 +1134,12 @@ function ConfigObjectFactory(Geo, gapiService, common) {
         static ICONS = 'icons';
         static IMAGES = 'images';
 
-        get layerId () { return this._layerId; }
-        get controlledIds () { return this._controlledIds; }
-        get entryIndex () { return this._entryIndex; }
-        get entryId () { return this._entryId; }
-        get coverIcon () { return this._coverIcon; }
+        get layerId () {        return this._layerId; }
+        get controlledIds () {  return this._controlledIds; }
+        get entryIndex () {     return this._entryIndex; }
+        get entryId () {        return this._entryId; }
+        get coverIcon () {      return this._coverIcon; }
+        get description () {    return this._description; }
         get symbologyStack () { return this._symbologyStack; }
 
         get symbologyRenderStyle () { return this._symbologyRenderStyle; }
@@ -1160,6 +1162,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                 entryIndex: this.entryIndex,
                 entryId: this.entryId,
                 coverIcon: this.coverIcon,
+                description: this.description,
                 symbologyStack: this.symbologyStack,
                 symbologyRenderStyle: this.symbologyRenderStyle,
                 hidden: this.hidden,
@@ -1232,6 +1235,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             this._content = entrySource.content;
 
             this._layerName = entrySource.layerName || '';
+            this._description = entrySource.description || '';
             this._symbologyStack = entrySource.symbologyStack || [];
             this._symbologyRenderStyle = entrySource.symbologyRenderStyle || Entry.ICONS;
         }
@@ -1240,6 +1244,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
         get content () {                return this._content; }
 
         get layerName () {              return this._layerName; }
+        get description () {            return this._description; }
         get symbologyStack () {         return this._symbologyStack; }
         get symbologyRenderStyle () {   return this._symbologyRenderStyle; }
 
@@ -1251,6 +1256,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                 content: this.content,
                 entryType: this.entryType,
                 layerName: this.layerName,
+                description: this.description,
                 symbologyStack: this.symbologyStack,
                 symbologyRenderStyle: this.symbologyRenderStyle
             };

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -303,6 +303,7 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
         get content () {                return this.blockConfig.content; }
 
         get layerName () {              return this.blockConfig.layerName; }
+        get description () {            return this.blockConfig.description; }
         get symbologyStack () {         return this._symbologyStack; }
         get symbologyRenderStyle () {   return this.blockConfig.symbologyRenderStyle; }
     }
@@ -601,6 +602,7 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
          */
         fetchGraphic(oid) {         return this._mainProxyWrapper.fetchGraphic(oid); }
 
+        get description () {        return this.blockConfig.description; }
         get symbologyStack () {     return this._symbologyStack; }
 
         get metadataUrl () {        return this._mainProxyWrapper.metadataUrl; }

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -4,6 +4,7 @@ const templateUrl = require('./templates/symbology-stack.html');
 const RV_SYMBOLOGY_ITEM_CLASS = '.rv-symbol';
 const RV_SYMBOLOGY_ITEM_NAME_CLASS = '.rv-symbol-label';
 const RV_SYMBOLOGY_ITEM_TRIGGER = '.rv-symbol-trigger';
+const RV_DESCRIPTION_ITEM = '.rv-description-container';
 
 const RV_DURATION = 0.3;
 const RV_SWIFT_IN_OUT_EASE = Power1;
@@ -42,8 +43,7 @@ function rvSymbologyStack($q, Geo, animationService) {
         templateUrl,
         scope: {
             symbology: '=',
-            // stack: '=',
-            // symbology.renderStyle: '=?',
+            description: '=?',
             container: '=?'
         },
         link: link,
@@ -74,6 +74,8 @@ function rvSymbologyStack($q, Geo, animationService) {
             expandTimeline: null, // expand/collapse animation timeline
             fanOutTimeline: null, // wiggle animation timeline
 
+            descriptionItem: null,
+
             // store reference to symbology nodes
             // the following are normal arrays of jQuery items, NOT jQuery pseudo-arrays
             symbolItems: [],
@@ -83,6 +85,10 @@ function rvSymbologyStack($q, Geo, animationService) {
             containerWidth: 350,
             maxItemWidth: 350
         };
+
+        // description persist, so need to store reference only once
+        ref.descriptionItem = element.find(RV_DESCRIPTION_ITEM);
+        ref.descriptionItem.css('width', ref.containerWidth)
 
         scope.$watchCollection('self.symbology.stack', (newStack, oldStack) => {
             if (newStack) {
@@ -100,17 +106,6 @@ function rvSymbologyStack($q, Geo, animationService) {
 
         scope.$watch('self.symbology.fannedOut', (newValue, oldValue) =>
             newValue !== oldValue ? self.fanOutSymbology(newValue) : angular.noop);
-
-
-        /* this should not be needed after all
-        const eventNameToAction = {
-            fanOut: self.fanOutSymbology,
-            expand: self.expandSymbology
-        };
-
-        scope.$on('symbology', (event, name, value) =>
-            eventNameToAction[name](value));
-        */
 
         return true;
 
@@ -223,11 +218,37 @@ function rvSymbologyStack($q, Geo, animationService) {
             });
 
             // in pixels
-            const symbologyListTopOffset = 48; // offset to cover the height of the legend entry nod
+            const symbologyListTopOffset = 48; // offset to cover the height of the legend entry node
             const symbologyListMargin = 16; // gap between the legend endtry and the symbology stack
 
             // keep track of the total height of symbology stack so far
             let totalHeight = symbologyListTopOffset + symbologyListMargin;
+
+            // optional description is displayed above the symbology items
+            if (self.description !== '') {
+                totalHeight -= symbologyListMargin / 2;
+
+                // briefly show the description node to grab it's height, and hide it again
+                ref.descriptionItem.show();
+                const descriptionHeight = ref.descriptionItem.height();
+                ref.descriptionItem.hide();
+
+                // move the node into position unhiding it (it's still invisible beacuse opacity is 0)
+                timeline.set(ref.descriptionItem, {
+                    display: 'block',
+                    top: totalHeight - 30
+                });
+
+                // show and animate description node
+                timeline.to(ref.descriptionItem, RV_DURATION / 3 * 2, {
+                    opacity: 1,
+                    top: totalHeight,
+                    ease: RV_SWIFT_IN_OUT_EASE
+                }, RV_DURATION / 3);
+
+                // include the description height in the total height of the symbology stack
+                totalHeight += descriptionHeight + symbologyListMargin;
+            }
 
             // future-proofing - in case we need different behaviours for other legend types
             const legendItemTLgenerator = {
@@ -285,9 +306,10 @@ function rvSymbologyStack($q, Geo, animationService) {
                 }, 0);
 
                 // wiggle the last icon in the stack
-                timeline.to(ref.symbolItems.slice(-1)
-                    .pop()
-                    .container, RV_DURATION, {
+                timeline.to(
+                    ref.symbolItems.slice(-1).pop().container,
+                    RV_DURATION,
+                    {
                         x: `+=${displacement}px`,
                         y: `+=${displacement}px`,
                         ease: RV_SWIFT_IN_OUT_EASE
@@ -433,7 +455,6 @@ function rvSymbologyStack($q, Geo, animationService) {
 }
 
 function symbologyStack(ConfigObject, gapiService) {
-
 
     class SymbologyStack {
         /**

--- a/src/app/ui/toc/templates/legend-info.html
+++ b/src/app/ui/toc/templates/legend-info.html
@@ -8,6 +8,7 @@
 
     <div ng-switch-when="unboundLayer">
         <rv-symbology-stack
+            description="self.block.description"
             symbology="self.block.symbologyStack"
             container="self.element"></rv-symbology-stack>
 

--- a/src/app/ui/toc/templates/legend-node.html
+++ b/src/app/ui/toc/templates/legend-node.html
@@ -9,6 +9,7 @@
 </div>
 
 <rv-symbology-stack
+    description="self.block.description"
     symbology="self.block.symbologyStack"
     container="self.element"></rv-symbology-stack>
 

--- a/src/app/ui/toc/templates/symbology-stack.html
+++ b/src/app/ui/toc/templates/symbology-stack.html
@@ -1,6 +1,10 @@
 <div
     class="rv-symbology-container rv-render-{{ self.symbology.renderStyle }}"
-    ng-class='[{ "rv-expanded" : self.isExpanded }, { "rv-compound" : self.symbology.stack.length > 1 } ]'>
+    ng-class='[{ "rv-expanded" : self.isExpanded }, { "rv-compound" : self.symbology.stack.length > 1 }]'>
+
+    <div class="rv-description-container">
+        <span class="rv-description">{{ ::self.description }}</span>
+    </div>
 
     <div class="rv-symbol" ng-repeat="symbol in self.symbology.stack | rvReverse">
         <rv-svg class="rv-symbol-graphic" src="symbol.svgcode"></rv-svg>

--- a/src/content/samples/config-mobile-2.json
+++ b/src/content/samples/config-mobile-2.json
@@ -322,10 +322,12 @@
             "layerId": "scaleDep",
             "controlledIds": [
               "ecogeo", "powerplant100mw-25"
-            ]
+            ],
+            "description": "Ozone's odour is sharp, reminiscent of chlorine, and detectable by many people at concentrations of as little as 100 ppb in air. Ozone's O3 structure was determined in 1865."
           },
           {
-            "layerId": "DateLayer"
+            "layerId": "DateLayer",
+            "description": "Ozone is a powerful oxidant (far more so than dioxygen) and has many industrial and consumer applications related to oxidation."
           },
           {
             "layerId": "powerplant100mw-24",

--- a/src/content/styles/modules/_symbology.scss
+++ b/src/content/styles/modules/_symbology.scss
@@ -1,6 +1,6 @@
 @mixin symbology {
     // item in the symbology list
-    @include layer-item-symbology;
+    // @include layer-item-symbology;
 
     $icon-size: rem(3.2);
     $icon-shadow: $whiteframe-shadow-1dp;
@@ -11,6 +11,12 @@
         width: $icon-size;
         position: relative;
         z-index: 0; // set up new stacking context
+
+        .rv-description-container {
+            display: none;
+            opacity: 0;
+            position: absolute;
+        }
 
         .rv-symbol {
             position: absolute;
@@ -71,14 +77,14 @@
             visibility: hidden;
 
             // the following arranges the first three items in a visible stack
-            &:first-of-type {
+            &:nth-of-type(2) {
                 top: 3px;
                 left: 3px;
                 opacity: 1;
                 visibility: visible;
             }
 
-            &:nth-of-type(2) {
+            &:nth-of-type(3) {
                 top: 1px;
                 left: 1px;
                 opacity: 1;
@@ -137,7 +143,7 @@
 
 
 ///// old
-
+/*
 $icon-size: rem(3.2);
 $icon-shadow: $whiteframe-shadow-1dp;
 
@@ -277,4 +283,4 @@ $icon-shadow: $whiteframe-shadow-1dp;
         opacity: 1;
         visibility: visible;
     }
-}
+}*/


### PR DESCRIPTION
## Description
Allows to add an optional description to legend entry blocks and legend info blocks (unbound layers only).

Config schema is updated to 2.1.

Closes #2260

## Testing
![](https://camo.githubusercontent.com/05a2ef12d143be821500e24220895f35fd4a0ba5/68747470733a2f2f692e696d6775722e636f6d2f56486a445551312e706e67)

![layer_description](https://user-images.githubusercontent.com/2285779/28719376-be2c4e0c-7377-11e7-857d-6805f9260dda.gif)


## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2281)
<!-- Reviewable:end -->
