### PR TITLE
Fix RCS layers ordering issue when they were loaded from bookmarks

### DIFF
--- a/src/app/core/bookmark.service.js
+++ b/src/app/core/bookmark.service.js
@@ -13,6 +13,7 @@ angular
 function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, ConfigObject) {
 
     let _bookmarkObject = null;
+    let _orderdBookmarkIds = [];
 
     const service = {
         getBookmark,
@@ -21,7 +22,9 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
         extractRcsLayers,
         insertRcsLayers,
         get storedBookmark() { return _bookmarkObject; },
-        emptyStoredBookmark() { _bookmarkObject = null; }
+        getOrderdBookmarkIds() { return _orderdBookmarkIds},
+        emptyStoredBookmark() { _bookmarkObject = null; },
+        emptyOrderdBookmarkIds() { _orderdBookmarkIds = []; }
     };
 
     return service;
@@ -399,6 +402,10 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
             //filterConfigLayers(bookmarkLayers, config);
         } else {
             bookmarkObject.bookmarkLayers = [];
+        }
+        // record the order of legends from the bookmark
+        for (let layer of bookmarkObject.bookmarkLayers) {
+            _orderdBookmarkIds.push(layer.id);
         }
 
         _bookmarkObject = bookmarkObject;

--- a/src/app/core/reload.service.js
+++ b/src/app/core/reload.service.js
@@ -41,6 +41,7 @@ function reloadService(events, bookmarkService, geoService, configService, state
         geoService._isMapReady = false;
         geoService.destroyMap();
         bookmarkService.emptyStoredBookmark();
+        bookmarkService.emptyOrderdBookmarkIds();
         configService.reInitialize();
 
         if (!bookmark) {

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -63,8 +63,19 @@ function geoService($http, $q, $rootScope, events, mapService, layerRegistry, co
                 this._isMapReady = true;
                 $rootScope.$broadcast(events.rvApiReady);
                 events.$on(events.rvCfgUpdated, (evt, layers) => {
-                    console.info(layers);
-                    layers.forEach(layer => legendService.addLayerDefinition(layer));
+                    let orderdBookmarkIds = bookmarkService.getOrderdBookmarkIds();
+                    layers.forEach(layer => {
+                        if (orderdBookmarkIds.length !== 0) {   // it is a bookmark
+                            for (let i = 0; i < orderdBookmarkIds.length; i++) {
+                                if (orderdBookmarkIds[i] === layer.id) {
+                                    legendService.addLayerDefinition(layer, i);
+                                    break;
+                                }
+                            }
+                        } else {
+                            legendService.addLayerDefinition(layer);
+                        }
+                    });
                 });
             }).catch(error => RV.logger.error('geoService', 'failed to assemble the map with error', error));
         }

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -60,7 +60,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
      * @param {pos} optional position for layer to be on the legend
      * @returns {LegendBlock} returns a corresponding, newly created legend block
      */
-    function addLayerDefinition(layerDefinition, pos) {
+    function addLayerDefinition(layerDefinition, pos = null) {
         return importLayerBlueprint(createBlueprint(layerDefinition), pos);
     }
 
@@ -85,7 +85,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
      * @param {pos} optional position for layer to be on the legend
      * @return {LegendBlock} returns a corresponding, newly created legend block
      */
-    function importLayerBlueprint(layerBlueprint, pos) {
+    function importLayerBlueprint(layerBlueprint, pos = null) {
         const layerBlueprintsCollection = configService.getSync.map.layerBlueprints;
         layerBlueprintsCollection.push(layerBlueprint);
 

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -12,7 +12,7 @@ angular
     .factory('legendService', legendServiceFactory);
 
 function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, LayerBlueprint,
-    layerRegistry, common) {
+    layerRegistry, common, bookmarkService) {
 
     const service = {
         constructLegend,
@@ -66,7 +66,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
     /**
      * Instantiates and registers a layer blueprint based on the given layer definition.
      *
-     * @function addLayerDefinition
+     * @function createBlueprint
      * @param {LayerDefinition} layerDefinition a layer definition from the config file or RCS snippets
      * @returns {LayerBlueprint} generated layer blueprint
      */
@@ -108,8 +108,15 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
         const importedLegendBlock = _makeLegendBlock(importedBlockConfig, [layerBlueprint]);
 
         let position = 0;
+        let orderdBookmarkIds = bookmarkService.getOrderdBookmarkIds();
         // find an appropriate spot in a auto legend;
-        if (configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE) {
+        if (orderdBookmarkIds.length !== 0) {   // If the order from bookmark exists
+            for (let i = 0; i < orderdBookmarkIds.length; i++) {
+                if (orderdBookmarkIds[i] === entryConfigObject.layerId) {
+                    position = i;
+                }
+            }
+        } else if (configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE) {
             position = legendBlocks.entries.findIndex(block =>
                 sortGroups[block.layerType] === sortGroups[importedLegendBlock.layerType]);
 

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -12,7 +12,7 @@ angular
     .factory('legendService', legendServiceFactory);
 
 function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, LayerBlueprint,
-    layerRegistry, common, bookmarkService) {
+    layerRegistry, common) {
 
     const service = {
         constructLegend,
@@ -57,10 +57,11 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
      *
      * @function addLayerDefinition
      * @param {LayerDefinition} layerDefinition a layer definition from the config file or RCS snippets
+     * @param {pos} optional position for layer to be on the legend
      * @returns {LegendBlock} returns a corresponding, newly created legend block
      */
-    function addLayerDefinition(layerDefinition) {
-        return importLayerBlueprint(createBlueprint(layerDefinition));
+    function addLayerDefinition(layerDefinition, pos) {
+        return importLayerBlueprint(createBlueprint(layerDefinition), pos);
     }
 
     /**
@@ -81,9 +82,10 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
      *
      * @function importLayerBlueprint
      * @param {LayerBlueprint} layerBlueprint a layer blueprint to be imported into the map and added to the legend
+     * @param {pos} optional position for layer to be on the legend
      * @return {LegendBlock} returns a corresponding, newly created legend block
      */
-    function importLayerBlueprint(layerBlueprint) {
+    function importLayerBlueprint(layerBlueprint, pos) {
         const layerBlueprintsCollection = configService.getSync.map.layerBlueprints;
         layerBlueprintsCollection.push(layerBlueprint);
 
@@ -108,14 +110,9 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
         const importedLegendBlock = _makeLegendBlock(importedBlockConfig, [layerBlueprint]);
 
         let position = 0;
-        let orderdBookmarkIds = bookmarkService.getOrderdBookmarkIds();
         // find an appropriate spot in a auto legend;
-        if (orderdBookmarkIds.length !== 0) {   // If the order from bookmark exists
-            for (let i = 0; i < orderdBookmarkIds.length; i++) {
-                if (orderdBookmarkIds[i] === entryConfigObject.layerId) {
-                    position = i;
-                }
-            }
+        if (pos) {   // If the order from bookmark exists
+           position = pos;
         } else if (configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE) {
             position = legendBlocks.entries.findIndex(block =>
                 sortGroups[block.layerType] === sortGroups[importedLegendBlock.layerType]);


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2152 

Changed the inserting position of RCS layers in legends.
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Manually

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2323)
<!-- Reviewable:end -->
