### PR TITLE
fix(table): parsing of dates in non-ISO format

### DIFF
--- a/src/app/ui/table/table-definition.directive.js
+++ b/src/app/ui/table/table-definition.directive.js
@@ -338,7 +338,7 @@ function rvTableDefinition(stateManager, events, $compile, tableService, layoutS
                 }
 
                 const date = data[i].split('-');
-
+                // length 3 when in the format [YYYY, MM, DD HH:mm:ss]
                 if (date.length !== 3) { return false; }  // different column that isn't a date
 
                 const day = date[2].split(' ');     // get the date without the time

--- a/src/app/ui/table/table-definition.directive.js
+++ b/src/app/ui/table/table-definition.directive.js
@@ -358,10 +358,16 @@ function rvTableDefinition(stateManager, events, $compile, tableService, layoutS
 
                 if (val && !isNaN(val.getTime())) {
                     // set date to filter values or minimum / maximum date value
-                    const min = (filter.min !== null) ? filter.min : new Date(-8640000000000000);
-                    const max = (filter.max !== null) ? filter.max : new Date(8640000000000000);
+                    // remove the time part from the filter values
+                    let min = (filter.min !== null) ? filter.min.toDateString() : new Date(-8640000000000000);
+                    let max = (filter.max !== null) ? filter.max.toDateString() : new Date(8640000000000000);
 
-                    // check date
+                    // create a new date object with the time set to beginning of the day
+                    min = new Date(min);
+                    max = new Date(max);
+                    val = new Date(val.toDateString());
+
+                    // check date; only compare the date and not time
                     return (val >= min && val <= max)
                 } else {
                     return false;

--- a/src/app/ui/table/table-definition.directive.js
+++ b/src/app/ui/table/table-definition.directive.js
@@ -1,3 +1,5 @@
+import * as moment from 'moment-timezone';
+
 // fields blueprints to be added to the table header for large layout and inside setting panel
 // `self` property is named so intentionally, as it will be passed on a scope to the FILTERS_TEMPLATE
 const FILTERS = {
@@ -336,10 +338,25 @@ function rvTableDefinition(stateManager, events, $compile, tableService, layoutS
                 }
 
                 const date = data[i].split('-');
-                const val = (date.length === 3) ?
-                    new Date(`${date[0]}-${parseInt(date[1])}-${parseInt(date[2])}`) : false;
 
-                if (val) {
+                if (date.length !== 3) { return false; }  // different column that isn't a date
+
+                const day = date[2].split(' ');     // get the date without the time
+
+                // use moment timezone to parse dates
+                const userTimeZone = moment.tz.guess();
+                // IE does not like dates not in ISO format, so need to add leading 0 if necessary
+                const time = moment.tz(`${date[0]}-${('0' + date[1]).slice(-2)}-${('0' + day[0]).slice(-2)}`, userTimeZone);
+
+                let val = false;
+                if (time !== 'Invalid date') {
+                    const date = new Date(time);
+                    // apply time offset to ensure date entered is not given in UTC (a day behind)
+                    // will allow for correct applying of filters
+                    val = new Date(date.getTime() + Math.abs(date.getTimezoneOffset()*60000));
+                }
+
+                if (val && !isNaN(val.getTime())) {
                     // set date to filter values or minimum / maximum date value
                     const min = (filter.min !== null) ? filter.min : new Date(-8640000000000000);
                     const max = (filter.max !== null) ? filter.max : new Date(8640000000000000);


### PR DESCRIPTION
## Description
Closes #2257.
Closes undocumented bug: When applying filters, keep the same offset between filters and row values to ensure the correct rows are filtered out.

## Testing
Visually tested; Chrome, IE.

## Documentation
In-line comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2287)
<!-- Reviewable:end -->
