### PR TITLE
fix(datatable): change focus link to allow proper tabbing

### DIFF
--- a/src/app/core/bookmark.service.js
+++ b/src/app/core/bookmark.service.js
@@ -152,9 +152,9 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
      */
     function hexToBinary(value) {
         const hexes = value.match(/./g); // split into single chars
-        return hexes.map(h => {
-            return encodeInteger(parseInt(h, 16), 4); // 4-digit padded binary
-        }).join('');
+        return hexes.map(h =>
+            encodeInteger(parseInt(h, 16), 4) // 4-digit padded binary
+        ).join('');
     }
 
     /**
@@ -217,12 +217,12 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
         // and let them go back to default when bookmark loads
         const goodState = state => {
             switch (state) {
-                case Geo.Layer.States.ERROR:
-                case Geo.Layer.States.LOADING:
-                case Geo.Layer.States.NEW:
-                    return false;
-                default:
-                    return true;
+            case Geo.Layer.States.ERROR:
+            case Geo.Layer.States.LOADING:
+            case Geo.Layer.States.NEW:
+                return false;
+            default:
+                return true;
             }
         };
 
@@ -602,7 +602,7 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
      * @returns {String}        The encoded string
      */
     function encode64(string) {
-        return btoa(string).replace(/=/g, '').replace(/\//g, '_').replace(/\+/g, '-');
+        return btoa(string).replace(/\=/g, '').replace(/\//g, '_').replace(/\+/g, '-');
     }
 
     /**

--- a/src/app/core/displaymanager.service.js
+++ b/src/app/core/displaymanager.service.js
@@ -108,7 +108,7 @@ function displayManager($timeout, $q, $rootElement) {
             // whenever a panel is opened (or updated) create a focus link between the element which triggered the
             // panel change to the first focusable element in the panel.
             animationPromise.then(() => {
-                const sourceEl = $rootElement.find(`[data-legend-id="${requester.id}"] button`).filter(':visible').first();
+                const sourceEl = $rootElement.find(`[legend-block-id="${requester.id}"] button`).filter(':visible').first();
                 $(sourceEl).link($rootElement.find(`[rv-state="${panelName}"]`));
             });
 

--- a/src/app/core/displaymanager.service.js
+++ b/src/app/core/displaymanager.service.js
@@ -107,7 +107,10 @@ function displayManager($timeout, $q, $rootElement) {
 
             // whenever a panel is opened (or updated) create a focus link between the element which triggered the
             // panel change to the first focusable element in the panel.
-            animationPromise.then(() => $.link($rootElement.find(`[rv-state="${panelName}"]`)));
+            animationPromise.then(() => {
+                const sourceEl = $rootElement.find(`[data-legend-id="${requester.id}"] button`).filter(':visible').first();
+                $(sourceEl).link($rootElement.find(`[rv-state="${panelName}"]`));
+            });
 
             // update requestId and the requester object
             display.requester = requester;

--- a/src/app/core/reload.service.js
+++ b/src/app/core/reload.service.js
@@ -187,7 +187,7 @@ function reloadService(events, bookmarkService, geoService, configService, state
         // TODO if we find this blocking check is redundant, we can get rid of
         //      this function and just call loadWithBookmark directly
         if (service.bookmarkBlocking) {
-           loadWithBookmark(bookmark, true, keys);
+            loadWithBookmark(bookmark, true, keys);
         }
     }
 

--- a/src/app/core/statemanager.constant.service.js
+++ b/src/app/core/statemanager.constant.service.js
@@ -23,14 +23,14 @@ const STATE_OBJECT_DEFAULTS = (parentName, displayName) => {
     }
 };
 
-const DISPLAY_OBJECT_DEFAULTS = data => {
-    return {
+const DISPLAY_OBJECT_DEFAULTS = data =>
+    ({
         isLoading: false,
         requester: null,
         requestId: null,
         data: data || null
-    };
-};
+    });
+
 
 /**
  * @member initialState

--- a/src/app/core/statemanager.service.js
+++ b/src/app/core/statemanager.service.js
@@ -156,8 +156,9 @@ function stateManager($q, $rootScope, displayManager, initialState, initialDispl
      * @return  {Promise}   resolves when a panel has finished its closing animation
      */
     function closePanelFromHistory() {
-        const promise = service.panelHistory.length > 0 ? closePanel(getItem(service.panelHistory.pop()))
-                                                        : $q.resolve();
+        const promise = service.panelHistory.length > 0 ?
+            closePanel(getItem(service.panelHistory.pop())) :
+            $q.resolve();
 
         return promise;
     }
@@ -224,18 +225,18 @@ function stateManager($q, $rootScope, displayManager, initialState, initialDispl
                 fulfill(true);
             }
         })
