### PR TITLE
2131 2345 confusing opacity slider and stuck legend stack

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "FGPV Config Schema",
     "type": "object",
-    "version": 2.0,
+    "version": 2.1,
     "comments": "FIXME: when draft 05 is release redo schema inheritance with patching / merging if they are accepted",
     "additionalProperties": false,
 
@@ -267,7 +267,8 @@
                     "items": { "oneOf": [ { "$ref": "#/definitions/entryGroup" }, { "$ref": "#/definitions/visibilitySet" }, { "$ref": "#/definitions/entry" }, { "$ref": "#/definitions/infoSection" } ] },
                     "minItems": 1
                 },
-                "controls": { "$ref": "#/definitions/legendGroupControls" }
+                "controls": { "$ref": "#/definitions/legendGroupControls" },
+                "disabledControls": { "$ref": "#/definitions/legendGroupControls" }
             },
             "required": ["name", "children"],
             "additionalProperties": false

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1183,7 +1183,10 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                 entryGroupSource.disabledControls,
                 DEFAULTS.legend[TYPES.legend.GROUP].controls) :
                 DEFAULTS.legend[TYPES.legend.GROUP].disabledControls;
-            this._userDisabledControls = [];
+            this._userDisabledControls = angular.isArray(entryGroupSource.userDisabledControls) ? common.intersect(
+                entryGroupSource.userDisabledControls,
+                DEFAULTS.legend[TYPES.legend.GROUP].controls) :
+                [];
 
             this._expanded = entryGroupSource.expanded || false;
 

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -1029,7 +1029,7 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
      * @return {Boolean} true if the control specified should be disabled in the UI
      */
     function isControlDisabled(controlName) {
-        return this.disabledControls.indexOf(controlName) !== -1;
+        return this.isControlSystemDisabled(controlName) || this.isControlUserDisabled(controlName);
     }
 
     /**
@@ -1041,7 +1041,7 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
      * @return {Boolean} true if the control specified is locked from modifications by the system and user
      */
     function isControlSystemDisabled(controlName) {
-        return this.isControlDisabled(controlName);
+        return this.disabledControls.indexOf(controlName) !== -1;
     }
 
     /**

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -462,12 +462,6 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
 
             const groupDefaults = ConfigObject.DEFAULTS.legend[ConfigObject.TYPES.legend.GROUP];
 
-            // dynamic children might not support opacity if the layer is not a true dynamic layer
-            // do not disable opacity on single entry collapsed blocks
-            if (!layerRecord.isTrueDynamic && !layerConfig.singleEntryCollapse) {
-                dynamicLayerChildDefaults.userDisabledControls.push('opacity');
-            }
-
             layerRecord.derivedChildConfigs = [];
             const tree = layerRecord.getChildTree();
             tree.forEach(treeChild =>
@@ -590,6 +584,16 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
                         layerEntryConfig.source,
                         dynamicLayerChildDefaults,
                         parentLayerConfigSource);
+
+                    // dynamic children might not support opacity if the layer is not a true dynamic layer
+                    // in such cases the opacity control is user disabled for all children and opacity of the whole layer should be changed at the root
+                    // in single entry collapse cases, the root is hidden, and opacity control is left user enabled at the top single entry; all subsequent children are user disabled as usual
+                    if (!layerRecord.isTrueDynamic &&
+                        !(layerConfig.singleEntryCollapse &&
+                        derivedChildLayerConfigSource.index === layerConfig.layerEntries[0].index)) {
+
+                        derivedChildLayerConfigSource.userDisabledControls.push('opacity');
+                    }
 
                     const derviedChildLayerConfig = new ConfigObject.layers.DynamicLayerEntryNode(
                         derivedChildLayerConfigSource, true);

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -388,6 +388,9 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
 
             if (layerConfig.singleEntryCollapse && meetsCollapseCondition) {
                 legendBlockGroup.collapsed = true;
+            } else {
+                // if collapse is not allowed, update the initial config value
+                layerConfig.singleEntryCollapse = false;
             }
 
             return legendBlockGroup;
@@ -460,8 +463,8 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
             const groupDefaults = ConfigObject.DEFAULTS.legend[ConfigObject.TYPES.legend.GROUP];
 
             // dynamic children might not support opacity if the layer is not a true dynamic layer
-            // TODO: allow for an optional description why the control is disabled
-            if (!layerRecord.isTrueDynamic) {
+            // do not disable opacity on single entry collapsed blocks
+            if (!layerRecord.isTrueDynamic && !layerConfig.singleEntryCollapse) {
                 dynamicLayerChildDefaults.userDisabledControls.push('opacity');
             }
 
@@ -507,6 +510,10 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
                                 disabledControls: common.intersect(
                                     originalSource.disabledControls,
                                     groupDefaults.controls),
+                                userDisabledControls: common.intersect(
+                                    originalSource.userDisabledControls,
+                                    groupDefaults.controls
+                                ),
                                 name: treeChild.name
                             });
 

--- a/src/app/ui/settings/settings-content.directive.js
+++ b/src/app/ui/settings/settings-content.directive.js
@@ -21,19 +21,54 @@ angular
  * @function rvSettingsContent
  * @return {object} directive body
  */
