### PR TITLE
fix(ui): side menu items are rendered correctly

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -634,7 +634,7 @@
             "type": "object",
             "properties": {
                 "logo": { "type": "boolean", "default": true, "description": "Indicates if the logo should be shown in the left side menu." },
-                "items": { "type": "array", "items": { "$ref": "#/definitions/sideMenuButtons" }, "default": [] }
+                "items": { "type": "array", "items": { "$ref": "#/definitions/sideMenuButtons" }, "default": [["layers","basemap"],["fullscreen","export","share","touch","help","about"],["language"],["plugins"]] }
             },
             "additionalProperties": false,
             "description": "Specifies which options are available in the left side menu."
@@ -645,7 +645,7 @@
             "uniqueItems": true,
             "items": {
                 "type": "string",
-                "enum": ["layers", "basemap", "about", "fullscreen", "export", "share", "touch", "help", "language"]
+                "enum": ["layers", "basemap", "about", "fullscreen", "export", "share", "touch", "help", "language", "plugins"]
             }
         },
 
@@ -653,15 +653,19 @@
             "type": "object",
             "properties": {
                 "zoom": { "type": "string", "enum": ["all", "buttons", "slider"], "default": "buttons" },
-                "extra": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/definitions/navBarButtons" }, "default": [] }
+                "extra": { "$ref": "#/definitions/navBarButtons", "default": ["fullscreen", "geoLocator", "home", "help"] }
             },
             "required": [ "zoom" ],
             "additionalProperties": false
         },
 
         "navBarButtons": {
-            "type": "string",
-            "enum": ["geoLocator", "marquee", "home", "history", "basemap", "help", "fullscreen"]
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "enum": ["geoLocator", "marquee", "home", "history", "basemap", "help", "fullscreen"]
+            }
         },
 
         "mapComponentsNode": {

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1816,15 +1816,12 @@ function ConfigObjectFactory(Geo, gapiService, common) {
      * @class NavBar
      */
     class NavBar {
-        constructor(source = {}, helpSource) {
+        constructor(source = {}) {
             this._source = source;
             this._zoom = source.zoom || 'buttons';
-            this._extra = source.extra || [];
-
-            // remove help if help or its folderName is absent
-            if (! helpSource || ! helpSource.folderName) {
-                common.removeFromArray(this._extra, 'help');
-            }
+            this._extra = angular.isArray(source.extra) ?
+                common.intersect(source.extra, NavBar.EXTRA_AVAILABLE_ITEMS) :
+                angular.copy(NavBar.EXTRA_ITEMS_DEFAULT);
         }
 
         get zoom () { return this._zoom; }
@@ -1836,6 +1833,23 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                 extra: this.extra
             }
         }
+
+        static EXTRA_ITEMS_DEFAULT = [
+            'fullscreen',
+            'geoLocator',
+            'home',
+            'help'
+        ];
+
+        static EXTRA_AVAILABLE_ITEMS = [
+            'history',
+            'fullscreen',
+            'marquee',
+            'home',
+            'help',
+            'geoLocator',
+            'basemap'
+        ];
     }
 
     /**
@@ -1843,40 +1857,35 @@ function ConfigObjectFactory(Geo, gapiService, common) {
      * @class SideMenu
      */
     class SideMenu {
-        constructor(source = {}, helpSource) {
+        constructor(source = {}) {
             this._source = source;
             this._logo = source.logo === true;
 
-            const ITEMS_DEFAULT = [
-                [
-                    'layers',
-                    'basemap'
-                ],
-                [
-                    'fullscreen',
-                    'export',
-                    'share',
-                    'touch',
-                    'help',
-                    'about'
-                ],
-                [
-                    'language'
-                ],
-                [
-                    'plugins'
-                ]
-            ];
-
             this._items = angular.isArray(source.items) ?
-                source.items.map(subItems =>
-                    common.intersect(source.items, SideMenu.AVAILABLE_ITEMS)) : angular.copy(ITEMS_DEFAULT);
-
-            // remove help if help or its folderName is absent
-            if (! helpSource || ! helpSource.folderName) {
-                common.removeFromArray(this.items[1], 'help');
-            }
+                source.items.map(subItems => common.intersect(subItems, SideMenu.AVAILABLE_ITEMS)) :
+                angular.copy(SideMenu.ITEMS_DEFAULT);
         }
+
+        static ITEMS_DEFAULT = [
+            [
+                'layers',
+                'basemap'
+            ],
+            [
+                'fullscreen',
+                'export',
+                'share',
+                'touch',
+                'help',
+                'about'
+            ],
+            [
+                'language'
+            ],
+            [
+                'plugins'
+            ]
+        ];
 
         static AVAILABLE_ITEMS = [
             'layers',
@@ -2113,6 +2122,20 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                     common.removeFromArray(section, optionName));
 
                 common.removeFromArray(this.ui.navBar.extra, optionName);
+            }
+
+            // remove help from the side menu and map nav cluster if help or its folderName is absent
+            if (!this.ui.help.folderName) {
+                common.removeFromArray(this.ui.navBar.extra, 'help');
+
+                this.ui.sideMenu.items.forEach(section =>
+                    common.removeFromArray(section, 'help'));
+            }
+
+            // remove `about` option if about content or about folder is not provided
+            if (!this.ui.about.folderName && !this.ui.about.content) {
+                this.ui.sideMenu.items.forEach(section =>
+                    common.removeFromArray(section, 'about'));
             }
 
             /**


### PR DESCRIPTION
## Description

Should now properly parse sidemenu items defintion. `items` is an array of arrays representing sections in a submenu.

```json
    items: [
        [
            "layers",
            "basemap"
        ],
        [
            "fullscreen",
            "export",
            "share",
            "touch",
            "help"
        ],
        [
            "language"
        ]
    ]
```

Closes #2289

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2291)
<!-- Reviewable:end -->