-        .then(skipEvent => {
-            if (!skipEvent) {
-                // emit event on the rootscope when change is complete
-                $rootScope.$broadcast('stateChangeComplete', itemName, property, value, skip);
+            .then(skipEvent => {
+                if (!skipEvent) {
+                    // emit event on the rootscope when change is complete
+                    $rootScope.$broadcast('stateChangeComplete', itemName, property, value, skip);
 
-                // record history of `active` changes only
-                if (property === 'morph') {
-                    return;
+                    // record history of `active` changes only
+                    if (property === 'morph') {
+                        return;
+                    }
                 }
-            }
-            return;
-        });
+                return;
+            });
     }
 
     /**
@@ -404,8 +405,9 @@ function stateManager($q, $rootScope, displayManager, initialState, initialDispl
             animationPromise = setItemProperty(panelToClose.name, 'active', false)
                 .then(() =>
                     // wait for all child transition promises to resolve
-                    propagate ? $q.all(getChildren(panelToClose.name).map(child => closePanel(child, false)))
-                                : true
+                    propagate ?
+                        $q.all(getChildren(panelToClose.name).map(child => closePanel(child, false))) :
+                        true
                 );
 
         // closing child panel
@@ -460,11 +462,10 @@ function stateManager($q, $rootScope, displayManager, initialState, initialDispl
      */
     function getChildren(parentName) {
         return Object.keys(service.state)
-            .filter(key =>
-                service.state[key].parent === parentName)
+            .filter(key => service.state[key].parent === parentName)
             .map(key => ({
-                    name: key,
-                    item: service.state[key]
-                }));
+                name: key,
+                item: service.state[key]
+            }));
     }
 }

