### PR TITLE
2362 2363 filtering on reload and applying to map when removing filters

### DIFF
--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -473,7 +473,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
         get columns () { return this._columns; }
         set columns (value) { this._columns = value; }
 
-        get applied() { return this._applied; }
+        get applied () { return this._applied; }
         set applied (value) { this._applied = value; }
 
         get JSON () {
@@ -657,6 +657,8 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             this._index = source.index;
             this._name = source.name;
 
+            // the initial filters to be applied for the layer
+            // applied on source object so the property is not lost when applying layer node defaults
             this._initialFilteredQuery = source.initialFilteredQuery;
 
             // state and controls defaults cannot be applied here;

--- a/src/app/geo/layer-blueprint.class.js
+++ b/src/app/geo/layer-blueprint.class.js
@@ -102,18 +102,18 @@ function LayerBlueprintFactory($q, $http, gapiService, Geo, ConfigObject, bookma
          *
          * @method _applyFilterQuery
          * @private
-         * @param   {LayerNode}   node   layer node object
+         * @param   {LayerNode}   layerSource   layer source object
          */
-        _applyFilterQuery(node) {
-            if (node.layerType === layerTypes.ESRI_DYNAMIC) {
+        _applyFilterQuery(layerSource) {
+            if (layerSource.layerType === layerTypes.ESRI_DYNAMIC) {
                 // walk through sub layers in dynamic layer
-                for (let i = 0; i < node.layerEntries.length; i++) {
-                    if (node.layerEntries[i].table && (node.layerEntries[i].table.applyMap || node.layerEntries[i].table.applied)) {
-                        node.layerEntries[i].initialFilteredQuery = this._getFilterDefintion(node.layerEntries[i].table.columns);
+                for (let i = 0; i < layerSource.layerEntries.length; i++) {
+                    if (layerSource.layerEntries[i].table && (layerSource.layerEntries[i].table.applyMap || layerSource.layerEntries[i].table.applied)) {
+                        layerSource.layerEntries[i].initialFilteredQuery = this._getFilterDefintion(layerSource.layerEntries[i].table.columns);
                     }
                 }
-            } else if (node.table && (node.table.applyMap || node.table.applied)) {
-                node.initialFilteredQuery = this._getFilterDefintion(node.table.columns);
+            } else if (layerSource.table && (layerSource.table.applyMap || layerSource.table.applied)) {
+                layerSource.initialFilteredQuery = this._getFilterDefintion(layerSource.table.columns);
             }
         }
 

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -367,22 +367,24 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
                 this.mainProxy, blockConfig.symbologyStack, blockConfig.symbologyRenderStyle, true);
         }
 
+        get mainProxyWrapper () { return this._mainProxyWrapper; }
+
         /**
          * @return {Proxy} the main proxy connected to the legend block
          */
-        get mainProxy () { return this._mainProxyWrapper.proxy; }
+        get mainProxy () { return this.mainProxyWrapper.proxy; }
 
         addControlledProxyWrapper(proxyWrapper) {
             this._controlledProxyWrappers.push(proxyWrapper);
         }
 
         applyInitialStateSettings() {
-            if (!this._mainProxyWrapper.initialStateSettingsApplied) {
-                this._mainProxyWrapper.applyInitialStateSettings();
-                this._mainProxyWrapper.validateProjection(configService.getSync.map.selectedBasemap.spatialReference);
+            if (!this.mainProxyWrapper.initialStateSettingsApplied) {
+                this.mainProxyWrapper.applyInitialStateSettings();
+                this.mainProxyWrapper.validateProjection(configService.getSync.map.selectedBasemap.spatialReference);
 
                 // bounding box is not linked to a proxy, so we need to apply it separately
-                this.boundingBox = this._mainProxyWrapper.boundingBox;
+                this.boundingBox = this.mainProxyWrapper.boundingBox;
             }
         }
 
@@ -404,14 +406,14 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
 
         get blockType () {              return TYPES.NODE; }
 
-        get _allProxyWrappers () {      return [this._mainProxyWrapper].concat(this._controlledProxyWrappers); }
+        get _allProxyWrappers () {      return [this.mainProxyWrapper].concat(this._controlledProxyWrappers); }
 
-        get availableControls () {      return this._mainProxyWrapper.availableControls; }
-        get disabledControls () {       return this._mainProxyWrapper.disabledControls; }
-        get userDisabledControls () {   return this._mainProxyWrapper.userDisabledControls; }
+        get availableControls () {      return this.mainProxyWrapper.availableControls; }
+        get disabledControls () {       return this.mainProxyWrapper.disabledControls; }
+        get userDisabledControls () {   return this.mainProxyWrapper.userDisabledControls; }
 
         get state () {
-            if (!this._mainProxyWrapper.validProjection) {
+            if (!this.mainProxyWrapper.validProjection) {
                 return 'rv-bad-projection';
             }
 
@@ -440,18 +442,18 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
             return state === 'rv-loading' || state === 'rv-refresh';
         }
 
-        get sortGroup () {          return Geo.Layer.SORT_GROUPS_[this._mainProxyWrapper.layerType]; }
+        get sortGroup () {          return Geo.Layer.SORT_GROUPS_[this.mainProxyWrapper.layerType]; }
 
-        get name () {               return this._mainProxyWrapper.name; }
-        get layerType () {          return this._mainProxyWrapper.layerType; }
-        get parentLayerType () {    return this._mainProxyWrapper.parentLayerType; }
-        get featureCount () {       return this._mainProxyWrapper.featureCount; }
-        get geometryType () {       return this._mainProxyWrapper.geometryType; }
+        get name () {               return this.mainProxyWrapper.name; }
+        get layerType () {          return this.mainProxyWrapper.layerType; }
+        get parentLayerType () {    return this.mainProxyWrapper.parentLayerType; }
+        get featureCount () {       return this.mainProxyWrapper.featureCount; }
+        get geometryType () {       return this.mainProxyWrapper.geometryType; }
         // on change, update the corresponding css rule to make bboxes click-through
         get bboxID () {             return this.layerRecordId + '_' + this.itemIndex + '_bbox'; }
-        get itemIndex () {          return this._mainProxyWrapper.itemIndex; }
+        get itemIndex () {          return this.mainProxyWrapper.itemIndex; }
 
-        get visibility () {         return this._mainProxyWrapper.visibility; }
+        get visibility () {         return this.mainProxyWrapper.visibility; }
         set visibility (value) {
             if (this.isControlSystemDisabled('visibility')) {
                 return;
@@ -467,7 +469,7 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
             }
         }
 
-        get opacity () {            return this._mainProxyWrapper.opacity; }
+        get opacity () {            return this.mainProxyWrapper.opacity; }
         set opacity (value) {
             if (this.isControlSystemDisabled('opacity')) {
                 return;
@@ -479,22 +481,22 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
         }
 
         // since query is applied only on the main proxy wrapper, we don't need to do an extra check if this control is available; it will be checked in the proxy wrapper
-        get query () {              return this._mainProxyWrapper.query; }
-        set query (value) {         this._mainProxyWrapper.query = value; }
+        get query () {              return this.mainProxyWrapper.query; }
+        set query (value) {         this.mainProxyWrapper.query = value; }
 
         /**
          * Set definition query to filter feature layer or dynamic layer
          *
          * @param {String} value the definition query to set
          */
-        set definitionQuery (value) {   this._mainProxyWrapper.definitionQuery = value; }
+        set definitionQuery (value) {   this.mainProxyWrapper.definitionQuery = value; }
 
-        get snapshot () {           return this._mainProxyWrapper.snapshot; }
+        get snapshot () {           return this.mainProxyWrapper.snapshot; }
         /**
          * Setting snapshot to `true` is permanent - if a snapshoted layer is reloaded manually in the future, it reloads as a snapshoted layer.
          * @param {Boolean} value specified layer's snapshot value
          */
-        set snapshot (value) {      this._mainProxyWrapper.snapshot = value; }
+        set snapshot (value) {      this.mainProxyWrapper.snapshot = value; }
 
         /**
          * Creates and stores (if missing) a boundign box based on the full extent exposed by the proxy object.
@@ -507,13 +509,13 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
                 this._bboxProxy = layerRegistry.getBoundingBoxRecord(this.bboxID);
 
                 if (!this._bboxProxy) {
-                    this._bboxProxy = layerRegistry.makeBoundingBoxRecord(this.bboxID, this._mainProxyWrapper.extent);
+                    this._bboxProxy = layerRegistry.makeBoundingBoxRecord(this.bboxID, this.mainProxyWrapper.extent);
                 }
             }
         }
 
         get boundingBox () {
-            if (!this._mainProxyWrapper.extent) {
+            if (!this.mainProxyWrapper.extent) {
                 return false;
             }
 
@@ -536,24 +538,24 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
             }
 
             this._bboxProxy.setVisibility(value);
-            this._mainProxyWrapper.boundingBox = value;
+            this.mainProxyWrapper.boundingBox = value;
         }
 
         get userAdded () {
-            return this._mainProxyWrapper.userAdded;
+            return this.mainProxyWrapper.userAdded;
         }
 
         get filter () {
-            return this._mainProxyWrapper.filter;
+            return this.mainProxyWrapper.filter;
         }
         set filter (value) {
-            this._mainProxyWrapper.filter = value;
+            this.mainProxyWrapper.filter = value;
         }
 
-        get queryUrl () { return this._mainProxyWrapper.queryUrl; }
+        get queryUrl () { return this.mainProxyWrapper.queryUrl; }
 
         get formattedData () {
-            return this._mainProxyWrapper.formattedAttributes;
+            return this.mainProxyWrapper.formattedAttributes;
         }
 
         // FIXME this can probably move directly into geoApi
@@ -567,7 +569,7 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
          *
          * @return {Object} in the form of { offScale: <Boolean>, zoomIn: <Boolean> }
          */
-        get scale() { return this._mainProxyWrapper.isOffScale(); }
+        get scale() { return this.mainProxyWrapper.isOffScale(); }
 
         /**
          * Zooms the layer controlled by the main proxy object in or out so features are visible on the map.
@@ -575,14 +577,14 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
          * @function zoomToScale
          * @return {Promise} resolving when the extent change has ended
          */
-        zoomToScale () { return this._mainProxyWrapper.zoomToScale(); }
+        zoomToScale () { return this.mainProxyWrapper.zoomToScale(); }
 
         /**
          * Zooms the layer controlled by the main proxy object to its bounding box.
          *
          * @function zoomToBoundary
          */
-        zoomToBoundary () { this._mainProxyWrapper.zoomToBoundary(); }
+        zoomToBoundary () { this.mainProxyWrapper.zoomToBoundary(); }
 
         /**
          * Zooms to a graphic with the specified oid.
@@ -591,7 +593,7 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
          * @param {Object} offsetFraction fractions of the current extent occupied by main and data panels in the form of { x: <Number>, y: <Number> }
          * @return {Promise} a promise resolving when the extent change is comlete
          */
-        zoomToGraphic (oid, offsetFraction) { return this._mainProxyWrapper.zoomToGraphic(oid, offsetFraction); }
+        zoomToGraphic (oid, offsetFraction) { return this.mainProxyWrapper.zoomToGraphic(oid, offsetFraction); }
 
         /**
          * Retrieves a graphic object from the main connected layer given the object id.
@@ -599,12 +601,12 @@ function LegendBlockFactory($q, Geo, layerRegistry, gapiService, configService, 
          * @param {Number} oid the object id
          * @return {Promise} a promise resolving with a graphic
          */
-        fetchGraphic(oid) {         return this._mainProxyWrapper.fetchGraphic(oid); }
+        fetchGraphic(oid) {         return this.mainProxyWrapper.fetchGraphic(oid); }
 
         get symbologyStack () {     return this._symbologyStack; }
 
-        get metadataUrl () {        return this._mainProxyWrapper.metadataUrl; }
-        get catalogueUrl () {       return this._mainProxyWrapper.catalogueUrl; }
+        get metadataUrl () {        return this.mainProxyWrapper.metadataUrl; }
+        get catalogueUrl () {       return this.mainProxyWrapper.catalogueUrl; }
     }
 
     // who is responsible for populating legend groups with entries? legend service or the legend group itself

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -440,7 +440,9 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
                     const entryConfig = new ConfigObject.legend.Entry(item);
                     legendBlock = new LegendBlock.Node(item.proxyWrapper, entryConfig);
                     legendBlock.layerRecordId = layerConfig.id; // map all dynamic children to the block config and layer record of their root parent
-                    legendBlock.filter = item.proxyWrapper.layerConfig.table && item.proxyWrapper.layerConfig.table.applyMap;
+
+                    // show filter flag if there is a filter query being applied
+                    legendBlock.filter = item.proxyWrapper.layerConfig.initialFilteredQuery && item.proxyWrapper.layerConfig.initialFilteredQuery !== "";
                     legendBlock.applyInitialStateSettings();
                 }
 
@@ -652,7 +654,9 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
 
             // map this legend block to the layerRecord
             node.layerRecordId = layerConfig.id;
-            node.filter = layerConfig.table && layerConfig.table.applyMap;
+
+            // show filter flag if there is a filter query being applied
+            node.filter = layerConfig.initialFilteredQuery && layerConfig.initialFilteredQuery !== "";
 
             legendMappings[layerConfig.id].push({
                 legendBlockId: node.id,

--- a/src/app/ui/table/table-default-menu.directive.js
+++ b/src/app/ui/table/table-default-menu.directive.js
@@ -58,7 +58,7 @@ function Controller($scope, stateManager, events, tableService, appInfo, $rootSc
 
     function setMode(mode) {
         const requester = stateManager.display.table.requester;
-        const config = requester.legendEntry._mainProxyWrapper.layerConfig.table;
+        const config = requester.legendEntry.mainProxyWrapper.layerConfig.table;
         stateManager.setMorph('table', mode);
         if (mode === 'full') {
             config.maximize = true;

--- a/src/app/ui/table/table-definition.directive.js
+++ b/src/app/ui/table/table-definition.directive.js
@@ -362,8 +362,8 @@ function rvTableDefinition(stateManager, events, $compile, tableService, referen
                 if (val && !isNaN(val.getTime())) {
                     // set date to filter values or minimum / maximum date value
                     // remove the time part from the filter values
-                    let min = (filter.min !== null) ? filter.min.toDateString() : new Date(-8640000000000000);
-                    let max = (filter.max !== null) ? filter.max.toDateString() : new Date(8640000000000000);
+                    let min = filter.min ? filter.min.toDateString() : new Date(-8640000000000000);
+                    let max = filter.max ? filter.max.toDateString() : new Date(8640000000000000);
 
                     // create a new date object with the time set to beginning of the day
                     min = new Date(min);

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -12,7 +12,7 @@ angular
     .factory('tableService', tableService);
 
 function tableService(stateManager, geoService, $rootScope, $q, gapiService, debounceService, $rootElement, $timeout,
-    referenceService, layerRegistry) {
+    referenceService, layerRegistry, configService) {
 
     // timestamps can be watched for key changes to filter data
     const filterTimeStamps = {
@@ -192,9 +192,35 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
             }
         });
 
-        // remove filter flag is filter by extend is not active (data is not filtered)
+        // store the reset filter values
+        filters.requester.legendEntry.mainProxyWrapper.layerConfig.table.columns.forEach(column => {
+            if (typeof column.filter !== 'undefined') {
+                if (!column.filter.static) {
+                    if (column.filter.type === 'selector') {
+                        column.filter.value = [];
+                    } else if (column.filter.type === 'rv-date') {
+                        column.filter.value = {};
+                    } else {
+                        column.filter.value = '';
+                    }
+                }
+            }
+        });
+
+        // remove filter flag if filter by extent is not active (data is not filtered)
         service.filter.isMapFiltered = false;
         filters.data.filter.isMapFiltered = service.filter.isMapFiltered;  // set on layer so it can persist when we change layer
+
+        const config = configService.getSync.map.layerRecords.find(item =>
+            item.config.id === filters.requester.legendEntry.layerRecordId).initialConfig;
+
+        config.table.applyMap = false;
+
+        // most recent 'filters' were applied (no filters but no changes either)
+        config.table.applied = true;
+
+        // update the query to use on layer reload
+        config.initialFilteredQuery = defs.join(' AND ');
 
         // get filters configuration and check if static field were used. If so, filters can't be remove and flag need to stay
         stateManager.display.table.requester.legendEntry.filter =
@@ -237,10 +263,35 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         // set layer defintion query
         setDefinitionExpression(filters.requester.legendEntry, defs);
 
-        // set filter flag (data is filtered)
-        service.filter.isMapFiltered = true;
+        if (defs.length === 0) {
+            // store the reset filter values
+            filters.requester.legendEntry.mainProxyWrapper.layerConfig.table.columns.forEach(column => {
+                if (typeof column.filter !== 'undefined') {
+                    if (column.filter.type === 'selector') {
+                        column.filter.value = [];
+                    } else if (column.filter.type === 'rv-date') {
+                        column.filter.value = {};
+                    } else {
+                        column.filter.value = '';
+                    }
+                }
+            });
+        }
+
+        // set filter flag accordingly (if data is filtered)
+        service.filter.isMapFiltered = defs.length > 0;
         filters.data.filter.isMapFiltered = service.filter.isMapFiltered;  // set on layer so it can persist when we change layer
+
+        const config = configService.getSync.map.layerRecords.find(item =>
+            item.config.id === filters.requester.legendEntry.layerRecordId).initialConfig;
+
+        // most recent 'filters' were applied (either no filters and no changes or updated filters applied)
+        config.table.applyMap = config.table.applied = true;
+
         stateManager.display.table.requester.legendEntry.filter = service.filter.isMapFiltered;
+
+        // update the query to use on layer reload
+        config.initialFilteredQuery = defs.join(' AND ');
     }
 
     /**
@@ -283,11 +334,11 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
             const min = column.filter.min;
             const max = column.filter.max;
 
-            if (min !== null) {
+            if (min) {
                 const dateMin = `${min.getMonth() + 1}/${min.getDate()}/${min.getFullYear()}`;
                 defs.push(`${column.name} >= DATE \'${dateMin}\'`);
             }
-            if (max !== null) {
+            if (max) {
                 const dateMax = `${max.getMonth() + 1}/${max.getDate()}/${max.getFullYear()}`;
                 defs.push(`${column.name} <= DATE \'${dateMax}\'`);
             }
@@ -353,11 +404,13 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         // keep filter state to know when to show apply map button
         setFiltersState(column, value);
 
+        const configTable = stateManager.display.table.requester.legendEntry.mainProxyWrapper.layerConfig.table;
+
         // keep filter value to reapply when table reopens
-        if (keep) {
-            const item = stateManager.display.table.data.columns.find(filter => column === filter.name);
-            item.filter.value = value;
-        }
+        configTable.columns.find(filter => column === filter.data).filter.value = value;
+
+        // changes made to filter, show Apply Map button
+        configTable.applyMap = configTable.applied = false;
     }
 
     /**
@@ -372,9 +425,13 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         const value = (values.length > 0) ? values.join('|').replace(/"/g, '') : '';
         onFilterStringChange(column, value);
 
-        // keep filter value to reapply when table reopens
-        const item = stateManager.display.table.data.columns.find(filter => column === filter.name);
-        item.filter.value = values;
+        const configTable = stateManager.display.table.requester.legendEntry.mainProxyWrapper.layerConfig.table;
+
+        // keep filter value when reloading layer
+        configTable.columns.find(filter => column === filter.data).filter.value = values;
+
+        // changes made to filter, show Apply Map button
+        configTable.applyMap = configTable.applied = false;
     }
 
     /**
@@ -396,10 +453,13 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         // use timeout for redraw so processing can show
         $timeout(() => { service.getTable().draw(); }, 100);
 
-        // keep filter value to reapply when table reopens
-        const item = stateManager.display.table.data.columns.find(filter => column === filter.name);
-        item.filter.min = min;
-        item.filter.max = max;
+        const configTable = stateManager.display.table.requester.legendEntry.mainProxyWrapper.layerConfig.table;
+
+        // keep filter value when reloading layer
+        configTable.columns.find(filter => column === filter.data).filter.value = `${min},${max}`;
+
+        // changes made to filter, show Apply Map button
+        configTable.applyMap = configTable.applied = false;
     }
 
     /**
@@ -421,10 +481,16 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         // use timeout for redraw so processing can show
         $timeout(() => { service.getTable().draw(); }, 100);
 
-        // keep filter value to reapply when table reopens
-        const item = stateManager.display.table.data.columns.find(filter => column === filter.name);
-        item.filter.min = min;
-        item.filter.max = max;
+        const configTable = stateManager.display.table.requester.legendEntry.mainProxyWrapper.layerConfig.table;
+
+        // keep filter value when reloading layer
+        configTable.columns.find(filter => column === filter.data).filter.value = {
+            min: min,
+            max: max
+        };
+
+        // changes made to filter, show Apply Map button
+        configTable.applyMap = configTable.applied = false;
     }
 
     /**
@@ -437,7 +503,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
      */
     function setFiltersState(column, value) {
         // if there is value, assign to column and show apply map button
-        // if not, it means value is '', loop trought the filters to see if we still need to show apply map button
+        // if not, it means value is '', loop through the filters to see if we still need to show apply map button
         if (value) {
             service.filters[column] = true;
             service.filter.isApplied = false;
@@ -447,10 +513,21 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
             // check filter flag to know if filter is applied
             service.filter.isApplied = stateManager.display.table.requester.legendEntry.filters ? false : true;
 
+            let flag = false;
+
             filtersObject.each(el => {
                 // check if another field have a filter. If so, show Apply Map
-                if (service.filters[el]) { service.filter.isApplied = false; }
+                if (service.filters[el]) {
+                    flag = true;
+                    service.filter.isApplied = false;
+                }
             });
+
+            // if flag is still false, no other field has a filter, so all filters have been cleared on table
+            // show Apply Map button to be able to clear all filters on the map as well
+            if (flag === false) {
+                service.filter.isApplied = false;
+            }
         }
 
         stateManager.display.table.data.filter.isApplied = service.filter.isApplied;  // set on layer so it can persist when we change layer

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -12,7 +12,7 @@ angular
     .factory('tableService', tableService);
 
 function tableService(stateManager, geoService, $rootScope, $q, gapiService, debounceService, $rootElement, $timeout,
-    referenceService, layerRegistry, configService) {
+    referenceService, layerRegistry, configService, Geo) {
 
     // timestamps can be watched for key changes to filter data
     const filterTimeStamps = {
@@ -217,7 +217,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
             item.config.id === filters.requester.legendEntry.layerRecordId).initialConfig;
 
         // TODO: Modify when filtering capabilities added for other layers such as WMS
-        if (config.layerType === 'esriDynamic') {
+        if (config.layerType === Geo.Layer.Types.ESRI_DYNAMIC) {
             config = config.layerEntries.find(item => item.index === layerConfig.index)
         }
 
@@ -295,7 +295,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
             item.config.id === filters.requester.legendEntry.layerRecordId).initialConfig;
 
         // TODO: Modify when filtering capabilities added for other layers such as WMS
-        if (config.layerType === 'esriDynamic') {
+        if (config.layerType === Geo.Layer.Types.ESRI_DYNAMIC) {
             config = config.layerEntries.find(item => item.index === layerConfig.index)
         }
 
@@ -590,8 +590,8 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         // user added layer from server support definition expression and time defintion
         const layer = layerRegistry.getLayerRecord(stateManager.display.table.requester.legendEntry.layerRecordId);
         const layerType = layer.initialConfig.layerType; // stateManager.display.table.requester.legendEntry.layerType;
-        service.isFeatureLayer = (layerType === 'esriFeature' && !layer.isFileLayer());
-        service.isDynamicLayer = (layerType === 'esriDynamic');
+        service.isFeatureLayer = (layerType === Geo.Layer.Types.ESRI_FEATURE && !layer.isFileLayer());
+        service.isDynamicLayer = (layerType === Geo.Layer.Types.ESRI_DYNAMIC);
 
         filteredState().then(() => {
             filterTimeStamps.onCreated = Date.now();

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -192,8 +192,10 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
             }
         });
 
+        const layerConfig = filters.requester.legendEntry.mainProxyWrapper.layerConfig;
+
         // store the reset filter values
-        filters.requester.legendEntry.mainProxyWrapper.layerConfig.table.columns.forEach(column => {
+        layerConfig.table.columns.forEach(column => {
             if (typeof column.filter !== 'undefined') {
                 if (!column.filter.static) {
                     if (column.filter.type === 'selector') {
@@ -211,8 +213,13 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         service.filter.isMapFiltered = false;
         filters.data.filter.isMapFiltered = service.filter.isMapFiltered;  // set on layer so it can persist when we change layer
 
-        const config = configService.getSync.map.layerRecords.find(item =>
+        let config = configService.getSync.map.layerRecords.find(item =>
             item.config.id === filters.requester.legendEntry.layerRecordId).initialConfig;
+
+        // TODO: Modify when filtering capabilities added for other layers such as WMS
+        if (config.layerType === 'esriDynamic') {
+            config = config.layerEntries.find(item => item.index === layerConfig.index)
+        }
 
         config.table.applyMap = false;
 
@@ -263,9 +270,11 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         // set layer defintion query
         setDefinitionExpression(filters.requester.legendEntry, defs);
 
+        const layerConfig = filters.requester.legendEntry.mainProxyWrapper.layerConfig;
+
         if (defs.length === 0) {
             // store the reset filter values
-            filters.requester.legendEntry.mainProxyWrapper.layerConfig.table.columns.forEach(column => {
+            layerConfig.table.columns.forEach(column => {
                 if (typeof column.filter !== 'undefined') {
                     if (column.filter.type === 'selector') {
                         column.filter.value = [];
@@ -282,8 +291,13 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         service.filter.isMapFiltered = defs.length > 0;
         filters.data.filter.isMapFiltered = service.filter.isMapFiltered;  // set on layer so it can persist when we change layer
 
-        const config = configService.getSync.map.layerRecords.find(item =>
+        let config = configService.getSync.map.layerRecords.find(item =>
             item.config.id === filters.requester.legendEntry.layerRecordId).initialConfig;
+
+        // TODO: Modify when filtering capabilities added for other layers such as WMS
+        if (config.layerType === 'esriDynamic') {
+            config = config.layerEntries.find(item => item.index === layerConfig.index)
+        }
 
         // most recent 'filters' were applied (either no filters and no changes or updated filters applied)
         config.table.applyMap = config.table.applied = true;

--- a/src/app/ui/toc/toc.directive.js
+++ b/src/app/ui/toc/toc.directive.js
@@ -268,7 +268,7 @@ function Controller($scope, tocService, layerRegistry, stateManager, geoService,
 
             if (layerRecord.layerType === Geo.Layer.Types.ESRI_DYNAMIC) {
                 layerRecord.config.layerEntries.forEach(currentSubLayer => {
-                    if (currentSubLayer.table && currentSubLayer.table.applyMap) {
+                    if (currentSubLayer.table && (currentSubLayer.table.applyMap || currentSubLayer.table.applied)) {
                         const proxy = layerRecord.getChildProxy(currentSubLayer.index);
 
                         proxy.setDefinitionQuery(currentSubLayer.initialFilteredQuery);

--- a/src/app/ui/toc/toc.directive.js
+++ b/src/app/ui/toc/toc.directive.js
@@ -268,7 +268,7 @@ function Controller($scope, tocService, layerRegistry, stateManager, geoService,
 
             if (layerRecord.layerType === Geo.Layer.Types.ESRI_DYNAMIC) {
                 layerRecord.config.layerEntries.forEach(currentSubLayer => {
-                    if (currentSubLayer.table && (currentSubLayer.table.applyMap || currentSubLayer.table.applied)) {
+                    if (currentSubLayer.table) {        // if table exists, we need to reaply the definition query every time on reload
                         const proxy = layerRecord.getChildProxy(currentSubLayer.index);
 
                         proxy.setDefinitionQuery(currentSubLayer.initialFilteredQuery);

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -62,9 +62,8 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, stat
         const config = configService.getSync.map.layerRecords.find(item =>
             item.config.id === legendBlock.layerRecordId).initialConfig.table;
 
-        // reset filter flag
-        legendBlock.filter = config.initialFilter;
-        config.applyMap =  config.initialFilter;
+        // update filter flag
+        legendBlock.filter = config.applied;
 
         stateManager.setActive({ tableFulldata: false } , { sideMetadata: false }, { sideSettings: false });
         legendService.reloadBoundLegendBlocks(legendBlock.layerRecordId);


### PR DESCRIPTION
## Description
Closes #2362 - filters are restored when reloading; currently only looks like it works for feature layers because of another bug that came up which is being looked at right now

Closes #2363 - when removing all filters by backspacing or deleting instead of hitting the `Clear filters` button, the `Apply to Map` option is available

Fixes small bug for #2120 - filtering on reload after opening datatable for dynamic layers

## Testing
Visually tested - hours and hours of testing (still might have missed something)

Sample 46 can be used to test pre-existing filters and any sample can be used to test by adding filters.

## Documentation
JSDoc and in-line comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2365)
<!-- Reviewable:end -->
