### PR TITLE
Replace geo search result animations with tooptips

### DIFF
--- a/src/app/ui/geosearch/geosearch.directive.js
+++ b/src/app/ui/geosearch/geosearch.directive.js
@@ -98,6 +98,7 @@ function Controller(geosearchService, events, debounceService, layoutService) {
 
     /**
      * Set the indicated self.isNameTruncated to True iff the the result is truncated
+     *
      * @function setTruncated
      * @private
      * @param{event} evt event when being hovered

--- a/src/app/ui/geosearch/geosearch.directive.js
+++ b/src/app/ui/geosearch/geosearch.directive.js
@@ -51,7 +51,7 @@ function rvGeosearch(layoutService, debounceService, globalRegistry, $rootElemen
     return directive;
 }
 
-function Controller(geosearchService, events, debounceService) {
+function Controller(geosearchService, events, debounceService, layoutService) {
     'ngInject';
     const self = this;
 
@@ -63,6 +63,9 @@ function Controller(geosearchService, events, debounceService) {
 
     self.onTopFiltersUpdate = onTopFiltersUpdate;
     self.onBottomFiltersUpdate = onBottomFiltersUpdate;
+    self.isNameTruncated = false;
+    self.setTruncated = setTruncated;
+    self.getTooltipDirection = getTooltipDirection;
 
     return;
 
@@ -91,5 +94,26 @@ function Controller(geosearchService, events, debounceService) {
 
         // also run query once on each filters update to refresh the results
         geosearchService.runQuery();
+    }
+
+    function setTruncated(evt) {
+        const target = evt.currentTarget;
+        const result = target.children[1];
+        const type = target.children[3];
+
+        self.isNameTruncated = (result.scrollWidth + type.scrollWidth) > (target.clientWidth - 50);
+    }
+
+    /**
+     * Maps tooltip direction on the legend items to the current layout size:
+     * - to the right of the legend item in large layouts
+     * - above the element on small and medium layouts
+     *
+     * @function getTooltipDirection
+     * @private
+     * @return {String} direction of the tooltip; either 'right' or 'top'
+     */
+    function getTooltipDirection() {
+        return layoutService.currentLayout() === layoutService.LAYOUT.LARGE ? 'right' : 'top';
     }
 }

