### PR TITLE
Fix focus in side and help panels

### DIFF
--- a/src/app/core/formatters.filter.js
+++ b/src/app/core/formatters.filter.js
@@ -28,10 +28,10 @@ function dateTimeZone() {
      *
      * @function dateTimeZone
      * @param {Number} esriDate epoch time to convert
-     * @param {String} [format=YYYY-MM-D H:MM:SSA z] moment format string for output date/time
+     * @param {String} [format=YYYY-MM-D H:mm:ssA z] moment format string for output date/time
      * @return {String} data/time adjusted to users timezone
      */
-    function dateTimeZone(esriDate, format = 'YYYY-MM-D H:MM:SSA z') {
+    function dateTimeZone(esriDate, format = 'YYYY-MM-D H:mm:ssA z') {
         if (esriDate) {
             const time = moment.tz(esriDate, userTimeZone).format(format);
             // if esriDate is not valid, assume it follows 'format'

--- a/src/app/core/statemanager.service.js
+++ b/src/app/core/statemanager.service.js
@@ -371,6 +371,10 @@ function stateManager($q, $rootScope, displayManager, initialState, initialDispl
         // prevent main panel from overlapping details panel in small/medium layouts
         } else if (panelToOpen.name === 'table') {
             $rootElement.find('rv-panel[type="main"]').css('z-index', 2);
+        } else if (panelToOpen.name === 'sideMetadata') {
+            $rootElement.find('rv-metadata-panel button.rv-close').rvFocus({ delay: 400 });
+        } else if (panelToOpen.name === 'sideSettings') {
+            $rootElement.find('rv-settings button.rv-close').rvFocus({ delay: 400 });
         }
 
         return typeof panelToOpen.item.parent === 'undefined' ?

--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -463,6 +463,7 @@ function onKeydown(event) {
             viewerActive.setStatus(statuses.INACTIVE);
 
         } else if (event.which === 9) { // tab keydown only
+            ignoreFocusLoss = false;
             const shiftState = shiftFocus(!event.shiftKey, restoreFromHistory);
             // prevent browser from changing focus iff our change took effect OR ours failed but did so on a non-direct child of the viewer trap
             // In general we ALWAYS want to prevent browser focus movements but on full page viewers shiftfocus will fail (correct behaviour) so we
@@ -636,7 +637,6 @@ HTMLElement.prototype.rvFocus = $.fn.rvFocus = function (opts = {}) {
 
         if (jqueryElem.is(':focus')) {
             history.push(jqueryElem);
-            ignoreFocusLoss = false;
         } else {
             // applying focus didn't work, try going back to a history element
             shiftFocus(false, true);

--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -361,7 +361,7 @@ function shiftFocus(forward = true, onlyUseHistory = false) {
     if (onlyUseHistory) {
         lastVisibleHistoryElement().rvFocus();
 
-    } else if (link) {
+    } else if (link && link[0][0] !== link[1][0]) {     // check that the link created is not the element with itself
         // goto target if focusable
         if (link.getDestinationElement(forward).is(elemIsFocusable)) {
             link.getDestinationElement(forward).rvFocus();

--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -463,7 +463,6 @@ function onKeydown(event) {
             viewerActive.setStatus(statuses.INACTIVE);
 
         } else if (event.which === 9) { // tab keydown only
-            ignoreFocusLoss = false;
             const shiftState = shiftFocus(!event.shiftKey, restoreFromHistory);
             // prevent browser from changing focus iff our change took effect OR ours failed but did so on a non-direct child of the viewer trap
             // In general we ALWAYS want to prevent browser focus movements but on full page viewers shiftfocus will fail (correct behaviour) so we
@@ -637,6 +636,7 @@ HTMLElement.prototype.rvFocus = $.fn.rvFocus = function (opts = {}) {
 
         if (jqueryElem.is(':focus')) {
             history.push(jqueryElem);
+            ignoreFocusLoss = false;
         } else {
             // applying focus didn't work, try going back to a history element
             shiftFocus(false, true);

--- a/src/app/ui/common/dialog.decorator.js
+++ b/src/app/ui/common/dialog.decorator.js
@@ -42,8 +42,8 @@ function mdDialog($delegate, $q) {
                     .removeAttr('tabindex');
 
                 // rv-focus attribute in dialogs bypasses default focus to close behaviour
-                const rvFocus = element.find('rv-focus');
-                if (rvFocus) {
+                const rvFocus = element.find('[rv-focus]');
+                if (rvFocus.length > 0) {
                     rvFocus.first().rvFocus();
                 } else if (opts.focusOnOpen) {
                     // if an element with property rv-close-button exists we set focus on it. Sometimes the close button is

--- a/src/app/ui/export/export-generators.service.js
+++ b/src/app/ui/export/export-generators.service.js
@@ -408,7 +408,7 @@ function exportGenerators($q, $filter, $translate, $templateCache, gapiService, 
      *                  value {Object} - a modified value passed from the ExportComponent
      */
     function timestampGenerator(exportSize) {
-        const timestampString = $filter('date')(new Date(), 'yyyy-MM-dd HH:mm:ss');
+        const timestampString = $filter('date')(new Date(), 'YYYY-MM-DD HH:mm:ss');
 
         const containerWidth = exportSize.width;
         let containerHeight = 100;

--- a/src/app/ui/metadata/metadata-panel.directive.js
+++ b/src/app/ui/metadata/metadata-panel.directive.js
@@ -33,12 +33,13 @@ function rvMetadataPanel(referenceService) {
     return directive;
 
     function link(scope, el) {
+        referenceService.panes.metadata = el;
+
         scope.$watch('self.display.data', metadata => {
             if (metadata) {
                 el.find('button.rv-close').rvFocus({ delay: 400 });
             }
         });
-        referenceService.panes.metadata = el;
     }
 }
 

--- a/src/app/ui/metadata/metadata-panel.directive.js
+++ b/src/app/ui/metadata/metadata-panel.directive.js
@@ -33,6 +33,11 @@ function rvMetadataPanel(referenceService) {
     return directive;
 
     function link(scope, el) {
+        scope.$watch('self.display.data', metadata => {
+            if (metadata) {
+                el.find('button.rv-close').rvFocus({ delay: 400 });
+            }
+        });
         referenceService.panes.metadata = el;
     }
 }

--- a/src/app/ui/metadata/metadata-panel.directive.js
+++ b/src/app/ui/metadata/metadata-panel.directive.js
@@ -34,12 +34,6 @@ function rvMetadataPanel(referenceService) {
 
     function link(scope, el) {
         referenceService.panes.metadata = el;
-
-        scope.$watch('self.display.data', metadata => {
-            if (metadata) {
-                el.find('button.rv-close').rvFocus({ delay: 400 });
-            }
-        });
     }
 }
 

--- a/src/app/ui/settings/settings.directive.js
+++ b/src/app/ui/settings/settings.directive.js
@@ -50,7 +50,11 @@ function rvSettings($compile) {
                 contentPanel
                     .empty()
                     .append($compile(template)(scope));
+<<<<<<< HEAD
 
+=======
+                element.find('button.rv-close').rvFocus({ delay: 400 });
+>>>>>>> fix(focus): close button has focus for side panels
             } else {
                 contentPanel.empty();
             }

--- a/src/app/ui/settings/settings.directive.js
+++ b/src/app/ui/settings/settings.directive.js
@@ -50,11 +50,6 @@ function rvSettings($compile) {
                 contentPanel
                     .empty()
                     .append($compile(template)(scope));
-<<<<<<< HEAD
-
-=======
-                element.find('button.rv-close').rvFocus({ delay: 400 });
->>>>>>> fix(focus): close button has focus for side panels
             } else {
                 contentPanel.empty();
             }

--- a/src/app/ui/table/table-default.directive.js
+++ b/src/app/ui/table/table-default.directive.js
@@ -715,6 +715,10 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
                     // get index value of currrent cell
                     index = self.table.cell(event.currentTarget).index();
 
+                    if (!index) {
+                        return;
+                    }
+
                     // get arrays of rows indexes (specifically if reordered) and the index where it is in the arrays
                     // get the number of columns
                     const indexes = self.table.rows().indexes();


### PR DESCRIPTION
## Description
Closes #2344.
Closes #2353 - formatting dates correctly. 

~~Focus is only applied to the close button in the metadata panel if there is metadata displayed; so as long as the error is not thrown.~~

Also prevents an error from being thrown when the datatable has no rows displayed.

## Testing
Visually tested.

## Documentation
In-line comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2350)
<!-- Reviewable:end -->