-function rvSettingsContent() {
+function rvSettingsContent(layerRegistry) {
     const directive = {
         restrict: 'E',
         templateUrl,
         scope: {
             block: '='
         },
+        link,
         controller: Controller,
         controllerAs: 'self',
         bindToController: true
     };
 
     return directive;
+
+    function link(scope) {
+        const self = scope.self;
+
+        const opacityName = 'opacity';
+        const layerRecord = layerRegistry.getLayerRecord(self.block.layerRecordId);
+
+        if (self.block.isControlDisabled(opacityName) && !layerRecord.isTrueDynamic) {
+            self.valueParentBlock = findOpacityParentBlock(self.block);
+        }
+
+        /**
+         * Finds the closes parent group which enabled and visible opacity control.
+         *
+         * @function findOpacityParentBlock
+         * @private
+         * @param {LegendBlock} block
+         * @return {LegendBlock|null} a LegendBlock group or null if the parent doesn't exist
+         */
+        function findOpacityParentBlock(block) {
+
+            const parent = block.visualParent;
+
+            if (!parent) {
+                return null;
+            }
+
+            if (!parent.isControlDisabled(opacityName) && parent.isControlVisible(opacityName)) {
+                return parent;
+            } else {
+                return findOpacityParentBlock(parent);
+            }
+        }
+    }
 }
 
 function Controller(common) {

--- a/src/app/ui/settings/settings-content.directive.js
+++ b/src/app/ui/settings/settings-content.directive.js
@@ -42,7 +42,8 @@ function rvSettingsContent(layerRegistry) {
         const opacityName = 'opacity';
         const layerRecord = layerRegistry.getLayerRecord(self.block.layerRecordId);
 
-        if (self.block.isControlDisabled(opacityName) && !layerRecord.isTrueDynamic) {
+        // only search for opacity parent if the control is userDisabled on non-true-dynamic dynamic layers
+        if (self.block.isControlUserDisabled(opacityName) && !layerRecord.isTrueDynamic) {
             self.valueParentBlock = findOpacityParentBlock(self.block);
         }
 
@@ -58,7 +59,8 @@ function rvSettingsContent(layerRegistry) {
 
             const parent = block.visualParent;
 
-            if (!parent) {
+            // the root of the legend doesn't have a parent or any visual representation, ignore it
+            if (!parent || !parent.parent) {
                 return null;
             }
 

--- a/src/app/ui/settings/settings-content.html
+++ b/src/app/ui/settings/settings-content.html
@@ -1,4 +1,4 @@
-<div class="rv-subsection" ng-if="self.checkAvailableControls('visibility|opacity|boundingBox')">
+<div class="rv-subsection" ng-if="::self.checkAvailableControls('visibility|opacity|boundingBox')">
     <div class="rv-subheader">
         <h4 translate class="md-subhead">settings.label.display</h4>
     </div>
@@ -8,7 +8,7 @@
         <md-divider class="rv-settings-divider"></md-divider>
         <rv-legend-control block="self.block" template="switch" name="visibility"></rv-legend-control>
         <md-divider class="rv-settings-divider"></md-divider>
-        <rv-legend-control block="self.block" template="slider" name="opacity"></rv-legend-control>
+        <rv-legend-control block="self.block" template="slider" name="opacity" value-parent-block="self.valueParentBlock"></rv-legend-control>
         <md-divider class="rv-settings-divider"></md-divider>
         <rv-legend-control block="self.block" template="switch" name="boundingBox"></rv-legend-control>
         <md-divider class="rv-settings-divider"></md-divider>
@@ -17,7 +17,7 @@
 
 </div>
 
-<div class="rv-subsection" ng-if="self.checkAvailableControls('query|snapshot')">
+<div class="rv-subsection" ng-if="::self.checkAvailableControls('query|snapshot')">
     <div class="rv-subheader">
         <h4 translate class="md-subhead">settings.label.data</h4>
     </div>

--- a/src/app/ui/settings/settings.directive.js
+++ b/src/app/ui/settings/settings.directive.js
@@ -37,18 +37,24 @@ function rvSettings($compile) {
         let contentPanel;
         const template = `<rv-settings-content block="self.block"></rv-settings-content>`;
 
-        scope.$watch('self.display.data', newLegendBlock => {
+        const self = scope.self;
+
+        scope.$watch('self.display.data', updateSettingsPanel);
+
+        function updateSettingsPanel(newLegendBlock) {
             contentPanel = element.find(SETTINGS_CONTENT_PANEL);
 
             if (newLegendBlock) {
-                scope.self.block = newLegendBlock;
+                self.block = newLegendBlock;
+
                 contentPanel
                     .empty()
                     .append($compile(template)(scope));
+
             } else {
                 contentPanel.empty();
             }
-        });
+        }
     }
 }
 

--- a/src/app/ui/toc/legend-control.directive.js
+++ b/src/app/ui/toc/legend-control.directive.js
@@ -1,6 +1,7 @@
 const templateUrl = {
     body: require('./templates/legend-control-body.html'),
     button: require('./templates/legend-control-button.html'),
+    link: require('./templates/legend-control-link.html'),
     menu: require('./templates/legend-control-menu.html'),
     slider: require('./templates/legend-control-slider.html'),
     switch: require('./templates/legend-control-switch.html'),
@@ -37,6 +38,7 @@ function rvLegendControl(LegendElementFactory) {
         templateUrl: (elm, attr) => templateUrl[attr.template || 'button'],
         scope: {
             block: '=',
+            valueParentBlock: '=',
             name: '@'
         },
         link: {

--- a/src/app/ui/toc/legend-element-factory.class.js
+++ b/src/app/ui/toc/legend-element-factory.class.js
@@ -26,6 +26,8 @@ function LegendElementFactory($translate, Geo, ConfigObject, tocService, debounc
             this._legendBlock = legendBlock;
         }
 
+        get controlName () { return this._controlName; }
+
         get block () { return this._legendBlock; }
 
         get icon () {    return ''; }
@@ -40,8 +42,7 @@ function LegendElementFactory($translate, Geo, ConfigObject, tocService, debounc
 
         get isDisabled () {
             const value =
-                this.block.isControlDisabled(this._controlName) ||
-                this.block.isControlUserDisabled(this._controlName);
+                this.block.isControlDisabled(this._controlName);
 
             return value;
         }

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -216,10 +216,8 @@ function rvSymbologyStack($q, Geo, animationService) {
         function makeExpandTimeline() {
             const timeline = animationService.timeLineLite({
                 paused: true,
-                onStart: () =>
-                    (self.isExpanded = true),
-                onReverseComplete: () =>
-                    (self.isExpanded = false)
+                onStart: () => { self.isExpanded = self.symbology.expanded = true; },
+                onReverseComplete: () => { self.isExpanded = self.symbology.expanded = false }
             });
 
             // in pixels
@@ -267,10 +265,8 @@ function rvSymbologyStack($q, Geo, animationService) {
             // we only need one timeline since we can reuse it
             const timeline = animationService.timeLineLite({
                 paused: true,
-                onStart: () =>
-                    (ref.isFannedOut = true),
-                onReverseComplete: () =>
-                    (ref.isFannedOut = false)
+                onStart: () => { ref.isFannedOut = self.symbology.fannedOut = true },
+                onReverseComplete: () => {ref.isFannedOut = self.symbology.fannedOut = false}
             });
 
             const displacement = 4;

--- a/src/app/ui/toc/templates/legend-control-link.html
+++ b/src/app/ui/toc/templates/legend-control-link.html
@@ -1,0 +1,8 @@
+<md-button
+    class="rv-link-button"
+    ng-click="self.uiControl.action()"
+    ng-disabled="self.uiControl.isDisabled"
+    aria-label="{{ self.uiControl.label | translate }}">
+        {{ self.uiControl.block.name }}
+</md-button>
+

--- a/src/app/ui/toc/templates/legend-control-slider.html
+++ b/src/app/ui/toc/templates/legend-control-slider.html
@@ -11,4 +11,12 @@
             max="1" min="0" step="0.01" ng-model="self.uiControl.value"></md-slider>
         <span class="rv-slider-indicator">{{ self.Math.round(self.uiControl.value * 100) }}%</span>
     </div>
+
+    <!-- this block is used when the control is disabled -->
+    <div class="rv-slider-footer" ng-if="self.valueParentBlock" >
+        <!-- double variable replacement https://github.com/angular-translate/angular-translate/issues/1667 -->
+        <span class="rv-slider-changeat md-caption" translate="settings.change.at" translate-values="{ controlName: self.uiControl.controlName }" translate-compile></span>
+
+        <rv-legend-control block="self.valueParentBlock" template="link" name="settings"></rv-legend-control>
+    </div>
 </div>

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -30,6 +30,10 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, stat
         reloadLayer
     };
 
+    const ref = {
+        selecteLegendBlockLog: {}
+    };
+
     let errorToast;
 
     // debounce toggle filter function
@@ -486,18 +490,21 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, stat
      * @param {Boolean} value defaults to true;
      */
     function setTocEntrySelectedState(id, value = true) {
-        console.log(configService, id, value);
+        const legendBlocks = configService.getSync.map.legendBlocks;
 
-        return;
+        const block = legendBlocks
+            .walk(lb => lb.id === id ? lb : null)
+            .filter(a => a)[0];
 
-        /* FIXME
-        const entry = geoService.legend.getItemById(id);
-        if (entry) {
-            // toc entry is considered selected if its metadata, settings, or data panel is opened;
-            // when switching between panels (opening metadata when settings is already open), events may happen out of order
-            // to ensure a toc entry is not deselected untimely, keep count of open/close events
-            selectedLayerLog[id] = (selectedLayerLog[id] || 0) + (value ? 1 : -1);
-            entry.selected = selectedLayerLog[id] > 0 ? true : false;
-        }*/
+        // there should always be a block with the provided id, but check anyway in case it was remove or something
+        if (!block) {
+            return;
+        }
+
+        // toc entry is considered selected if its metadata, settings, or data panel is opened;
+        // when switching between panels (opening metadata when settings is already open), events may happen out of order
+        // to ensure a toc entry is not deselected untimely, keep count of open/close events
+        ref.selecteLegendBlockLog[id] = (ref.selecteLegendBlockLog[id] || 0) + (value ? 1 : -1);
+        block.isSelected = ref.selecteLegendBlockLog[id] > 0;
     }
 }

--- a/src/content/samples/config/config-sample-47.json
+++ b/src/content/samples/config/config-sample-47.json
@@ -1,0 +1,501 @@
+{
+  "ui": {
+    "title": "Custom Title",
+    "navBar": {
+      "zoom": "buttons",
+      "extra": [
+        "fullscreen",
+        "geoLocator",
+        "home",
+        "help"
+      ]
+    },
+    "sideMenu": {
+      "logo": true
+    },
+    "help": {
+      "folderName": "default"
+    },
+    "legendIsOpen": {
+      "large": true,
+      "medium": true,
+      "small": false
+    }
+  },
+  "version": "2.0",
+  "language": "en",
+  "services": {
+    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+    "exportMapUrl": "http://webservices.maps.canada.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+    "export": {
+      "title": {
+        "value": "Title"
+      },
+      "map": {},
+      "mapElements": {},
+      "legend":{},
+      "footnote": {
+        "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+      }
+    },
+    "search": {
+      "serviceUrls": {
+        "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
+        "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
+        "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+        "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
+        "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+      }
+    }
+  },
+  "map": {
+    "initialBasemapId": "baseNrCan",
+    "components": {
+      "geoSearch": {
+        "enabled": true,
+        "showGraphic": true,
+        "showInfo": true
+      },
+      "mouseInfo": {
+        "enabled": true,
+        "spatialReference": {
+          "wkid": 102100
+        }
+      },
+      "northArrow": {
+        "enabled": true
+      },
+      "basemap": {
+        "enabled": true
+      },
+      "overviewMap": {
+        "enabled": true,
+        "layerType": "imagery"
+      },
+      "scaleBar": {
+        "enabled": true
+      }
+    },
+    "extentSets": [
+      {
+        "id": "EXT_NRCAN_Lambert_3978",
+        "default": {
+          "xmax": 3549492,
+          "xmin": -2681457,
+          "ymax": 3482193,
+          "ymin": -883440
+        },
+        "spatialReference": {
+          "wkid": 3978
+        }
+      },
+      {
+        "id": "EXT_ESRI_World_AuxMerc_3857",
+        "default": {
+          "xmax": -5007771.626060756,
+          "xmin": -16632697.354854,
+          "ymax": 10015875.184845109,
+          "ymin": 5022907.964742964
+        },
+        "spatialReference": {
+          "wkid": 102100,
+          "latestWkid": 3857
+        }
+      }
+    ],
+    "lodSets": [
+      {
+        "id": "LOD_NRCAN_Lambert_3978",
+        "lods": [
+          {
+            "level": 0,
+            "resolution": 38364.660062653464,
+            "scale": 145000000
+          },
+          {
+            "level": 1,
+            "resolution": 22489.62831258996,
+            "scale": 85000000
+          },
+          {
+            "level": 2,
+            "resolution": 13229.193125052918,
+            "scale": 50000000
+          },
+          {
+            "level": 3,
+            "resolution": 7937.5158750317505,
+            "scale": 30000000
+          },
+          {
+            "level": 4,
+            "resolution": 4630.2175937685215,
+            "scale": 17500000
+          },
+          {
+            "level": 5,
+            "resolution": 2645.8386250105837,
+            "scale": 10000000
+          },
+          {
+            "level": 6,
+            "resolution": 1587.5031750063501,
+            "scale": 6000000
+          },
+          {
+            "level": 7,
+            "resolution": 926.0435187537042,
+            "scale": 3500000
+          },
+          {
+            "level": 8,
+            "resolution": 529.1677250021168,
+            "scale": 2000000
+          },
+          {
+            "level": 9,
+            "resolution": 317.50063500127004,
+            "scale": 1200000
+          },
+          {
+            "level": 10,
+            "resolution": 185.20870375074085,
+            "scale": 700000
+          },
+          {
+            "level": 11,
+            "resolution": 111.12522225044451,
+            "scale": 420000
+          },
+          {
+            "level": 12,
+            "resolution": 66.1459656252646,
+            "scale": 250000
+          },
+          {
+            "level": 13,
+            "resolution": 38.36466006265346,
+            "scale": 145000
+          },
+          {
+            "level": 14,
+            "resolution": 22.48962831258996,
+            "scale": 85000
+          },
+          {
+            "level": 15,
+            "resolution": 13.229193125052918,
+            "scale": 50000
+          },
+          {
+            "level": 16,
+            "resolution": 7.9375158750317505,
+            "scale": 30000
+          },
+          {
+            "level": 17,
+            "resolution": 4.6302175937685215,
+            "scale": 17500
+          }
+        ]
+      },
+      {
+        "id": "LOD_ESRI_World_AuxMerc_3857",
+        "lods": [
+          {
+            "level": 0,
+            "resolution": 19567.87924099992,
+            "scale": 73957190.948944
+          },
+          {
+            "level": 1,
+            "resolution": 9783.93962049996,
+            "scale": 36978595.474472
+          },
+          {
+            "level": 2,
+            "resolution": 4891.96981024998,
+            "scale": 18489297.737236
+          },
+          {
+            "level": 3,
+            "resolution": 2445.98490512499,
+            "scale": 9244648.868618
+          },
+          {
+            "level": 4,
+            "resolution": 1222.992452562495,
+            "scale": 4622324.434309
+          },
+          {
+            "level": 5,
+            "resolution": 611.4962262813797,
+            "scale": 2311162.217155
+          },
+          {
+            "level": 6,
+            "resolution": 305.74811314055756,
+            "scale": 1155581.108577
+          },
+          {
+            "level": 7,
+            "resolution": 152.87405657041106,
+            "scale": 577790.554289
+          },
+          {
+            "level": 8,
+            "resolution": 76.43702828507324,
+            "scale": 288895.277144
+          },
+          {
+            "level": 9,
+            "resolution": 38.21851414253662,
+            "scale": 144447.638572
+          },
+          {
+            "level": 10,
+            "resolution": 19.10925707126831,
+            "scale": 72223.819286
+          },
+          {
+            "level": 11,
+            "resolution": 9.554628535634155,
+            "scale": 36111.909643
+          },
+          {
+            "level": 12,
+            "resolution": 4.77731426794937,
+            "scale": 18055.954822
+          },
+          {
+            "level": 13,
+            "resolution": 2.388657133974685,
+            "scale": 9027.977411
+          },
+          {
+            "level": 14,
+            "resolution": 1.1943285668550503,
+            "scale": 4513.988705
+          },
+          {
+            "level": 15,
+            "resolution": 0.5971642835598172,
+            "scale": 2256.994353
+          },
+          {
+            "level": 16,
+            "resolution": 0.29858214164761665,
+            "scale": 1128.497176
+          },
+          {
+            "level": 17,
+            "resolution": 0.14929107082380833,
+            "scale": 564.248588
+          },
+          {
+            "level": 18,
+            "resolution": 0.07464553541190416,
+            "scale": 282.124294
+          },
+          {
+            "level": 19,
+            "resolution": 0.03732276770595208,
+            "scale": 141.062147
+          },
+          {
+            "level": 20,
+            "resolution": 0.01866138385297604,
+            "scale": 70.5310735
+          }
+        ]
+      }
+    ],
+    "legend": {
+      "type": "structured",
+      "root": {
+        "name": "root",
+        "children": [
+          {
+              "layerId": "blah"
+          },
+          {
+              "layerId": "blah2"
+          }
+        ]
+      }
+    },
+    "layers": [
+      {
+        "id": "blah",
+        "name": "Test Data",
+        "layerType": "esriDynamic",
+        "layerEntries": [{"index": 0}],
+        "url": "http://section917.cloudapp.net/arcgis/rest/services/TestData/Nest/MapServer"
+      },
+      {
+        "id": "blah2",
+        "name": "Test Data",
+        "layerType": "esriDynamic",
+        "layerEntries": [{"index": 2}],
+        "singleEntryCollapse": true,
+        "url": "http://section917.cloudapp.net/arcgis/rest/services/TestData/Nest/MapServer"
+      }
+    ],
+    "tileSchemas": [
+      {
+        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+        "name": "Lambert Maps",
+        "extentSetId": "EXT_NRCAN_Lambert_3978",
+        "lodSetId": "LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+        "name": "Web Mercator Maps",
+        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+      }
+    ],
+    "baseMaps": [
+      {
+        "id": "baseNrCan",
+        "name": "Canada Base Map - Transportation (CBMT)",
+        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+        "layers": [
+          {
+            "id": "CBMT",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseSimple",
+        "name": "Canada Base Map - Simple",
+        "description": "Canada Base Map - Simple",
+        "altText": "altText - Canada base map - Simple",
+        "layers": [
+          {
+            "id": "SMR",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseCBME_CBCE_HS_RO_3978",
+        "name": "Canada Base Map - Elevation (CBME)",
+        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+        "altText": "altText - Canada Base Map - Elevation (CBME)",
+        "layers": [
+          {
+            "id": "CBME_CBCE_HS_RO_3978",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseCBMT_CBCT_GEOM_3978",
+        "name": "Canada Base Map - Transportation (CBMT)",
+        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+        "altText": "altText - Canada Base Map - Transportation (CBMT)",
+        "layers": [
+          {
+            "id": "CBMT_CBCT_GEOM_3978",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseEsriWorld",
+        "name": "World Imagery",
+        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+        "altText": "altText - World Imagery",
+        "layers": [
+          {
+            "id": "World_Imagery",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriPhysical",
+        "name": "World Physical Map",
+        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+        "altText": "altText - World Physical Map",
+        "layers": [
+          {
+            "id": "World_Physical_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriRelief",
+        "name": "World Shaded Relief",
+        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+        "altText": "altText - World Shaded Relief",
+        "layers": [
+          {
+            "id": "World_Shaded_Relief",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriStreet",
+        "name": "World Street Map",
+        "description": "This worldwide street map presents highway-level data for the world.",
+        "altText": "altText - ESWorld Street Map",
+        "layers": [
+          {
+            "id": "World_Street_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriTerrain",
+        "name": "World Terrain Base",
+        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+        "altText": "altText - World Terrain Base",
+        "layers": [
+          {
+            "id": "World_Terrain_Base",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriTopo",
+        "name": "World Topographic Map",
+        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+        "altText": "altText - World Topographic Map",
+        "layers": [
+          {
+            "id": "World_Topo_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      }
+    ]
+  }
+}

--- a/src/content/samples/config/config-sample-47.json
+++ b/src/content/samples/config/config-sample-47.json
@@ -316,10 +316,91 @@
         "name": "root",
         "children": [
           {
-              "layerId": "blah"
+            "infoType": "title",
+            "content": "Confusing Opacity Controls"
           },
           {
-              "layerId": "blah2"
+            "name": "Description",
+            "controls": [],
+            "children": [
+              {
+                "infoType": "text",
+                "content": "If a dynamic layer does not support children opacity, all children will have their opacity controls disabled and display a jump link to its parent unless it's single entry collapsed. Jump link should never point to group blocks not belonging to this layer record."
+              },
+              {
+                "infoType": "image",
+                "content": "https://i.imgur.com/DJGO9mN.png"
+              }
+            ]
+          },
+          {
+            "name": "Test 1",
+            "controls": [],
+            "children": [
+              {
+                  "infoType": "text",
+                  "content": "Opacity only enabled at the 'Test Data' group block; all children should have opacity disabled and display a jump link to that group."
+              },
+              {
+                  "layerId": "blah"
+              }
+            ]
+          },
+          {
+            "name": "Test 2",
+            "controls": [],
+            "children": [
+              {
+                  "infoType": "text",
+                  "content": "Opacity should be enabled on the single entry collapsed child since the layer root (its parent) is hidden."
+              },
+              {
+                  "layerId": "blah2"
+              }
+            ]
+          },
+          {
+            "name": "Test 3",
+            "controls": [],
+            "children": [
+              {
+                  "infoType": "text",
+                  "content": "Opacity should be enabled at the 'Group 2' group block; its single child should have opacity disabled and display a jump link to that group."
+              },
+              {
+                  "layerId": "blah3"
+              }
+            ]
+          },
+          {
+            "name": "Test 4",
+            "controls": [],
+            "children": [
+              {
+                  "infoType": "text",
+                  "content": "'Group with opacity disabled' has the opacity control disabled :D Both its children are single entry collapsed."
+              },
+              {
+                "name": "Group with opacity disabled",
+                "disabledControls": ["opacity"],
+                "children": [
+                  {
+                    "infoType": "text",
+                    "content": "1 This layer has the opacity control disabled in the config using 'disabledControls'; should not have a jump link to its visual (real parent is hidden) parent group."
+                  },
+                  {
+                      "layerId": "blah4"
+                  },
+                  {
+                    "infoType": "text",
+                    "content": "2 This layer has the opacity control enabled since it's single entry collapsed."
+                  },
+                  {
+                      "layerId": "blah5"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }
@@ -334,6 +415,31 @@
       },
       {
         "id": "blah2",
+        "name": "Test Data",
+        "layerType": "esriDynamic",
+        "layerEntries": [{"index": 2}],
+        "singleEntryCollapse": true,
+        "url": "http://section917.cloudapp.net/arcgis/rest/services/TestData/Nest/MapServer"
+      },
+      {
+        "id": "blah3",
+        "name": "Test Data",
+        "layerType": "esriDynamic",
+        "layerEntries": [{"index": 1}],
+        "singleEntryCollapse": true,
+        "url": "http://section917.cloudapp.net/arcgis/rest/services/TestData/Nest/MapServer"
+      },
+      {
+        "id": "blah4",
+        "name": "Test Data",
+        "layerType": "esriDynamic",
+        "layerEntries": [{"index": 2}],
+        "disabledControls": ["opacity"],
+        "singleEntryCollapse": true,
+        "url": "http://section917.cloudapp.net/arcgis/rest/services/TestData/Nest/MapServer"
+      },
+      {
+        "id": "blah5",
         "name": "Test Data",
         "layerType": "esriDynamic",
         "layerEntries": [{"index": 2}],

--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -140,6 +140,7 @@
                 <option value="config/config-sample-43.json">43. Map with custom title</option>
                 <option value="config/config-sample-44.json">44. Viewer with custom name and logo</option>
                 <option value="config/config-sample-45.json">45. Viewer defaulting to Mercator, with no layers</option>
+                <option value="config/config-sample-47.json">47. Dynamic opacity controls for "not-true-dynamic" dynamic layers</option>
             </select>
         </div>
 

--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -40,7 +40,8 @@
             width: 150px;
             right: 45%;
             z-index: 100;
-            top: 90px;
+            top: 76px;
+            padding: 0;
         }
 
         .fade {
@@ -269,12 +270,12 @@
                 document.getElementById("header").style.display = "block";
                 document.getElementById("hideShow").classList.remove('bottom');
                 document.getElementById("hideShow").classList.add('top');
-                document.getElementById("hideShow").style.top = ('100px');
+                document.getElementById("hideShow").style.top = ('76px');
             } else {
                 document.getElementById("header").style.display = "none";
                 document.getElementById("hideShow").classList.remove('top');
                 document.getElementById("hideShow").classList.add('bottom');
-                document.getElementById("hideShow").style.top = ('20px');
+                document.getElementById("hideShow").style.top = ('0px');
             }
         }
 

--- a/src/content/styles/modules/_setting-controls.scss
+++ b/src/content/styles/modules/_setting-controls.scss
@@ -83,5 +83,36 @@
                 text-align: right;
             }
         }
+
+        .rv-slider-footer {
+            display: flex;
+            padding-left: rem(3.2);
+            top: - rem(1.2);
+            position: relative;
+            margin-bottom: - rem(1.3);
+
+            .rv-slider-changeat {
+                .rv-control-name {
+                    text-transform: lowercase;
+                }
+            }
+
+            rv-legend-control {
+                padding: 0;
+                margin: 0 rem(0.4);
+
+                .rv-link-button {
+                    color: $primary-color-dark;
+                    font-size: rem(1.2);
+                    line-height: rem(1.2);
+                    min-height: rem(1.2);
+                    text-transform: none;
+                    min-width: auto;
+                    margin: 0;
+                    padding: 0 rem(0.4);
+                    height: rem(2);
+                }
+            }
+        }
     }
 }

--- a/src/content/styles/modules/_toc.scss
+++ b/src/content/styles/modules/_toc.scss
@@ -147,6 +147,11 @@ $layer-item-height-touch: rem(7.2);
             &:hover ~ .rv-shadow {
                 background-color: $primary-color;
             }
+
+            // highlight the selected item
+            &.rv-selected:before {
+                background-color: $accent-color;
+            }
         }
 
         &.rv-legend-node,

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -127,6 +127,7 @@ Map Navigation basemap tooltip,nav.tooltip.basemap,Basemap,1,Carte de base,1
 Metadata pane title,metadata.title,Metadata,1,Métadonnées,1
 Metadata pane expand,metadata.expand.tooltip,Expand Metadata,1,Agrandir métadonnées,1
 Hovertip loading text,maptip.hover.label.loading,Loading...,1,Chargement en cours...,1
+,settings.change.at,Change <span class="rv-control-name" translate="settings.label.{{controlName}}"></span> at,1,[fr]Change {{settingName}} at,0
 Settings main title,settings.title,Settings,1,Paramètres,1
 Settings visibility header label,settings.label.display,Display,1,Affichage,1
 Settings bounding box visibility label,settings.label.boundingBox,Bounding Box,1,Zone de délimitation,1


### PR DESCRIPTION
## Description
- [bug #2345] legend block symbology stack got stuck when expanded from the menu
- [bug #2131] opacity controls for `not-true-dynamic` dynamic layers are confusing - added jump link to parent block

Closes #2131, #2345

## Testing
Eyeballs.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2347)
<!-- Reviewable:end -->
