### PR TITLE
Handle null in esri detail pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "^1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "^1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.0.0-2",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.0.1-2",
     "gsap": "^1.19.1",
     "jquery": "^2.2.1",
     "jquery-hoverintent": "^1.8.2",

--- a/src/app/core/formatters.filter.js
+++ b/src/app/core/formatters.filter.js
@@ -94,6 +94,9 @@ function picture() {
      */
     function picture(items) {
         // item must be a string
+        if (items === null) {
+            items = '';
+        }
         items = items.toString().split(';');
         const results = Array.isArray(items) ? items.map(process) : process(items);
 


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2239

Stops detail pane from getting angry if a null appears

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Loaded null-riddled layer in viewer. Tested detail view, identify, data grid.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->


## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2288)
<!-- Reviewable:end -->
