### PR TITLE
fix(ui): close open panels when switching projection

### DIFF
--- a/src/app/core/reload.service.js
+++ b/src/app/core/reload.service.js
@@ -36,6 +36,8 @@ function reloadService(events, bookmarkService, geoService, configService, state
     function reloadConfig(bookmark) {
         events.$broadcast(events.rvApiHalt);
 
+        _closeOpenPanels();
+
         geoService._isMapReady = false;
         geoService.destroyMap();
         bookmarkService.emptyStoredBookmark();
@@ -57,18 +59,15 @@ function reloadService(events, bookmarkService, geoService, configService, state
 
     function changeProjection(startPoint) {
         events.$broadcast(events.rvApiHalt);
+
+        _closeOpenPanels();
+
         const bookmark = bookmarkService.getBookmark(startPoint);
         bookmarkService.parseBookmark(bookmark);
 
         geoService
             .destroyMap()
             .assembleMap();
-
-        stateManager.setActive({
-            side: false
-        }, {
-            table: false
-        });
     }
 
     /**
@@ -80,6 +79,8 @@ function reloadService(events, bookmarkService, geoService, configService, state
      */
     function loadNewLang(lang) {
         events.$broadcast(events.rvApiHalt);
+
+        _closeOpenPanels();
 
         const bookmark = bookmarkService.getBookmark();
 
@@ -104,10 +105,12 @@ function reloadService(events, bookmarkService, geoService, configService, state
     function loadWithBookmark(bookmark, initial, additionalKeys = []) {
         if (!bookmark) {
             events.$broadcast(events.rvBookmarkInit);
+            _closeOpenPanels();
             service.bookmarkBlocking = false;
         } else if (!initial || service.bookmarkBlocking) {
             events.$broadcast(events.rvApiHalt);
             events.$broadcast(events.rvBookmarkDetected);
+            _closeOpenPanels();
 
             // FIXME / TODO I think we need more analysis here for what happens if
             // this is not the initial bookmark and there are RCS layers involved.
@@ -185,5 +188,19 @@ function reloadService(events, bookmarkService, geoService, configService, state
         if (service.bookmarkBlocking) {
            loadWithBookmark(bookmark, true, keys);
         }
+    }
+
+    /**
+     * Closes open settings or datatable panels when re-loading configs.
+     *
+     * @function _closeOpenPanels
+     * @private
+     */
+    function _closeOpenPanels() {
+        stateManager.setActive({
+            side: false
+        }, {
+            table: false
+        });
     }
 }

--- a/src/app/core/reload.service.js
+++ b/src/app/core/reload.service.js
@@ -10,7 +10,7 @@ angular
     .module('app.core')
     .factory('reloadService', reloadService);
 
-function reloadService(events, bookmarkService, geoService, configService) {
+function reloadService(events, bookmarkService, geoService, configService, stateManager) {
     const service = {
         // loadNewProjection,
         loadWithExtraKeys,
@@ -63,6 +63,12 @@ function reloadService(events, bookmarkService, geoService, configService) {
         geoService
             .destroyMap()
             .assembleMap();
+
+        stateManager.setActive({
+            side: false
+        }, {
+            table: false
+        });
     }
 
     /**


### PR DESCRIPTION
## Description
Closes #1365 and #2136 

Intermediate solution because complete solution requires full state stored. Previously, the panels remained open but were not functional after changing projection. This will close the side or datatable panel if open.

## Testing
Visually tested

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2311)
<!-- Reviewable:end -->