--- a/src/app/ui/geosearch/geosearch.directive.js
+++ b/src/app/ui/geosearch/geosearch.directive.js
@@ -103,12 +103,12 @@ function Controller(geosearchService, events, debounceService, layoutService) {
      * @private
      * @param{event} evt event when being hovered
      */
-    function setTruncated(evt) {
+    function setTruncated(evt, result) {
         const target = evt.currentTarget;
-        const result = target.children[1];
+        const location = target.children[1];
         const type = target.children[3];
 
-        self.isNameTruncated = (result.scrollWidth + type.scrollWidth) > (target.clientWidth - 50);
+        result.isNameTruncated = (location.scrollWidth + type.scrollWidth) > (target.clientWidth - 50);
     }
 
     /**

--- a/src/app/ui/geosearch/geosearch.directive.js
+++ b/src/app/ui/geosearch/geosearch.directive.js
@@ -96,6 +96,12 @@ function Controller(geosearchService, events, debounceService, layoutService) {
         geosearchService.runQuery();
     }
 
+    /**
+     * Set the indicated self.isNameTruncated to True iff the the result is truncated
+     * @function setTruncated
+     * @private
+     * @param{event} evt event when being hovered
+     */
     function setTruncated(evt) {
         const target = evt.currentTarget;
         const result = target.children[1];

--- a/src/app/ui/geosearch/geosearch.directive.js
+++ b/src/app/ui/geosearch/geosearch.directive.js
@@ -61,48 +61,10 @@ function Controller(geosearchService, events, debounceService) {
         extentChangeListener: angular.noop
     };
 
-    self.onItemFocus = debounceService.registerDebounce(onItemFocus, 700, false);
-    self.onItemBlur = onItemBlur;
     self.onTopFiltersUpdate = onTopFiltersUpdate;
     self.onBottomFiltersUpdate = onBottomFiltersUpdate;
 
     return;
-
-    /**
-     * On focus, create a tooltip who contains all text section.
-     *
-     * @function onItemFocus
-     * @private
-     */
-    function onItemFocus(evt) {
-        const target = evt.target;
-
-        // get li from event (can be the button or li itself) then children
-        const li = !target.classList.contains('rv-results-item-body-button') ? target : target.parentElement;
-        const children = li.children;
-
-        // create tooltip element
-        const div = document.createElement('div');
-        div.className = 'rv-results-item-tooltip';
-        div.appendChild(children[1]);
-        div.appendChild(children[1]);
-        div.appendChild(children[1]);
-        li.appendChild(div);
-
-        // check it the text exceed the menu width. If so, set the animation so text will move and
-        // user will be able to see it.
-        div.style.left = $(div).width() > 380 ? `${360 - $(div).width()}px` : 0;
-    }
-
-    /**
-     * On blur, remove tooltip.
-     *
-     * @function onItemBlur
-     * @private
-     */
-    function onItemBlur() {
-        $('.rv-results-item-tooltip').children().unwrap();
-    }
 
     /**
      * Triggers geosearch query on top filters (province, type) update.

--- a/src/app/ui/geosearch/geosearch.html
+++ b/src/app/ui/geosearch/geosearch.html
@@ -11,16 +11,12 @@
         <ul class="rv-results-list">
 
             <li class="rv-results-item" ng-repeat="result in self.service.searchResults"
-                ng-mouseenter="self.onItemFocus($event)"
-                ng-mouseleave="self.onItemBlur($event)"
                 ng-mousedown="self.service.zoomTo(result)">
                 <!-- need to use ng-mousedown on li instead of ng-click on button because of ng-focus and ng-blur -->
                 <md-button
                     aria-label="result.name + ' ' + result.location.city ' ' + result.location.province.abbr + ' ' + result.type.name"
                     class="rv-results-item-body-button rv-button-square"
-                    ng-click="self.service.zoomTo(result)"
-                    ng-focus="self.onItemFocus($event)"
-                    ng-blur="self.onItemBlur($event)">
+                    ng-click="self.service.zoomTo(result)">
                 </md-button>
 
                 <div class="rv-results-item-main">
@@ -40,6 +36,13 @@
                     {{ ::result.type.name }}
                 </span>
 
+                <md-tooltip md-direction="right">
+                    {{ result.name
+                    + (result.location.city ? ', ' + result.location.city : '')
+                    + (result.location.province.abbr ? ', ' + result.location.province.abbr : '')
+                    }}&nbsp;
+                    {{ result.type.name }}
+                </md-tooltip>
             </li>
         </ul>
 

--- a/src/app/ui/geosearch/geosearch.html
+++ b/src/app/ui/geosearch/geosearch.html
@@ -12,7 +12,7 @@
 
             <li class="rv-results-item" ng-repeat="result in self.service.searchResults"
                 ng-mousedown="self.service.zoomTo(result)"
-                ng-mouseenter="self.setTruncated($event)">
+                ng-mouseenter="self.setTruncated($event, result)">
                 <!-- need to use ng-mousedown on li instead of ng-click on button because of ng-focus and ng-blur -->
                 <md-button
                     aria-label="result.name + ' ' + result.location.city ' ' + result.location.province.abbr + ' ' + result.type.name"
@@ -37,7 +37,7 @@
                     {{ ::result.type.name }}
                 </span>
 
-                <md-tooltip md-delay="750" md-direction="{{ self.getTooltipDirection() }}" ng-show="self.isNameTruncated">
+                <md-tooltip md-delay="750" md-direction="{{ self.getTooltipDirection() }}" ng-show="result.isNameTruncated">
                     {{ result.name
                     + (result.location.city ? ', ' + result.location.city : '')
                     + (result.location.province.abbr ? ', ' + result.location.province.abbr : '')

--- a/src/app/ui/geosearch/geosearch.html
+++ b/src/app/ui/geosearch/geosearch.html
@@ -11,7 +11,8 @@
         <ul class="rv-results-list">
 
             <li class="rv-results-item" ng-repeat="result in self.service.searchResults"
-                ng-mousedown="self.service.zoomTo(result)">
+                ng-mousedown="self.service.zoomTo(result)"
+                ng-mouseenter="self.setTruncated($event)">
                 <!-- need to use ng-mousedown on li instead of ng-click on button because of ng-focus and ng-blur -->
                 <md-button
                     aria-label="result.name + ' ' + result.location.city ' ' + result.location.province.abbr + ' ' + result.type.name"
@@ -36,7 +37,7 @@
                     {{ ::result.type.name }}
                 </span>
 
-                <md-tooltip md-direction="right">
+                <md-tooltip md-delay="750" md-direction="{{ self.getTooltipDirection() }}" ng-show="self.isNameTruncated">
                     {{ result.name
                     + (result.location.city ? ', ' + result.location.city : '')
                     + (result.location.province.abbr ? ', ' + result.location.province.abbr : '')


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Replace geo search result animations when truncated with tool tips

Closes #1877 
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Manually
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2285)
<!-- Reviewable:end -->
