### PR TITLE
fix(ui): rvInteractive button widths adjusted

### DIFF
--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -232,7 +232,7 @@ function tocService($q, $rootScope, $mdToast, $translate, layoutService, stateMa
                         title: '',
                         orderable: false,
                         render: '',
-                        width: '20px' // for datatables
+                        width: '40px' // for datatables
                     });
 
                     // add a column for symbols
@@ -313,7 +313,7 @@ function tocService($q, $rootScope, $mdToast, $translate, layoutService, stateMa
                         title: '',
                         orderable: false,
                         render: '',
-                        width: '20px', // for datatables
+                        width: '40px', // for datatables
                         position: 1, // for datatables
                         className: 'rv-filter-noexport' // do not show when datatble export or print
                     });

--- a/src/content/styles/modules/_table.scss
+++ b/src/content/styles/modules/_table.scss
@@ -130,7 +130,7 @@
                                 align-items: center;
 
                                 @include touch {
-                                    @include button-size(rem(4.0));
+                                    @include button-size(rem(3.5));
                                     @include icon-size(rem(2.0));
                                 }
 


### PR DESCRIPTION
## Description
It seems datatables does not adjust the column width of `rvInteractive` based on the child width as would be expected. It could be using the literal value `rvInteractive` as a basis for the width.

It also seems it does not properly use the column width as defined in
our columnDefs.

These issues made it necessary to resort to manual width adjustments.

Closes #2262

## Testing
👀 

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2298)
<!-- Reviewable:end -->