--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -431,15 +431,15 @@ function onFocusin(event) {
 
     viewer.setDialogAction(() =>
         viewer.mdDialog
-        .show({
-            contentElement: viewer.rootElement.find('.rv-focus-dialog-content > div'),
-            clickOutsideToClose: false,
-            escapeToClose: false,
-            disableParentScroll: false,
-            parent: viewer.rootElement.find('rv-shell'),
-            focusOnOpen: false
-        })
-        .then(() => viewer.clearTabindex()));
+            .show({
+                contentElement: viewer.rootElement.find('.rv-focus-dialog-content > div'),
+                clickOutsideToClose: false,
+                escapeToClose: false,
+                disableParentScroll: false,
+                parent: viewer.rootElement.find('rv-shell'),
+                focusOnOpen: false
+            })
+            .then(() => viewer.clearTabindex()));
 }
 
 /**

--- a/src/app/geo/geo-search.service.js
+++ b/src/app/geo/geo-search.service.js
@@ -238,9 +238,9 @@ function geoSearch($http, $q, configService, geoService, mapService, gapiService
                 position: item.position.coordinates
             }))))
             .then(res => res.length === 0 ?
-                    $http.get(serviceUrls.geoSuggest + q)
-                        .then(s => ({ suggestions: s.data.suggestions, results: [] })) :
-                    { results: res }
+                $http.get(serviceUrls.geoSuggest + q)
+                    .then(s => ({ suggestions: s.data.suggestions, results: [] })) :
+                { results: res }
             ));
 
         // return value from geogratis and geonames services

--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -188,7 +188,7 @@ function rvInitMap($rootScope, geoService, events, referenceService, $rootElemen
         let hasShiftMultiplier = 1;
         for (let i = 0; i < keyMap.length; i++) {
             switch (keyMap[i]) {
-                // enter key is pressed - trigger identify
+            // enter key is pressed - trigger identify
             case 13:
                 // prevent identify if focus manager is in a waiting state since ENTER key is used to activate the focus manager.
                 // Also disable if SHIFT key is depressed so identify is not triggered on leaving focus manager

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -112,7 +112,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
         let position = 0;
         // find an appropriate spot in a auto legend;
         if (pos) {   // If the order from bookmark exists
-           position = pos;
+            position = pos;
         } else if (configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE) {
             position = legendBlocks.entries.findIndex(block =>
                 sortGroups[block.layerType] === sortGroups[importedLegendBlock.layerType]);

--- a/src/app/geo/map-tools.service.js
+++ b/src/app/geo/map-tools.service.js
@@ -176,8 +176,10 @@ function mapToolService(configService, geoService, gapiService, $translate) {
         const mx = Math.floor(Math.abs((long - dx) * 60));
         const sx = Math.round((Math.abs(long) - Math.abs(dx) - mx / 60) * 3600);
 
-        return { y: `${Math.abs(dy)}${cardinal.deg} ${padZero(my)}\' ${padZero(sy)}\"`,
-                x: `${Math.abs(dx)}${cardinal.deg} ${padZero(mx)}\' ${padZero(sx)}\"` };
+        return {
+            y: `${Math.abs(dy)}${cardinal.deg} ${padZero(my)}\' ${padZero(sy)}\"`,
+            x: `${Math.abs(dx)}${cardinal.deg} ${padZero(mx)}\' ${padZero(sx)}\"`
+        };
     }
 
     /**

--- a/src/app/ui/common/full-screen.service.js
+++ b/src/app/ui/common/full-screen.service.js
@@ -193,7 +193,6 @@ function fullScreenService($rootElement, $timeout, referenceService, gapiService
         const map = configService.getSync.map.instance;
         const originalPanDuration = map.mapDefault('panDuration');
         map.mapDefault('panDuration', 0);
-        // TODO: fix after geoapi allows this through
         map.resize();
         map.reposition();
 

--- a/src/app/ui/common/full-screen.service.js
+++ b/src/app/ui/common/full-screen.service.js
@@ -194,14 +194,14 @@ function fullScreenService($rootElement, $timeout, referenceService, gapiService
         const originalPanDuration = map.mapDefault('panDuration');
         map.mapDefault('panDuration', 0);
         // TODO: fix after geoapi allows this through
-        map._map.resize();
-        map._map.reposition();
+        map.resize();
+        map.reposition();
 
         // wait for a bit before recentring the map
         // if call right after animation completes, the map object still confused about its true size and extent
         $timeout(() => {
             // center the map
-            map._map.centerAt(ref.trueCenterPoint);
+            map.centerAt(ref.trueCenterPoint);
 
             // clear offset properties on the map container node
             animationService.set(ref.mapContainerNode, {

--- a/src/app/ui/common/stepper/stepper.class.js
+++ b/src/app/ui/common/stepper/stepper.class.js
@@ -126,8 +126,8 @@ function StepperFactory($q) {
             let isMoveCanceled = false;
             // create a cancel promise for the move can be canceled by calling `cancelMove` on the stepper instance
             // technically, it's a deferred
-            const cancelPromise = $q(resolve =>
-                (this._resolveCancelPromise = resolve)).then(() => {
+            const cancelPromise = $q(resolve => (this._resolveCancelPromise = resolve))
+                .then(() => {
                     isMoveCanceled = true;
                     this._think(currentStep, false);
                 });

--- a/src/app/ui/details/layer-list-slider.directive.js
+++ b/src/app/ui/details/layer-list-slider.directive.js
@@ -45,11 +45,11 @@ function rvLayerListSlider(animationService) {
 
         // This will explicitly "animate" the overflow property from hidden to auto and not try to figure
         // out what it was initially on the reverse run.
-        .fromTo(element, 0.01, {
-            'overflow-y': 'hidden'
-        }, {
-            'overflow-y': 'auto'
-        }, RV_SLIDE_DURATION / 2);
+            .fromTo(element, 0.01, {
+                'overflow-y': 'hidden'
+            }, {
+                'overflow-y': 'auto'
+            }, RV_SLIDE_DURATION / 2);
 
         // Place rv-expanded class on parent element once defined in details.directive.js
         const pElemWatcher = scope.$watch(self.getSectionNode, node => {

--- a/src/app/ui/geosearch/geosearch-bar.directive.js
+++ b/src/app/ui/geosearch/geosearch-bar.directive.js
@@ -121,9 +121,9 @@ function Controller(appInfo, sideNavigationService, debounceService, geosearchSe
      * @return {Promise} a promise resolving with geo search query suggestion if any
      */
     function getSuggestions() {
-        const suggestionsPromise = geosearchService.runQuery().then((data = {}) => {
-            return data.suggestions || [];
-        });
+        const suggestionsPromise = geosearchService.runQuery().then((data = {}) =>
+            data.suggestions || []
+        );
 
         return suggestionsPromise;
     }

