### PR TITLE
feat(ui): add toast for bad boundary zooms

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "^1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "^1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.1.0-6",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.1.0-7",
     "gsap": "^1.19.1",
     "jquery": "^2.2.1",
     "jquery-hoverintent": "^1.8.2",

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -659,8 +659,9 @@ function LegendBlockFactory(common, Geo, layerRegistry, gapiService, configServi
          * Zooms the layer controlled by the main proxy object to its bounding box.
          *
          * @function zoomToBoundary
+         * @return {Promise} resolving when the extent change has ended
          */
-        zoomToBoundary () { this._mainProxyWrapper.zoomToBoundary(); }
+        zoomToBoundary () { return this._mainProxyWrapper.zoomToBoundary(); }
 
         /**
          * Zooms to a graphic with the specified oid.

--- a/src/app/geo/locate.service.js
+++ b/src/app/geo/locate.service.js
@@ -11,7 +11,7 @@ angular
     .module('app.geo')
     .factory('locateService', locateService);
 
-function locateService($http, gapiService, configService, errorService) {
+function locateService($http, $translate, gapiService, configService, errorService) {
 
     let apiURL;
     const location = {};
@@ -60,7 +60,7 @@ function locateService($http, gapiService, configService, errorService) {
         const onFailedBrowserCB = () =>
             _apiLocate(
                 geolocate,
-                () => errorService.display('Your location could not be found.')
+                () => errorService.display({ textContent: $translate.instant('geoLocation.error') })
             );
 
         if (location.latitude) {

--- a/src/app/ui/common/error.service.js
+++ b/src/app/ui/common/error.service.js
@@ -10,7 +10,7 @@ angular
     .module('app.ui')
     .factory('errorService', errorService);
 
-function errorService($mdToast) {
+function errorService($mdToast, $translate) {
     const service = {
         display,
         remove
@@ -31,22 +31,14 @@ function errorService($mdToast) {
      * Renders a toast message containing the supplied errorMsg
      *
      * @function display
-     * @param {String} errorMsg     The message to display inside the toast
-     * @param {Object} parentElem   optional element to attach toast message. Appears on bottom of element if supplied, default is rootElement
-     * @return {Promise}
+     * @param {Object} opts toast options object; see https://material.angularjs.org/latest/api/service/$mdToast for details
+     * @return {Promise} resolving when the toast is hidden
      */
-    function display(errorMsg, parentElem) {
-        const opts = {
-            textContent: errorMsg,
-            // action: 'Close',
-            // hideDelay: 0,
+    function display(opts) {
+        const extendedOpts = angular.extend({}, {
             position: 'bottom rv-flex-global'
-        };
+        }, opts);
 
-        if (typeof parentElem !== 'undefined') {
-            opts.parent = parentElem;
-        }
-
-        return $mdToast.show($mdToast.simple(opts));
+        return $mdToast.show($mdToast.simple(extendedOpts));
     }
 }

--- a/src/app/ui/toc/legend-element-factory.class.js
+++ b/src/app/ui/toc/legend-element-factory.class.js
@@ -14,7 +14,7 @@ angular
     .module('app.ui')
     .factory('LegendElementFactory', LegendElementFactory);
 
-function LegendElementFactory($translate, Geo, ConfigObject, tocService, debounceService, configService) {
+function LegendElementFactory($translate, Geo, ConfigObject, tocService, debounceService, configService, mapService) {
     const ref = {
         get autoLegendEh() {
             return configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE;
@@ -228,7 +228,7 @@ function LegendElementFactory($translate, Geo, ConfigObject, tocService, debounc
         get icon () {   return 'action:zoom_in'; }
         get label () {  return 'toc.label.boundaryZoom'; }
 
-        action () {     this.block.zoomToBoundary(); }
+        action () { this.block.zoomToBoundary().then(mapService.checkForBadZoom); }
     }
 
     class DataControl extends BaseControl {

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -74,14 +74,15 @@ function tocService($q, $rootScope, $mdToast, $translate, common, layoutService,
         const [resolve, reject] = legendService.removeLegendBlock(legendBlock);
 
         // create notification toast
-        const undoToast = $mdToast.simple()
-            .textContent($translate.instant('toc.label.state.remove'))
-            .action($translate.instant('toc.label.action.remove'))
-            .parent(layoutService.panes.toc)
-            .position('bottom rv-flex');
+        const toast = {
+            textContent: $translate.instant('toc.label.state.remove'),
+            action: $translate.instant('toc.label.action.remove'),
+            parent: layoutService.panes.toc,
+            position: 'bottom rv-flex'
+        };
 
         // promise resolves with 'ok' when user clicks 'undo'
-        $mdToast.show(undoToast)
+        errorService.display(toast)
             .then(response =>
                 response === 'ok' ? _restoreLegendBlock() : resolve());
 
@@ -298,8 +299,10 @@ function tocService($q, $rootScope, $mdToast, $translate, common, layoutService,
 
                 requester.error = true; // this will hide the table loading splash
 
-                errorToast = errorService.display($translate.instant('toc.error.resource.loadfailed'),
-                    layoutService.panes.filter);
+                errorToast = errorService.display({
+                    textContent: $translate.instant('toc.error.resource.loadfailed'),
+                    parent: layoutService.panes.filter
+                });
             });
     }
 
@@ -333,8 +336,10 @@ function tocService($q, $rootScope, $mdToast, $translate, common, layoutService,
                 resolve(metadataPackage);
 
             }).catch(error => {
-                errorService.display($translate.instant('toc.error.resource.loadfailed'),
-                    layoutService.panes.metadata);
+                errorService.display({
+                    textContent: $translate.instant('toc.error.resource.loadfailed'),
+                    parent: layoutService.panes.metadata
+                });
 
                 // display manager will stop the progress bar when datapromise is rejected
                 reject(error);

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -123,6 +123,7 @@ Map Navigation basemap label,nav.label.basemap,Basemap,1,Carte de base,1
 Map Navigation zoom in tooltip,nav.tooltip.zoomIn,Zoom in,1,Zoom avant,1
 Map Navigation zoom out tooltip,nav.tooltip.zoomOut,Zoom out,1,Zoom arrière,1
 Map Navigation geolocation tooltip,nav.tooltip.geoLocation,Your Location,1,Votre position,1
+,geoLocation.error,Your location could not be found.,1,[Your location could not be found.],0
 Map Navigation search tooltip,nav.tooltip.search,Search,1,Recherche,1
 Map Navigation home tooltip,nav.tooltip.home,Canada,1,Canada,1
 Map Navigation history tooltip,nav.tooltip.history,History,1,Historique,1
@@ -223,6 +224,8 @@ Table of Content templates placeholder loading error label,toc.tmp.label.error.l
 Table of Content zoom to boundary label,toc.label.boundaryZoom,Zoom to Layer Boundary,1,Zoomer à la limite,1
 Table of Content open datatable label,toc.label.dataTable,Datatable,1,Tableau de données,1
 Table of Content zoom to boundary tooltip,toc.tooltip.boundaryZoom,Zoom to Layer Boundary,1,Zoomer à la limite,1
+,toc.boundaryZoom.badzoom,Have we zoomed too far?,1,[fr] Zoomed too far?,0
+,toc.boundaryZoom.undo,fix,1,[fr] fix?,0
 Table of Content keyboard reoder tooltip,toc.label.reorder,Reorder,1,Réorganiser,1
 ,toc.menu.visibility.title,Toggle Visibility,1,Basculer la visibilité,1
 ,toc.menu.visibility.allon,Show All,1,Montrer tout,1


### PR DESCRIPTION
## Description
Detect zoom to boundary events that move the extent center outside the full extent of the basemap and display a toast to the user with an option to adjust the new extent.

Closes #2273


## Testing
![](https://camo.githubusercontent.com/05a2ef12d143be821500e24220895f35fd4a0ba5/68747470733a2f2f692e696d6775722e636f6d2f56486a445551312e706e67
)

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2304)
<!-- Reviewable:end -->
