### PR TITLE
fix(layout): use screen width when going fullscreen

### DIFF
--- a/src/app/core/plugin.service.js
+++ b/src/app/core/plugin.service.js
@@ -10,7 +10,7 @@ angular
     .module('app.core')
     .factory('pluginService', pluginService);
 
-function pluginService(translationService, $mdDialog, layoutService) {
+function pluginService(translationService, $mdDialog, referenceService) {
     const service = {
         onCreate,
         register,
@@ -101,7 +101,7 @@ function pluginService(translationService, $mdDialog, layoutService) {
                 items: opts.items
             },
             template: opts.template,
-            parent: layoutService.panels.shell,
+            parent: referenceService.panels.shell,
             disableParentScroll: opts.hasOwnProperty('disableParentScroll') ? opts.disableParentScroll : false,
             clickOutsideToClose: opts.hasOwnProperty('clickOutsideToClose') ? opts.clickOutsideToClose : true,
             fullscreen: opts.hasOwnProperty('fullscreen') ? opts.fullscreen : false

--- a/src/app/core/statemanager.service.js
+++ b/src/app/core/statemanager.service.js
@@ -23,7 +23,7 @@ angular
 // https://github.com/johnpapa/angular-styleguide#factory-and-service-names
 
 function stateManager($q, $rootScope, displayManager, initialState, initialDisplay, $rootElement,
-    layoutService) {
+    referenceService) {
 
     const service = {
         addState,
@@ -64,8 +64,8 @@ function stateManager($q, $rootScope, displayManager, initialState, initialDispl
         };
 
         if (service.state[pName].active) {
-            dimensions.width = layoutService.panels[pName].outerWidth();
-            dimensions.height = layoutService.panels[pName].outerHeight();
+            dimensions.width = referenceService.panels[pName].outerWidth();
+            dimensions.height = referenceService.panels[pName].outerHeight();
         }
 
         return dimensions;

--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -13,7 +13,7 @@ angular
     .module('app.geo')
     .directive('rvInitMap', rvInitMap);
 
-function rvInitMap($rootScope, geoService, events, layoutService, $rootElement, $interval, globalRegistry) {
+function rvInitMap($rootScope, geoService, events, referenceService, $rootElement, $interval, globalRegistry) {
 
     // key codes that are currently active
     let keyMap = [];
@@ -33,7 +33,7 @@ function rvInitMap($rootScope, geoService, events, layoutService, $rootElement, 
 
         // deregister after the first `rvReady` event as it's fired only once
         const deRegister = scope.$on(events.rvReady, () => {
-            layoutService.mapNode = el;
+            referenceService.mapNode = el;
             geoService.assembleMap(/*el[0]*/);
             deRegister();
         });
@@ -137,7 +137,7 @@ function rvInitMap($rootScope, geoService, events, layoutService, $rootElement, 
 
         } else if (keyMap.indexOf(event.which) === -1) {
             // enable keyboard support only when map is focused
-            if (layoutService.mapNode.is($(document.activeElement))) {
+            if (referenceService.mapNode.is($(document.activeElement))) {
                 keyMap.push(event.which);
                 animate(event);
             }

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -11,7 +11,7 @@ angular
     .module('app.geo')
     .factory('mapService', mapServiceFactory);
 
-function mapServiceFactory($q, $timeout, layoutService, gapiService, configService, identifyService, events) {
+function mapServiceFactory($q, $timeout, referenceService, gapiService, configService, identifyService, events) {
     const service = {
         destroyMap,
         makeMap,
@@ -89,7 +89,7 @@ function mapServiceFactory($q, $timeout, layoutService, gapiService, configServi
         mapConfig.instance._map.destroy();
         mapConfig.reset();
 
-        layoutService.mapNode.empty();
+        referenceService.mapNode.empty();
         // FIXME: do we need to destroy scalebar and overview map even after we empty the node
     }
 
@@ -104,7 +104,7 @@ function mapServiceFactory($q, $timeout, layoutService, gapiService, configServi
         const { map: mapConfig, services: servicesConfig } = configService.getSync;
 
         // dom node to build the map on; need to be specified only the first time the map is created and stored for reuse;
-        const mapNode = layoutService.mapNode;
+        const mapNode = referenceService.mapNode;
 
         const mapSettings = {
             basemaps: mapConfig.basemaps,
@@ -330,7 +330,7 @@ function mapServiceFactory($q, $timeout, layoutService, gapiService, configServi
      */
     function _toggleHighlightHaze(value = null) {
         if (value !== null) {
-            angular.element(layoutService.mapNode).toggleClass('rv-map-highlight', value);
+            angular.element(referenceService.mapNode).toggleClass('rv-map-highlight', value);
         }
     }
 
@@ -343,12 +343,12 @@ function mapServiceFactory($q, $timeout, layoutService, gapiService, configServi
      * @return {Promise} a promise resolving after map completes extent change
      */
     function zoomToFeature(proxy, oid) {
-        const offset = layoutService.mainPanelsOffset
+        const offset = referenceService.mainPanelsOffset
         const peekFactor = 0.4;
         // if either of the offsets is greater than 80%, peek at the map instead of offsetting the map extent
         if (offset.x > peekFactor || offset.y > peekFactor) {
             offset.x = offset.y = 0;
-            layoutService.peekAtMap();
+            referenceService.peekAtMap();
         }
 
         const zoomPromise = proxy.zoomToGraphic(

--- a/src/app/layout/layout-loader.js
+++ b/src/app/layout/layout-loader.js
@@ -1,5 +1,6 @@
 import './layout.module.js';
 import './animation.service.js';
 import './layout.service.js';
+import './reference.service.js';
 import './shell.directive.js';
 import './tooltip.decorator.js';

--- a/src/app/layout/layout.service.js
+++ b/src/app/layout/layout.service.js
@@ -9,7 +9,7 @@ angular
     .module('app.layout')
     .factory('layoutService', layoutService);
 
-function layoutService($rootElement, $rootScope) {
+function layoutService($rootElement, $rootScope, fullScreenService) {
 
     const ref = {
         onResizeSubscriptions: [] // [ { element: <Node>, listeners: [Function ... ] } ... ]
@@ -39,8 +39,8 @@ function layoutService($rootElement, $rootScope) {
         let elWidth;
         // IE doesn't like giving the correct width when in full screen
         // See: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2266#issuecomment-320984287
-        if ($rootElement[0].parentElement.className.includes('rv-full-screen')) {
-            elWidth = document.documentElement.clientWidth;
+        if (fullScreenService.isExpanded()) {
+            elWidth = screen.width
         } else {
             elWidth = $rootElement.width();
         }

--- a/src/app/layout/layout.service.js
+++ b/src/app/layout/layout.service.js
@@ -19,32 +19,13 @@ function layoutService($rootElement, $rootScope) {
         currentLayout,
         isShort,
 
-        panels: {},
-        panes: {}, // registry for content pane nodes,
-
-        _mapNode: null,
-        set mapNode (value) {
-            if (this._mapNode) {
-                console.error('Map node can only be set once');
-                return;
-            }
-
-            this._mapNode = value;
-        },
-
-        get mapNode () { return this._mapNode; },
-
-        get mainPanelsOffset () { return getPanelOffset() },
-
         onResize,
-        peekAtMap,
 
         LAYOUT: {
             SMALL: 'small',
             MEDIUM: 'medium',
             LARGE: 'large'
-        },
-        isFiltersVisible: false
+        }
     };
 
     return service;
@@ -144,58 +125,5 @@ function layoutService($rootElement, $rootScope) {
                 };
             };
         }
-    }
-
-    /**
-     * Briefly makes all panels almost transparent so the map underneath can be clearly see.
-     * Restores the regular opacity on the next click/touch event.
-     *
-     * @function peekAtMap
-     */
-    function peekAtMap() {
-        // filter out the shell it's a container for everything
-        const filteredPanels = Object.entries(service.panels)
-            .filter(( [name] ) => name !== 'shell')
-            .map(([name, panel]) => panel);
-
-        // convert panel of jQuery object into a jQuery array
-        const jQuerywrappedPanels = angular.element(angular.element.map(filteredPanels, el => el.get() ));
-
-        let ignoreClick = true;
-
-        // otherPanels.addClass('rv-lt-lg-hide');
-        jQuerywrappedPanels.addClass('rv-peek rv-peek-enabled');
-        jQuerywrappedPanels.on('click.peek mousedown.peek touchstart.peek', () =>
-            ignoreClick ? (ignoreClick = false) : _removePeekTransparency());
-        const deRegisterReiszeWatcher = service.onResize($rootElement, (newDimensions, oldDimensions) => {
-            if (newDimensions.width !== oldDimensions.width || newDimensions.height !== oldDimensions.height) {
-                _removePeekTransparency();
-            }
-        });
-
-        function _removePeekTransparency() {
-            jQuerywrappedPanels.removeClass('rv-peek-enabled');
-            jQuerywrappedPanels.off('.peek');
-            deRegisterReiszeWatcher();
-        }
-    }
-
-    /**
-     * Returns the main and data panel offsets relative to the visible map.
-     *
-     * @return {Object} fractions of the current extent occupied by main and data panels in the form of { x: <Number>, y: <Number> }
-     */
-    function getPanelOffset() {
-        // calculate what portion of the screen the main and filter panels take
-        const { main, table } = service.panels;
-
-        const offsetFraction = {
-            x: (main.filter(':visible').length > 0 ? main.width() : 0) /
-                service.mapNode.width() / 2,
-            y: (table.filter(':visible').length > 0 ? table.height() : 0) /
-                service.mapNode.height() / 2
-        };
-
-        return offsetFraction;
     }
 }

--- a/src/app/layout/reference.service.js
+++ b/src/app/layout/reference.service.js
@@ -1,0 +1,91 @@
+/**
+ * @module referenceService
+ * @memberof app.layout
+ *
+ * @description
+ * The `referenceService` service works as a reference manager for the rest of the application. `referenceService` exposes references for individual components.
+ */
+angular
+    .module('app.layout')
+    .factory('referenceService', referenceService);
+
+function referenceService($rootElement) {
+
+    const service = {
+        panels: {},
+        panes: {}, // registry for content pane nodes,
+
+        peekAtMap,
+
+        _mapNode: null,
+        set mapNode (value) {
+            if (this._mapNode) {
+                console.error('Map node can only be set once');
+                return;
+            }
+
+            this._mapNode = value;
+        },
+
+        get mapNode () { return this._mapNode; },
+
+        get mainPanelsOffset () { return getPanelOffset() },
+
+        isFiltersVisible: false
+    };
+
+    return service;
+
+    /**
+     * Briefly makes all panels almost transparent so the map underneath can be clearly see.
+     * Restores the regular opacity on the next click/touch event.
+     *
+     * @function peekAtMap
+     */
+    function peekAtMap() {
+        // filter out the shell it's a container for everything
+        const filteredPanels = Object.entries(service.panels)
+            .filter(( [name] ) => name !== 'shell')
+            .map(([name, panel]) => panel);
+
+        // convert panel of jQuery object into a jQuery array
+        const jQuerywrappedPanels = angular.element(angular.element.map(filteredPanels, el => el.get() ));
+
+        let ignoreClick = true;
+
+        // otherPanels.addClass('rv-lt-lg-hide');
+        jQuerywrappedPanels.addClass('rv-peek rv-peek-enabled');
+        jQuerywrappedPanels.on('click.peek mousedown.peek touchstart.peek', () =>
+            ignoreClick ? (ignoreClick = false) : _removePeekTransparency());
+        const deRegisterReiszeWatcher = service.onResize($rootElement, (newDimensions, oldDimensions) => {
+            if (newDimensions.width !== oldDimensions.width || newDimensions.height !== oldDimensions.height) {
+                _removePeekTransparency();
+            }
+        });
+
+        function _removePeekTransparency() {
+            jQuerywrappedPanels.removeClass('rv-peek-enabled');
+            jQuerywrappedPanels.off('.peek');
+            deRegisterReiszeWatcher();
+        }
+    }
+
+    /**
+     * Returns the main and data panel offsets relative to the visible map.
+     *
+     * @return {Object} fractions of the current extent occupied by main and data panels in the form of { x: <Number>, y: <Number> }
+     */
+    function getPanelOffset() {
+        // calculate what portion of the screen the main and filter panels take
+        const { main, table } = service.panels;
+
+        const offsetFraction = {
+            x: (main.filter(':visible').length > 0 ? main.width() : 0) /
+                service.mapNode.width() / 2,
+            y: (table.filter(':visible').length > 0 ? table.height() : 0) /
+                service.mapNode.height() / 2
+        };
+
+        return offsetFraction;
+    }
+}

--- a/src/app/layout/shell.directive.js
+++ b/src/app/layout/shell.directive.js
@@ -14,7 +14,7 @@ angular
     .module('app.layout')
     .directive('rvShell', rvShell);
 
-function rvShell($rootElement, $rootScope, events, stateManager, configService, layoutService,
+function rvShell($rootElement, $rootScope, events, stateManager, configService, layoutService, referenceService,
     mapToolService, debounceService, geoService) {
 
     const directive = {
@@ -41,7 +41,7 @@ function rvShell($rootElement, $rootScope, events, stateManager, configService, 
             scope.self.map = config.map;
         });
 
-        layoutService.panels.shell = el;
+        referenceService.panels.shell = el;
 
         // fix for IE 11 where focus can move to esri generated svg elements
         $rootScope.$on(events.rvApiReady, () => {

--- a/src/app/ui/appbar/appbar.directive.js
+++ b/src/app/ui/appbar/appbar.directive.js
@@ -19,7 +19,7 @@ angular
  * @function rvAppbar
  * @return {object} directive body
  */
-function rvAppbar(layoutService) {
+function rvAppbar(referenceService) {
     const directive = {
         restrict: 'E',
         templateUrl,
@@ -31,7 +31,7 @@ function rvAppbar(layoutService) {
     };
 
     function link(scope, el) {
-        layoutService.panels.sidePanel = el;
+        referenceService.panels.sidePanel = el;
     }
 
     return directive;

--- a/src/app/ui/basemap/basemap.directive.js
+++ b/src/app/ui/basemap/basemap.directive.js
@@ -17,6 +17,7 @@ function rvBasemap() {
     const directive = {
         restrict: 'E',
         templateUrl,
+        scope: {},
         controller: Controller,
         controllerAs: 'self',
         bindToController: true

--- a/src/app/ui/common/full-screen.service.js
+++ b/src/app/ui/common/full-screen.service.js
@@ -17,7 +17,7 @@ const FULL_SCREEN_Z_INDEX = 50;
 /**
  * @module fullScreenService
  * @memberof app.ui
- * @requires $rootElement, $timeout, layoutService, gapiService
+ * @requires $rootElement, $timeout, referenceService, gapiService
  * @description
  *
  * The `fullscreen` factory makes the map go "Boom!".
@@ -27,7 +27,7 @@ angular
     .module('app.ui')
     .factory('fullScreenService', fullScreenService);
 
-function fullScreenService($rootElement, $timeout, layoutService, gapiService, animationService, configService, appInfo) {
+function fullScreenService($rootElement, $timeout, referenceService, gapiService, animationService, configService, appInfo) {
     const ref = {
         isExpanded: false,
         toggleLock: false,
@@ -100,8 +100,8 @@ function fullScreenService($rootElement, $timeout, layoutService, gapiService, a
             });
 
             // get the container of all map layers
-            ref.mapContainerNode = layoutService.mapNode.find('> .container > .container');
-            ref.shellNode = layoutService.panels.shell;
+            ref.mapContainerNode = referenceService.mapNode.find('> .container > .container');
+            ref.shellNode = referenceService.panels.shell;
             ref.shellNodeBox = ref.shellNode[0].getBoundingClientRect();
 
             // make overflow on the root element visible so we can 'pop' the map shell out

--- a/src/app/ui/details/detail.service.js
+++ b/src/app/ui/details/detail.service.js
@@ -12,7 +12,7 @@ angular
     .module('app.ui')
     .factory('detailService', detailService);
 
-function detailService($mdDialog, stateManager, mapService, layoutService) {
+function detailService($mdDialog, stateManager, mapService, referenceService) {
 
     const service = {
         expandPanel,
@@ -30,7 +30,7 @@ function detailService($mdDialog, stateManager, mapService, layoutService) {
     function expandPanel(hasBackdrop = true) {
         $mdDialog.show({
             controller: () => {},
-            parent: layoutService.panels.shell,
+            parent: referenceService.panels.shell,
             locals: {
                 item: stateManager.display.details.selectedItem,
                 cancel: $mdDialog.cancel

--- a/src/app/ui/details/details-record-esrifeature.directive.js
+++ b/src/app/ui/details/details-record-esrifeature.directive.js
@@ -35,7 +35,7 @@ function rvDetailsRecordEsrifeature() {
     return directive;
 }
 
-function Controller($scope, events, mapService, geoService, configService, layoutService) {
+function Controller($scope, events, mapService, geoService, configService) {
     'ngInject';
     const self = this;
 

--- a/src/app/ui/export/export-sizes.service.js
+++ b/src/app/ui/export/export-sizes.service.js
@@ -14,7 +14,7 @@ angular
     .module('app.ui')
     .factory('exportSizesService', exportSizesService);
 
-function exportSizesService(ExportSize, layoutService) {
+function exportSizesService(ExportSize, referenceService) {
     const customOption = new ExportSize('export.size.custom', 1); // user types in the exact size
     const defaultOption = new ExportSize('export.size.default', 1); // default option is always the same size as the map/shell
     const tempOption = new ExportSize('export.size.custom', 1); // temp option is used as an intermediary step when setting a custom size
@@ -61,7 +61,7 @@ function exportSizesService(ExportSize, layoutService) {
      * @return {Object} itself
      */
     function update() {
-        const shellNode = layoutService.panels.shell;
+        const shellNode = referenceService.panels.shell;
         const [mapWidth, mapHeight] = [shellNode.width(), shellNode.height()];
 
         service.exportSizeRatio = mapWidth / mapHeight;

--- a/src/app/ui/export/export.service.js
+++ b/src/app/ui/export/export.service.js
@@ -20,7 +20,7 @@ angular
     .module('app.ui')
     .service('exportService', exportService);
 
-function exportService($mdDialog, $mdToast, layoutService) {
+function exportService($mdDialog, $mdToast, referenceService) {
     const service = {
         open,
         close
@@ -36,7 +36,7 @@ function exportService($mdDialog, $mdToast, layoutService) {
      * @param {Object} event original click event
      */
     function open(event) {
-        const shellNode = layoutService.panels.shell;
+        const shellNode = referenceService.panels.shell;
 
         $mdDialog.show({
             locals: {

--- a/src/app/ui/geosearch/geosearch.directive.js
+++ b/src/app/ui/geosearch/geosearch.directive.js
@@ -19,7 +19,7 @@ angular
  * @function rvGeosearch
  * @return {object} directive body
  */
-function rvGeosearch(layoutService, debounceService, globalRegistry, $rootElement, $rootScope,
+function rvGeosearch(layoutService, referenceService, debounceService, globalRegistry, $rootElement, $rootScope,
     stateManager, events) {
     const directive = {
         restrict: 'E',
@@ -40,7 +40,7 @@ function rvGeosearch(layoutService, debounceService, globalRegistry, $rootElemen
                 const debounceUpdateMaxHeight = debounceService.registerDebounce(newDimensions =>
                     geosearchContentNode.css('max-height', newDimensions.height - 10), 175, false, true); // 10 accounts for top margin :()
 
-                layoutService.onResize(layoutService.panels.main, debounceUpdateMaxHeight);
+                layoutService.onResize(referenceService.panels.main, debounceUpdateMaxHeight);
             }
 
             // force focus on open geosearch because sometimes it is lost

--- a/src/app/ui/geosearch/geosearch.service.js
+++ b/src/app/ui/geosearch/geosearch.service.js
@@ -10,7 +10,7 @@ angular
     .module('app.ui')
     .factory('geosearchService', geosearchService);
 
-function geosearchService($q, $rootScope, stateManager, layoutService, geoSearch, events, debounceService) {
+function geosearchService($q, $rootScope, stateManager, referenceService, geoSearch, events, debounceService) {
 
     const service = {
         isLoading: false, // waiting for results
@@ -29,7 +29,7 @@ function geosearchService($q, $rootScope, stateManager, layoutService, geoSearch
     };
 
     const ref = {
-        mainPanel: layoutService.panels.shell.find('[rv-state=main]'),
+        mainPanel: referenceService.panels.shell.find('[rv-state=main]'),
 
         runningRequestCount: 0 // used to track the latest query and discard results from previous ones if they resolve after an older query
     };

--- a/src/app/ui/help/help.service.js
+++ b/src/app/ui/help/help.service.js
@@ -102,7 +102,7 @@ function highlightFilter($sce) {
     };
 }
 
-function helpService($mdDialog, $translate, translations, layoutService) {
+function helpService($mdDialog, $translate, translations, referenceService) {
     // all help sections (populated when elements tagged with rv-help are created)
     const registry = [];
 
@@ -133,7 +133,7 @@ function helpService($mdDialog, $translate, translations, layoutService) {
             controllerAs: 'self',
             bindToController: true,
             templateUrl,
-            parent: layoutService.panels.shell,
+            parent: referenceService.panels.shell,
             disableParentScroll: false,
             clickOutsideToClose: true,
             fullscreen: false

--- a/src/app/ui/lightbox/lightbox.directive.js
+++ b/src/app/ui/lightbox/lightbox.directive.js
@@ -13,7 +13,7 @@ angular
     .module('app.ui')
     .directive('rvLightbox', rvLightbox);
 
-function rvLightbox($mdDialog, layoutService) {
+function rvLightbox($mdDialog, referenceService) {
     const directive = {
         restrict: 'A',
         scope: '=',
@@ -39,7 +39,7 @@ function rvLightbox($mdDialog, layoutService) {
 
                 $mdDialog.show({
                     controller: LightboxController,
-                    parent: layoutService.panels.shell,
+                    parent: referenceService.panels.shell,
                     locals: {
                         items: { images }
                     },

--- a/src/app/ui/metadata/metadata-expand.directive.js
+++ b/src/app/ui/metadata/metadata-expand.directive.js
@@ -34,7 +34,7 @@ function rvMetadataExpand() {
     return directive;
 }
 
-function Controller(stateManager, $mdDialog, layoutService) {
+function Controller(stateManager, $mdDialog, referenceService) {
     'ngInject';
     const self = this;
 
@@ -58,7 +58,7 @@ function Controller(stateManager, $mdDialog, layoutService) {
             controllerAs: 'self',
             disableParentScroll: false,
             bindToController: true,
-            parent: layoutService.panels.shell
+            parent: referenceService.panels.shell
         });
     }
 }

--- a/src/app/ui/metadata/metadata-panel.directive.js
+++ b/src/app/ui/metadata/metadata-panel.directive.js
@@ -19,7 +19,7 @@ angular
  * @function rvMetadataPanel
  * @return {object} directive body
  */
-function rvMetadataPanel(layoutService) {
+function rvMetadataPanel(referenceService) {
     const directive = {
         restrict: 'E',
         templateUrl,
@@ -33,7 +33,7 @@ function rvMetadataPanel(layoutService) {
     return directive;
 
     function link(scope, el) {
-        layoutService.panes.metadata = el;
+        referenceService.panes.metadata = el;
     }
 }
 

--- a/src/app/ui/panels/panel.directive.js
+++ b/src/app/ui/panels/panel.directive.js
@@ -20,7 +20,7 @@ angular
     .module('app.ui')
     .directive('rvPanel', rvPanel);
 
-function rvPanel(layoutService) {
+function rvPanel(referenceService) {
     const directive = {
         restrict: 'E',
         templateUrl: function (element, attr) {
@@ -47,7 +47,7 @@ function rvPanel(layoutService) {
      * @param {Array} attr directive's attributes
      */
     function link(scope, element, attr) {
-        layoutService.panels[attr.type] = element;
+        referenceService.panels[attr.type] = element;
     }
 }
 
@@ -55,11 +55,11 @@ function rvPanel(layoutService) {
  * Skeleton controller function.
  * @function Controller
  */
-function Controller($attrs, stateManager, layoutService, $element, debounceService) {
+function Controller($attrs, stateManager, referenceService, $element, debounceService) {
     'ngInject';
     const self = this;
 
-    layoutService.panels[$attrs.type] = $element;
+    referenceService.panels[$attrs.type] = $element;
 
     self.closePanel = self.closeButton !== 'false' ? closePanel() : undefined;
 

--- a/src/app/ui/sidenav/sidenav.service.js
+++ b/src/app/ui/sidenav/sidenav.service.js
@@ -42,7 +42,7 @@ angular
 
 // need to find a more elegant way to include all these dependencies
 function sideNavigationService($mdSidenav, $rootScope, $rootElement, globalRegistry, configService, events,
-    stateManager, basemapService, fullScreenService, exportService, layoutService, helpService, reloadService,
+    stateManager, basemapService, fullScreenService, exportService, referenceService, helpService, reloadService,
     translations, $mdDialog, pluginService) {
 
     const service = {
@@ -95,7 +95,7 @@ function sideNavigationService($mdSidenav, $rootScope, $rootElement, globalRegis
                     controller: service.ShareController,
                     controllerAs: 'self',
                     templateUrl: templateURLs.share,
-                    parent: layoutService.panels.shell,
+                    parent: referenceService.panels.shell,
                     disableParentScroll: false,
                     clickOutsideToClose: true,
                     fullscreen: false,
@@ -116,7 +116,7 @@ function sideNavigationService($mdSidenav, $rootScope, $rootElement, globalRegis
                     controller: service.AboutController,
                     controllerAs: 'self',
                     templateUrl: templateURLs.about,
-                    parent: layoutService.panels.shell,
+                    parent: referenceService.panels.shell,
                     disableParentScroll: false,
                     clickOutsideToClose: true,
                     fullscreen: false

--- a/src/app/ui/table/table-default-menu.directive.js
+++ b/src/app/ui/table/table-default-menu.directive.js
@@ -34,7 +34,7 @@ function rvTableDefaultMenu(layoutService) {
     }
 }
 
-function Controller($scope, stateManager, events, tableService, appInfo, $rootScope, layoutService) {
+function Controller($scope, stateManager, events, tableService, appInfo, $rootScope, referenceService) {
     'ngInject';
     const self = this;
 
@@ -53,7 +53,7 @@ function Controller($scope, stateManager, events, tableService, appInfo, $rootSc
     function showFilters() {
         stateManager.display.table.data.filter.isOpen = self.filter.isOpen; // set on layer so it will persist when we switch between layers
         // always show filters if settings panel is open
-        layoutService.isFiltersVisible = tableService.isSettingOpen ? true : stateManager.display.table.data.filter.isOpen;
+        referenceService.isFiltersVisible = tableService.isSettingOpen ? true : stateManager.display.table.data.filter.isOpen;
     }
 
     function setMode(mode) {

--- a/src/app/ui/table/table-default.directive.js
+++ b/src/app/ui/table/table-default.directive.js
@@ -68,7 +68,7 @@ angular
  * @function rvTableDefault
  * @return {object} directive body
  */
-function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $translate, layoutService,
+function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $translate, referenceService, layoutService,
     detailService, $rootElement, $filter, keyNames, $sanitize, debounceService, configService, SymbologyStack,
     tableService, events) {
 
@@ -97,7 +97,7 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
         self.createTable = createTable;
         self.destroyTable = destroyTable;
 
-        layoutService.panes.table = el;
+        referenceService.panes.table = el;
 
         // columns type with filters information
         const columnTypes = {

--- a/src/app/ui/table/table-definition.directive.js
+++ b/src/app/ui/table/table-definition.directive.js
@@ -140,7 +140,7 @@ angular
  * @function rvTableDefinition
  * @return {object} directive body
  */
-function rvTableDefinition(stateManager, events, $compile, tableService, layoutService, $rootScope) {
+function rvTableDefinition(stateManager, events, $compile, tableService, referenceService, $rootScope) {
     const directive = {
         restrict: 'A',
         template: '',
@@ -284,7 +284,7 @@ function rvTableDefinition(stateManager, events, $compile, tableService, layoutS
 
             filter.scope.self[column.simpleColumnName] = column.filter;
 
-            $rootScope.$watch(() => layoutService.isFiltersVisible, val => { filter.self[column.simpleColumnName].filtersVisible = val });
+            $rootScope.$watch(() => referenceService.isFiltersVisible, val => { filter.self[column.simpleColumnName].filtersVisible = val });
 
             // create directive
             const template = FILTERS_TEMPLATE[column.type](column.simpleColumnName);

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -12,7 +12,7 @@ angular
     .factory('tableService', tableService);
 
 function tableService(stateManager, geoService, $rootScope, $q, gapiService, debounceService, $rootElement, $timeout,
-    layoutService, layerRegistry) {
+    referenceService, layerRegistry) {
 
     // timestamps can be watched for key changes to filter data
     const filterTimeStamps = {
@@ -321,10 +321,10 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
 
         // show filters if setting is open
         if (service.isSettingOpen) {
-            layoutService.isFiltersVisible = true;
+            referenceService.isFiltersVisible = true;
         } else {
             // when setting is close, check if we need to show setting
-            layoutService.isFiltersVisible = service.filter.isOpen;
+            referenceService.isFiltersVisible = service.filter.isOpen;
 
             // need to recalculate scroller space because user may have switch from default to full view inside setting panel
             // need a timeout, if not measure occurs when datatable is not displayed and it fails
@@ -491,7 +491,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
 
         // check if we need to show the filters (need this check when table is created)
         // always show filters if settings panel is open
-        layoutService.isFiltersVisible = service.isSettingOpen ? true : service.filter.isOpen;
+        referenceService.isFiltersVisible = service.isSettingOpen ? true : service.filter.isOpen;
 
         // set layer type to see if we show apply filter button. Only works on feature/dynamic layer
         // user added layer (layer created by value from a feature collection like CSV file) does not support definition expressions and time definitions)

--- a/src/app/ui/toc/toc.directive.js
+++ b/src/app/ui/toc/toc.directive.js
@@ -16,7 +16,7 @@ angular
     .module('app.ui')
     .directive('rvToc', rvToc);
 
-function rvToc($timeout, layoutService, layerRegistry, dragulaService, geoService, animationService, configService) {
+function rvToc($timeout, referenceService, layerRegistry, dragulaService, geoService, animationService, configService) {
     const directive = {
         restrict: 'E',
         templateUrl,
@@ -40,8 +40,8 @@ function rvToc($timeout, layoutService, layerRegistry, dragulaService, geoServic
         directiveElement.on('touchstart', () =>
             (isTouchDetected = true));
 
-        // register toc node with layoutService so it can be targeted
-        layoutService.panes.toc = directiveElement;
+        // register toc node with referenceService so it can be targeted
+        referenceService.panes.toc = directiveElement;
 
         // TODO convert this object into an ES6 class
         // jscs doesn't like enhanced object notation

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -11,7 +11,7 @@ angular
     .module('app.ui')
     .factory('tocService', tocService);
 
-function tocService($q, $rootScope, $mdToast, $translate, layoutService, stateManager, graphicsService,
+function tocService($q, $rootScope, $mdToast, $translate, referenceService, stateManager, graphicsService,
     geoService, metadataService, errorService, debounceService, $timeout, LegendBlock, configService,
     legendService) {
 
@@ -116,7 +116,7 @@ function tocService($q, $rootScope, $mdToast, $translate, layoutService, stateMa
         const undoToast = $mdToast.simple()
         .textContent($translate.instant('toc.label.state.remove'))
         .action($translate.instant('toc.label.action.remove'))
-        .parent(layoutService.panes.toc)
+        .parent(referenceService.panes.toc)
         .position('bottom rv-flex');
 
         // promise resolves with 'ok' when user clicks 'undo'
@@ -295,7 +295,7 @@ function tocService($q, $rootScope, $mdToast, $translate, layoutService, stateMa
             })
             .catch(() => {
                 errorToast = errorService.display($translate.instant('toc.error.resource.loadfailed'),
-                    layoutService.panes.filter);
+                    referenceService.panes.filter);
             });
     }
 
@@ -393,7 +393,7 @@ function tocService($q, $rootScope, $mdToast, $translate, layoutService, stateMa
             })
             .catch(() => {
                 errorToast = errorService.display($translate.instant('toc.error.resource.loadfailed'),
-                    layoutService.panes.filter);
+                    referenceService.panes.filter);
             });
     }
 
@@ -437,7 +437,7 @@ function tocService($q, $rootScope, $mdToast, $translate, layoutService, stateMa
 
             }).catch(error => {
                 errorService.display($translate.instant('toc.error.resource.loadfailed'),
-                    layoutService.panes.metadata);
+                    referenceService.panes.metadata);
 
                 // display manager will stop the progress bar when datapromise is rejected
                 reject(error);

--- a/src/app/ui/tooltip/tooltip.service.js
+++ b/src/app/ui/tooltip/tooltip.service.js
@@ -20,7 +20,7 @@ angular
     .module('app.ui')
     .factory('tooltipService', tooltipService);
 
-function tooltipService($rootScope, $compile, $q, layoutService, events) {
+function tooltipService($rootScope, $compile, $q, referenceService, events) {
     /**
      * Tooltip's origin point is generally the position of the initial mouse cursor or clientX/Y of a mouse event when the tooltip was first created.
      * Movement and Collision strategies are defined in the TooltipService on initialization and then passed to Tooltip instances.
@@ -418,8 +418,8 @@ function tooltipService($rootScope, $compile, $q, layoutService, events) {
 
         // create both tooltip movement strategies
         ref.followMapStrategy = new FollowMap();
-        ref.followMouseStrategy = new FollowMouse(layoutService.panels.shell);
-        ref.containInsideStrategy = new ContainInside(layoutService.panels.shell);
+        ref.followMouseStrategy = new FollowMouse(referenceService.panels.shell);
+        ref.containInsideStrategy = new ContainInside(referenceService.panels.shell);
     }
 
     /**
@@ -437,7 +437,7 @@ function tooltipService($rootScope, $compile, $q, layoutService, events) {
         removeHoverTooltip();
 
         ref.hoverTooltip = new Tooltip(ref.followMouseStrategy, ref.containInsideStrategy, content, tooltipScope);
-        layoutService.panels.shell.append(ref.hoverTooltip.node);
+        referenceService.panels.shell.append(ref.hoverTooltip.node);
 
         ref.hoverTooltip.position(point.x, point.y);
 


### PR DESCRIPTION
## Description
Closes #2266 and related issues.

Split `layoutService` into two separate services:
- `LayoutService` works with actual layout (`currentLayout`, `isShort`, etc.)
- `ReferenceService` works with panels, mapnode, etc.

## Testing
Visually tested.

## Documentation
`reference.service` description

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2337)
<!-- Reviewable:end -->
