### PR TITLE
fix(datatable): column headings position corrected on resize

### DIFF
--- a/src/app/ui/table/table-default.directive.js
+++ b/src/app/ui/table/table-default.directive.js
@@ -605,6 +605,12 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
 
                         // fired event to create filters
                         events.$broadcast(events.rvTableReady);
+
+                        // handle when screen is resized and column headings need to be readjusted
+                        self.onResizeDelistener = layoutService.onResize(
+                            $rootElement,
+                            debounceService.registerDebounce(self.table.columns.adjust)
+                        );
                     }
                 });
             }
@@ -846,6 +852,7 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
                 // reset index and reference to tablebody for keytable navigation
                 index = undefined;
                 self.tableBody = undefined;
+                self.onResizeDelistener();
             }
         }
     }


### PR DESCRIPTION
## Description
Closes #2271

## Testing
![eagle eyes](https://user-images.githubusercontent.com/10187181/28779642-ed031dee-75d1-11e7-9625-6af075adc3f8.png)

## Documentation
inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2286)
<!-- Reviewable:end -->
