### PR TITLE
fix(legend): close panel only when matching layer removed

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -192,7 +192,8 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
      * @return {Array} returns two functions [resolve, reject]; calling `resolve` will clean up by removing the hidden layer record form the map; calling `reject` will restore the legend block and the corresponding layer record to its previous visibility
      */
     function removeLegendBlock(legendBlock) {
-        const cachedVisibility = legendBlock.visibility;
+        // store visibility for legendBlock and any children being removed
+        const cache = legendBlock.walk(item => item.visibility);
         legendBlock.visibility = false;
 
         const legendBlocks = configService.getSync.map.legendBlocks;
@@ -240,7 +241,8 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
          */
         function _reject() {
             legendBlockParent.addEntry(legendBlock, index);
-            legendBlock.visibility = cachedVisibility;
+            // restore visibility of all legendBlock and any children
+            legendBlock.walk(item => (item.visibility = cache.shift()));
         }
     }
 

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -193,7 +193,12 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
      */
     function removeLegendBlock(legendBlock) {
         // store visibility for legendBlock and any children being removed
-        const cache = legendBlock.walk(item => item.visibility);
+        let cache;
+        if (legendBlock.entries) {
+            cache = legendBlock.walk(item => item.visibility);
+        } else {
+            cache = legendBlock.visibility;
+        }
         legendBlock.visibility = false;
 
         const legendBlocks = configService.getSync.map.legendBlocks;
@@ -242,7 +247,11 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
         function _reject() {
             legendBlockParent.addEntry(legendBlock, index);
             // restore visibility of all legendBlock and any children
-            legendBlock.walk(item => (item.visibility = cache.shift()));
+            if (legendBlock.entries) {
+                legendBlock.walk(item => (item.visibility = cache.shift()));
+            } else {
+                legendBlock.visibility = cache;
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Closes #2329
Closes [undocumented bug] - when removing layers, cache visibility of layer and any children, instead of only top level visibility

## Testing
Visually tested

## Documentation
In-line comments, JSDoc for helper function

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2331)
<!-- Reviewable:end -->
