### PR TITLE
2374 table width 

### DIFF
--- a/src/app/ui/table/default.html
+++ b/src/app/ui/table/default.html
@@ -7,7 +7,7 @@
         title-value="{{ 'filter.title' | translate }} {{ self.title }}"
         is-loading="self.display.isLoading"
         hide-when-loading="false"
-        ng-hide="self.tableService.isSettingOpen">
+        ng-class="{ 'rv-transparent-class': self.tableService.isSettingOpen }">
 
         <div class="rv-table-splash rv-hide-animate"
             ng-if="!self.display.requester.error"
@@ -28,7 +28,7 @@
         <div class="rv-table rv-hide-animate" ng-class="{ 'rv-hide': self.display.isLoading }">
 
             <!--md-button ng-click="self.draw()">click this button if you don't see the table below</md-button-->
-            <div class="rv-table-data-container" rv-table-definition info="columns" ng-show="!self.tableService.isSettingOpen"></div>
+            <div class="rv-table-data-container" rv-table-definition info="columns"></div>
 
             <rv-table-setting-panel ng-cloak ng-show="self.tableService.isSettingOpen"></rv-table-setting-panel>
 

--- a/src/app/ui/table/default.html
+++ b/src/app/ui/table/default.html
@@ -7,7 +7,7 @@
         title-value="{{ 'filter.title' | translate }} {{ self.title }}"
         is-loading="self.display.isLoading"
         hide-when-loading="false"
-        ng-class="{ 'rv-transparent-class': self.tableService.isSettingOpen }">
+        ng-class="{ 'rv-transparent': self.tableService.isSettingOpen }">
 
         <div class="rv-table-splash rv-hide-animate"
             ng-if="!self.display.requester.error"

--- a/src/app/ui/table/setting-cluster.html
+++ b/src/app/ui/table/setting-cluster.html
@@ -24,7 +24,7 @@
         aria-label="{{ filter.table.setting.tooltip | translate }}"
         class="md-icon-button primary"
         rv-help="table-setting-button"
-        ng-click="self.tableService.toggleSetting()">
+        ng-click="self.tableService.openSettings()">
         <md-tooltip>{{ 'filter.table.setting.tooltip' | translate }}</md-tooltip>
         <md-icon md-svg-src="action:settings"></md-icon>
     </md-button>

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -40,7 +40,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         getTable,
         clearFilters,
         applyFilters,
-        toggleSetting,
+        openSettings,
         onFilterStringChange: debounceService.registerDebounce(onFilterStringChange, 700, false),
         onFilterSelectorChange: onFilterSelectorChange,
         onFilterNumberChange: debounceService.registerDebounce(onFilterNumberChange, 700, false),
@@ -378,11 +378,11 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
     }
 
     /**
-     * Toggle settings info section
+     * Open settings info section
      *
-     * @function toggleSetting
+     * @function openSettings
      */
-    function toggleSetting() {
+    function openSettings() {
         service.isSettingOpen = !service.isSettingOpen;
 
         // show filters if setting is open

--- a/src/content/styles/modules/_table.scss
+++ b/src/content/styles/modules/_table.scss
@@ -5,7 +5,7 @@
         }
     }
 
-    .rv-transparent-class {
+    .rv-transparent {
         visibility: hidden;
     }
 

--- a/src/content/styles/modules/_table.scss
+++ b/src/content/styles/modules/_table.scss
@@ -5,6 +5,10 @@
         }
     }
 
+    .rv-transparent-class {
+        opacity: 0;
+    }
+
     .rv-table-splash {
         height: 100%;
         width: 100%;

--- a/src/content/styles/modules/_table.scss
+++ b/src/content/styles/modules/_table.scss
@@ -6,7 +6,7 @@
     }
 
     .rv-transparent-class {
-        opacity: 0;
+        visibility: hidden;
     }
 
     .rv-table-splash {


### PR DESCRIPTION
## Description
Closes #2374 - The table is still 'open' when the settings panel is open so the correct column widths can be calculated

Also renamed function `toggleSetting` to `openSettings` in `table.service.js`

## Testing
Visually tested

## Documentation
Changed JSDoc for `openSettings`

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2382)
<!-- Reviewable:end -->