--- a/src/app/ui/help/help.service.js
+++ b/src/app/ui/help/help.service.js
@@ -224,6 +224,7 @@ function helpService($mdDialog, $translate, translations, referenceService) {
                 mdStr = mdStr.replace(new RegExp(String.fromCharCode(13), 'g'), '');
 
                 // start breaking down markdown file into sections where h1 headers (#) denote a new section
+                // eslint-disable-next-line no-cond-assign
                 while (section = reg.exec(mdStr)) { // jshint ignore:line
                     self.sections.push({
                         header: section[1],

--- a/src/app/ui/lightbox/lightbox.directive.js
+++ b/src/app/ui/lightbox/lightbox.directive.js
@@ -26,7 +26,7 @@ function rvLightbox($mdDialog, referenceService) {
 
     function link(scope, element) {
 
-        element.on('click', (event) => {
+        element.on('click', event => {
             // prevent the link from opening
             event.preventDefault(true);
             event.stopPropagation(true);
@@ -35,7 +35,7 @@ function rvLightbox($mdDialog, referenceService) {
 
             if (imgs.length > 0) {
                 const images = [];
-                imgs.each((index) => { images.push(imgs[index].src); });
+                imgs.each(index => { images.push(imgs[index].src); });
 
                 $mdDialog.show({
                     controller: LightboxController,

--- a/src/app/ui/table/table-default.directive.js
+++ b/src/app/ui/table/table-default.directive.js
@@ -178,12 +178,9 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
                 oSettings.aaSorting = [];
 
                 /* Sort display arrays so we get them in numerical order */
-                oSettings.aiDisplay.sort((x,y) => {
-                    return x-y;
-                });
-                oSettings.aiDisplayMaster.sort((x,y) => {
-                    return x-y;
-                });
+                oSettings.aiDisplay.sort((x,y) => x-y);
+
+                oSettings.aiDisplayMaster.sort((x,y) => x-y);
 
                 /* Redraw */
                 oSettings.oApi._fnReDraw(oSettings);
@@ -441,6 +438,7 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
             * @private
             * @param {Object} config    configuration file for table
             */
+            // eslint-disable-next-line complexity
             function customizeTable(config = {}) {
                 // set title and description
                 displayData.filter.title = config.title ?

--- a/src/app/ui/table/table-definition.directive.js
+++ b/src/app/ui/table/table-definition.directive.js
@@ -70,7 +70,7 @@ const FILTERS_TEMPLATE = {
                         ng-disabled="self.${column}.static" />
             </md-input-container>
         </div>`,
-    selector: (column) =>
+    selector: column =>
         `<div class="rv-filter-selector" ng-show="self.${column}.filtersVisible">
             <md-input-container class="md-block" md-no-float flex>
                 <md-select ng-click="self.prevent($event)"
@@ -177,7 +177,7 @@ function rvTableDefinition(stateManager, events, $compile, tableService, referen
         transclude(() => {
             if (!el[0].hasChildNodes() && typeof scope.self.info !== 'undefined' &&
                 (scope.self.info.data !== 'rvSymbol' && scope.self.info.data !== 'rvInteractive')) {
-                    // if filter is not visible. This happen for customize columns where user doesn't want to have a filter.
+                // if filter is not visible. This happen for customize columns where user doesn't want to have a filter.
                 if (typeof scope.self.info.filter !== 'undefined') {
                     const filterInfo = setFilter(scope.self.info);
                     el.append(filterInfo.directive);
@@ -290,8 +290,10 @@ function rvTableDefinition(stateManager, events, $compile, tableService, referen
             const template = FILTERS_TEMPLATE[column.type](column.simpleColumnName);
 
             // return directive, scope and column type
-            return { directive: $compile(template)(filter.scope),
-                    scope: filter.scope.self[column.simpleColumnName] };
+            return {
+                directive: $compile(template)(filter.scope),
+                scope: filter.scope.self[column.simpleColumnName]
+            };
         }
 
         /**
@@ -327,6 +329,7 @@ function rvTableDefinition(stateManager, events, $compile, tableService, referen
          * @param {Integer} index    the column index to retreive the data to filter on
          */
         function setDateFilter(filter, index) {
+            // eslint-disable-next-line complexity
             $.fn.dataTable.ext.searchTemp.push((settings, data) => {
                 // check if it is a valid date and remove leading 0 because it doesn't set the date properly
                 const i = settings._colReorder.fnTranspose(index); // get the real index if columns have been reordered

--- a/src/app/ui/table/table-search.directive.js
+++ b/src/app/ui/table/table-search.directive.js
@@ -190,6 +190,7 @@ function Controller(tableService, debounceService, $timeout, $rootElement, state
      * @param {String} column column name to search on
      * @param {String} value the search term
      */
+    // eslint-disable-next-line complexity
     function setFilterInfo(column, value) {
         // default filter object
         const filter = { column, searchTerm: null, operator: null };

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -252,6 +252,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
      * @param   {Object}   column   column object
      * @return {Array} defs definition queries array
      */
+    // eslint-disable-next-line complexity
     function getFilterDefintion(defs, column) {
         /*jshint maxcomplexity:11 */
         if (column.type === 'string') {

--- a/src/app/ui/toc/legend-control.directive.js
+++ b/src/app/ui/toc/legend-control.directive.js
@@ -33,10 +33,8 @@ angular
 function rvLegendControl(LegendElementFactory) {
     const directive = {
         restrict: 'E',
-        templateUrl: (elm, attr) => {
-            // returns a different templateUrl based on the value of the templateUrl attribute
-            return templateUrl[attr.template || 'button'];
-        },
+        // returns a different templateUrl based on the value of the templateUrl attribute
+        templateUrl: (elm, attr) => templateUrl[attr.template || 'button'],
         scope: {
             block: '=',
             name: '@'

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -285,9 +285,10 @@ function rvSymbologyStack($q, Geo, animationService) {
                 }, 0);
 
                 // wiggle the last icon in the stack
-                timeline.to(ref.symbolItems.slice(-1)
-                    .pop()
-                    .container, RV_DURATION, {
+                timeline.to(
+                    ref.symbolItems.slice(-1).pop().container,
+                    RV_DURATION,
+                    {
                         x: `+=${displacement}px`,
                         y: `+=${displacement}px`,
                         ease: RV_SWIFT_IN_OUT_EASE

--- a/src/app/ui/toc/toc.html
+++ b/src/app/ui/toc/toc.html
@@ -39,7 +39,8 @@
             <!-- filter: { controlled: false } will filter out layer controled by a dynamic layer which is rendered as a group -->
             <li ng-repeat="block in $dxPrior.entries | filter: { controlled: false } track by block.id"
                 class="rv-toggle-slide"
-                data-sort-group="{{ ::block.sortGroup }}">
+                data-sort-group="{{ ::block.sortGroup }}"
+                data-legend-id="{{ block.id }}">
 
                 <!-- legend block -->
                 <rv-legend-block

--- a/src/app/ui/toc/toc.html
+++ b/src/app/ui/toc/toc.html
@@ -40,7 +40,7 @@
             <li ng-repeat="block in $dxPrior.entries | filter: { controlled: false } track by block.id"
                 class="rv-toggle-slide"
                 data-sort-group="{{ ::block.sortGroup }}"
-                data-legend-id="{{ block.id }}">
+                legend-block-id="{{ block.id }}">
 
                 <!-- legend block -->
                 <rv-legend-block

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -114,15 +114,15 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, stat
 
         // create notification toast
         const undoToast = $mdToast.simple()
-        .textContent($translate.instant('toc.label.state.remove'))
-        .action($translate.instant('toc.label.action.remove'))
-        .parent(referenceService.panes.toc)
-        .position('bottom rv-flex');
+            .textContent($translate.instant('toc.label.state.remove'))
+            .action($translate.instant('toc.label.action.remove'))
+            .parent(referenceService.panes.toc)
+            .position('bottom rv-flex');
 
         // promise resolves with 'ok' when user clicks 'undo'
         $mdToast.show(undoToast)
-        .then(response =>
-            response === 'ok' ? _restoreLegendBlock() : resolve());
+            .then(response =>
+                response === 'ok' ? _restoreLegendBlock() : resolve());
 
         console.log(stateManager.display);
 
@@ -149,9 +149,7 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, stat
                 else if (panelDisplay.requester && legendBlock.entries) {
                     // walk thruogh the children of the current block to see if there's an open panel being removed
                     return legendBlock
-                        .walk(lb => {
-                            return lb.id === panelDisplay.requester.id ? lb.id : null;
-                        })
+                        .walk(lb => lb.id === panelDisplay.requester.id ? lb.id : null)
                         .filter(a => a)[0] ? panelName : null;
                 } else {
                     return null;

--- a/src/app/ui/tooltip/tooltip.directive.js
+++ b/src/app/ui/tooltip/tooltip.directive.js
@@ -32,7 +32,7 @@ function rvTooltip($q, debounceService) {
 
             // TODO: use layoutservice on resize here somehow to avoid duplication
             scope.$watch(watchBBoxChanges, newDimensions =>
-                    debouncedUpdateDimensions(newDimensions), true); // the last argument (true) is set for $watch to do object equality comparison instead of reference equality
+                debouncedUpdateDimensions(newDimensions), true); // the last argument (true) is set for $watch to do object equality comparison instead of reference equality
 
             /**
              * @function watchBBoxChanges


### PR DESCRIPTION
## Description
Closes #1636 - focus link is set between legend block button and first focusable element in table
Also cleaned up some console warnings

## Testing
Visually tested

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2343)
<!-- Reviewable:end -->
