### PR TITLE
Config options for export and overview map and removing layer toast

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -148,6 +148,11 @@
                 "value": {
                     "type": "string",
                     "description": "Value to be passed to the generation function of this export component."
+                },
+                "showSymbology": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Indicates whether symbology from controlled layers and info sections to be included in export legend"
                 }
             },
             "description": "This is the initial configuration for an export component.",

--- a/schema.json
+++ b/schema.json
@@ -149,7 +149,7 @@
                     "type": "string",
                     "description": "Value to be passed to the generation function of this export component."
                 },
-                "showSymbology": {
+                "showInfoAndControlledSymbology": {
                     "type": "boolean",
                     "default": false,
                     "description": "Indicates whether symbology from controlled layers and info sections to be included in export legend"

--- a/schema.json
+++ b/schema.json
@@ -148,14 +148,41 @@
                 "value": {
                     "type": "string",
                     "description": "Value to be passed to the generation function of this export component."
-                },
-                "showInfoAndControlledSymbology": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Indicates whether symbology from controlled layers and info sections to be included in export legend"
                 }
             },
             "description": "This is the initial configuration for an export component.",
+            "additionalProperties": false
+        },
+
+        "legendExportComponent": {
+            "type": "object",
+            "properties": {
+                "isSelected": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Indicates if the component is selected and included in the export graphic."
+                },
+                "isSelectable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Indicates if the component can be included or excluded from the export graphic by the user."
+                },
+                "value": {
+                    "type": "string",
+                    "description": "Value to be passed to the generation function of this export component."
+                },
+                "showInfoSymbology": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Indicates whether symbology from info sections should be included in export legend"
+                },
+                "showControlledSymbology": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Indicates whether symbology from controlled layers should be included in export legend"
+                }
+            },
+            "description": "This is the initial configuration for a legend export component.",
             "additionalProperties": false
         },
 
@@ -821,7 +848,7 @@
                         "title": { "$ref": "#/definitions/exportComponent", "description": "Title of the export graphic." },
                         "map": { "$ref": "#/definitions/exportComponent", "description": "Map component." },
                         "mapElements": { "$ref": "#/definitions/exportComponent", "description": "North arrow and scalebar component." },
-                        "legend": { "$ref": "#/definitions/exportComponent", "description": "Legend component." },
+                        "legend": { "$ref": "#/definitions/legendExportComponent", "description": "Legend component." },
                         "footnote": { "$ref": "#/definitions/exportComponent", "description": "Foot notice to add to exported map" },
                         "timestamp":  { "$ref": "#/definitions/exportComponent", "description": "Timestamp component." }
                     },

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1624,27 +1624,15 @@ function ConfigObjectFactory(Geo, gapiService, common) {
 
     /**
      * Typed representation of the `services.export.legend` section of the config.
-     * @class ExportComponent
+     * @class LegendExportComponent
      */
-    class LegendExportComponent {
-        constructor (source = { value: '', isSelectable: false, isSelected: false, isVisible: false,
-                showInfoSymbology: false, showControlledSymbology: false }) {
-            this._isSelected = source.isSelected;
-            this._isSelectable = source.isSelectable;
-            this._isVisible = source.isVisible;
-            this._value = source.value;
+    class LegendExportComponent extends ExportComponent {
+        constructor (source) {
+            super(source);
+
             this._showInfoSymbology = source.showInfoSymbology || false;
             this._showControlledSymbology = source.showControlledSymbology || false;
         }
-
-        get isSelected () {         return this._isSelected; }
-        set isSelected (value) {    this._isSelected = value; }
-        get isSelectable () {       return this._isSelectable; }
-        set isSelectable (value) {  this._isSelectable = value; }
-        get isVisible () {          return this._isVisible; }
-        set isVisible (value) {     this._isVisible = value; }
-        get value () {              return this._value; }
-        set value (value) {         this._value = value; }
 
         get showInfoSymbology () {      return this._showInfoSymbology; }
         set showInfoSymbology (value) { this._showInfoSymbology = value; }
@@ -1652,23 +1640,11 @@ function ConfigObjectFactory(Geo, gapiService, common) {
         get showControlledSymbology () {      return this._showControlledSymbology; }
         set showControlledSymbology (value) { this._showControlledSymbology = value; }
 
-        _generators = [];
-        _graphicOrder = null;
-
-        get generators () { return this._generators; }
-        set generators(value = []) { this._generators = value; }
-        get graphicOrder () { return this._graphicOrder; }
-        set graphicOrder(value = null) { this._graphicOrder = value; }
-
         get JSON() {
-            return {
-                isSelected: this.isSelected,
-                isSelectable: this.isSelectable,
-                isVisible: this.isVisible,
-                value: this.value,
+            return angular.merge(super.JSON, {
                 showInfoSymbology: this.showInfoSymbology,
                 showControlledSymbology: this.showControlledSymbology
-            };
+            });
         }
     }
 

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1588,12 +1588,12 @@ function ConfigObjectFactory(Geo, gapiService, common) {
      * @class ExportComponent
      */
     class ExportComponent {
-        constructor (source = { value: '', isSelectable: false, isSelected: false, isVisible: false, showSymbology: false }) {
+        constructor (source = { value: '', isSelectable: false, isSelected: false, isVisible: false, showInfoAndControlledSymbology: false }) {
             this._isSelected = source.isSelected;
             this._isSelectable = source.isSelectable;
             this._isVisible = source.isVisible;
             this._value = source.value;
-            this._showSymbology = source.showSymbology || false;
+            this._showInfoAndControlledSymbology = source.showInfoAndControlledSymbology || false;
         }
 
         get isSelected () {         return this._isSelected; }
@@ -1604,8 +1604,8 @@ function ConfigObjectFactory(Geo, gapiService, common) {
         set isVisible (value) {     this._isVisible = value; }
         get value () {              return this._value; }
         set value (value) {         this._value = value; }
-        get showSymbology () {      return this._showSymbology; }
-        set showSymbology (value) { this._showSymbology = value; }
+        get showInfoAndControlledSymbology () {      return this._showInfoAndControlledSymbology; }
+        set showInfoAndControlledSymbology (value) { this._showInfoAndControlledSymbology = value; }
 
         _generators = [];
         _graphicOrder = null;
@@ -1621,7 +1621,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                 isSelectable: this.isSelectable,
                 isVisible: this.isVisible,
                 value: this.value,
-                showSymbology: this.showSymbology
+                showInfoAndControlledSymbology: this.showInfoAndControlledSymbology
             };
         }
     }

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1584,16 +1584,15 @@ function ConfigObjectFactory(Geo, gapiService, common) {
     }
 
     /**
-     * Typed representation of the `services.export.[components]` section of the config.
+     * Typed representation of the `services.export.[components]` section of the config (excluding the legend).
      * @class ExportComponent
      */
     class ExportComponent {
-        constructor (source = { value: '', isSelectable: false, isSelected: false, isVisible: false, showInfoAndControlledSymbology: false }) {
+        constructor (source = { value: '', isSelectable: false, isSelected: false, isVisible: false }) {
             this._isSelected = source.isSelected;
             this._isSelectable = source.isSelectable;
             this._isVisible = source.isVisible;
             this._value = source.value;
-            this._showInfoAndControlledSymbology = source.showInfoAndControlledSymbology || false;
         }
 
         get isSelected () {         return this._isSelected; }
@@ -1604,8 +1603,54 @@ function ConfigObjectFactory(Geo, gapiService, common) {
         set isVisible (value) {     this._isVisible = value; }
         get value () {              return this._value; }
         set value (value) {         this._value = value; }
-        get showInfoAndControlledSymbology () {      return this._showInfoAndControlledSymbology; }
-        set showInfoAndControlledSymbology (value) { this._showInfoAndControlledSymbology = value; }
+
+        _generators = [];
+        _graphicOrder = null;
+
+        get generators () { return this._generators; }
+        set generators(value = []) { this._generators = value; }
+        get graphicOrder () { return this._graphicOrder; }
+        set graphicOrder(value = null) { this._graphicOrder = value; }
+
+        get JSON() {
+            return {
+                isSelected: this.isSelected,
+                isSelectable: this.isSelectable,
+                isVisible: this.isVisible,
+                value: this.value
+            };
+        }
+    }
+
+    /**
+     * Typed representation of the `services.export.legend` section of the config.
+     * @class ExportComponent
+     */
+    class LegendExportComponent {
+        constructor (source = { value: '', isSelectable: false, isSelected: false, isVisible: false,
+                showInfoSymbology: false, showControlledSymbology: false }) {
+            this._isSelected = source.isSelected;
+            this._isSelectable = source.isSelectable;
+            this._isVisible = source.isVisible;
+            this._value = source.value;
+            this._showInfoSymbology = source.showInfoSymbology || false;
+            this._showControlledSymbology = source.showControlledSymbology || false;
+        }
+
+        get isSelected () {         return this._isSelected; }
+        set isSelected (value) {    this._isSelected = value; }
+        get isSelectable () {       return this._isSelectable; }
+        set isSelectable (value) {  this._isSelectable = value; }
+        get isVisible () {          return this._isVisible; }
+        set isVisible (value) {     this._isVisible = value; }
+        get value () {              return this._value; }
+        set value (value) {         this._value = value; }
+
+        get showInfoSymbology () {      return this._showInfoSymbology; }
+        set showInfoSymbology (value) { this._showInfoSymbology = value; }
+
+        get showControlledSymbology () {      return this._showControlledSymbology; }
+        set showControlledSymbology (value) { this._showControlledSymbology = value; }
 
         _generators = [];
         _graphicOrder = null;
@@ -1621,7 +1666,8 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                 isSelectable: this.isSelectable,
                 isVisible: this.isVisible,
                 value: this.value,
-                showInfoAndControlledSymbology: this.showInfoAndControlledSymbology
+                showInfoSymbology: this.showInfoSymbology,
+                showControlledSymbology: this.showControlledSymbology
             };
         }
     }
@@ -1636,7 +1682,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             this._title.isVisible = false; // rendered export title should not be visible in the ui
             this._map = new ExportComponent(source.map);
             this._mapElements = new ExportComponent(source.mapElements);
-            this._legend = new ExportComponent(source.legend);
+            this._legend = new LegendExportComponent(source.legend);
             this._footnote = new ExportComponent(source.footnote);
             this._timestamp = new ExportComponent(source.timestamp);
         }

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1495,17 +1495,20 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             this._maximizeButton = source.maximizeButton;
             this._layerType = source.layerType;
             this._expandFactor = source.expandFactor || 2;
+            this._initiallyExpanded = typeof source.initiallyExpanded !== 'undefined' ? source.initiallyExpanded : true;
         }
 
         get maximizeButton () { return this._maximizeButton; }
         get layerType () { return this._layerType; }
         get expandFactor () { return this._expandFactor; }
+        get initiallyExpanded () { return this._initiallyExpanded; }
 
         get JSON() {
             return angular.merge(super.JSON, {
                 maximizeButton: this.maximizeButton,
                 layerType: this.layerType,
-                expandFactor: this.expandFactor
+                expandFactor: this.expandFactor,
+                initiallyExpanded: this.initiallyExpanded
             });
         }
     }

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1588,11 +1588,12 @@ function ConfigObjectFactory(Geo, gapiService, common) {
      * @class ExportComponent
      */
     class ExportComponent {
-        constructor (source = { value: '', isSelectable: false, isSelected: false, isVisible: false }) {
+        constructor (source = { value: '', isSelectable: false, isSelected: false, isVisible: false, showSymbology: false }) {
             this._isSelected = source.isSelected;
             this._isSelectable = source.isSelectable;
             this._isVisible = source.isVisible;
             this._value = source.value;
+            this._showSymbology = source.showSymbology || false;
         }
 
         get isSelected () {         return this._isSelected; }
@@ -1603,6 +1604,8 @@ function ConfigObjectFactory(Geo, gapiService, common) {
         set isVisible (value) {     this._isVisible = value; }
         get value () {              return this._value; }
         set value (value) {         this._value = value; }
+        get showSymbology () {      return this._showSymbology; }
+        set showSymbology (value) { this._showSymbology = value; }
 
         _generators = [];
         _graphicOrder = null;
@@ -1617,7 +1620,8 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                 isSelected: this.isSelected,
                 isSelectable: this.isSelectable,
                 isVisible: this.isVisible,
-                value: this.value
+                value: this.value,
+                showSymbology: this.showSymbology
             };
         }
     }

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -312,6 +312,10 @@ function LegendBlockFactory(common, Geo, layerRegistry, gapiService, configServi
         get description () {            return this.blockConfig.description; }
         get symbologyStack () {         return this._symbologyStack; }
         get symbologyRenderStyle () {   return this.blockConfig.symbologyRenderStyle; }
+
+        get isVisibleOnExport () {
+            return configService.getSync.services.export.legend.showInfoAndControlledSymbology;
+        }
     }
 
     // can be node or group
@@ -700,6 +704,12 @@ function LegendBlockFactory(common, Geo, layerRegistry, gapiService, configServi
 
         get metadataUrl () {        return this.mainProxyWrapper.metadataUrl; }
         get catalogueUrl () {       return this.mainProxyWrapper.catalogueUrl; }
+
+        get isVisibleOnExport () {
+            return this.visibility && !this.hidden && this.opacity !== 0 &&
+                (this.state === 'rv-refresh' || this.state === 'rv-loaded') &&
+                !this.scale.offscale;
+        }
     }
 
     // who is responsible for populating legend groups with entries? legend service or the legend group itself
@@ -965,6 +975,12 @@ function LegendBlockFactory(common, Geo, layerRegistry, gapiService, configServi
         walk (...args) {
             return this._walk(...args);
         }
+
+        get isVisibleOnExport () {
+            return !this.hidden && this.opacity !== 0 &&
+                (this.state === 'rv-refresh' || this.state === 'rv-loaded') &&
+                this.entries.some(entry => entry.isVisibleOnExport);
+        }
     }
 
     class LegendSet extends LegendEntry {
@@ -1075,6 +1091,11 @@ function LegendBlockFactory(common, Geo, layerRegistry, gapiService, configServi
 
         walk (...args) {
             return this._walk(...args);
+        }
+
+        get isVisibleOnExport () {
+            return !this.hidden && this.opacity !== 0 &&
+                this.entries.some(entry => entry.isVisibleOnExport);
         }
     }
 

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -708,7 +708,7 @@ function LegendBlockFactory(common, Geo, layerRegistry, gapiService, configServi
         get isVisibleOnExport () {
             return this.visibility && !this.hidden && this.opacity !== 0 &&
                 (this.state === 'rv-refresh' || this.state === 'rv-loaded') &&
-                !this.scale.offscale;
+                !this.scale.offScale;
         }
     }
 

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -314,7 +314,7 @@ function LegendBlockFactory(common, Geo, layerRegistry, gapiService, configServi
         get symbologyRenderStyle () {   return this.blockConfig.symbologyRenderStyle; }
 
         get isVisibleOnExport () {
-            return configService.getSync.services.export.legend.showInfoAndControlledSymbology;
+            return configService.getSync.services.export.legend.showInfoSymbology;
         }
     }
 

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -10,7 +10,7 @@ angular
     .module('app.geo')
     .factory('mapService', mapServiceFactory);
 
-function mapServiceFactory($timeout, referenceService, gapiService, configService, identifyService, events, $translate, errorService, layoutService) {
+function mapServiceFactory($timeout, referenceService, gapiService, configService, identifyService, events, $translate, errorService) {
     const service = {
         destroyMap,
         makeMap,
@@ -380,7 +380,7 @@ function mapServiceFactory($timeout, referenceService, gapiService, configServic
             const toast = {
                 textContent: $translate.instant('toc.boundaryZoom.badzoom'),
                 action: $translate.instant('toc.boundaryZoom.undo'),
-                parent: layoutService.panels.shell
+                parent: referenceService.panels.shell
             };
 
             // promise resolves with 'ok' when user clicks 'undo'

--- a/src/app/geo/overview-toggle.directive.js
+++ b/src/app/geo/overview-toggle.directive.js
@@ -54,12 +54,11 @@ function rvOverviewToggle($compile, $rootScope, geoService, $timeout, animationS
         });
 
         const self = scope.self;
+        self.overviewActive = true;
 
         configService.getAsync.then(config => {
             if (config.map.components.overviewMap.enabled) {
                 self.overviewActive = config.map.components.overviewMap.initiallyExpanded;
-            } else {
-                self.overviewActive = true;
             }
         });
 

--- a/src/app/geo/overview-toggle.directive.js
+++ b/src/app/geo/overview-toggle.directive.js
@@ -54,7 +54,14 @@ function rvOverviewToggle($compile, $rootScope, geoService, $timeout, animationS
         });
 
         const self = scope.self;
-        self.overviewActive = true;
+
+        configService.getAsync.then(config => {
+            if (config.map.components.overviewMap.enabled) {
+                self.overviewActive = config.map.components.overviewMap.initiallyExpanded;
+            } else {
+                self.overviewActive = true;
+            }
+        });
 
         const overviewScope = $rootScope.$new();
         overviewScope.self = self;

--- a/src/app/ui/export/export-legend.service.js
+++ b/src/app/ui/export/export-legend.service.js
@@ -456,12 +456,12 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
      * @return {Boolean} true if block should be shown in export legend
      */
     function _showBlock(entry) {
-        const showInfoAndControlledSymbology = configService.getSync.services.export.legend.showInfoAndControlledSymbology;
+        const exportLegend = configService.getSync.services.export.legend;
 
         if (entry.blockType === LegendBlock.TYPES.INFO) {
-            return showInfoAndControlledSymbology
+            return exportLegend.showInfoSymbology;
         } else if (entry.controlled) {
-            return showInfoAndControlledSymbology && entry.isVisibleOnExport;
+            return exportLegend.showControlledSymbology && entry.isVisibleOnExport;
         }
 
         return entry.isVisibleOnExport;

--- a/src/app/ui/export/export-legend.service.js
+++ b/src/app/ui/export/export-legend.service.js
@@ -476,14 +476,16 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
      * @return {String} the HTML fragment of the SVG element created
      */
     function _createSVGCode(link) {
-        let svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
-        svg.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
-        svg.setAttribute('height','105');
-        svg.setAttribute('width','345');
+        const img = $rootElement.find(`[src="${link}"]`)[0];
 
-        let svgimg = document.createElementNS('http://www.w3.org/2000/svg','image');
-        svgimg.setAttribute('height','105');
-        svgimg.setAttribute('width','345');
+        let svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+        svg.setAttribute('height', img.naturalHeight);
+        svg.setAttribute('width', img.naturalWidth);
+
+        let svgimg = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+        svgimg.setAttribute('height', img.naturalHeight);
+        svgimg.setAttribute('width', img.naturalWidth);
         svgimg.setAttributeNS('http://www.w3.org/1999/xlink','href', link);
 
         svg.appendChild(svgimg);

--- a/src/app/ui/export/export-legend.service.js
+++ b/src/app/ui/export/export-legend.service.js
@@ -419,22 +419,45 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                     items: extractLegendTree(entry)
                 }),
             [LegendBlock.TYPES.SET]: () => null,
-            [LegendBlock.TYPES.INFO]: () => null
+            [LegendBlock.TYPES.INFO]: entry =>
+                ({
+                    name: entry.layerName || entry.content,
+                    items: entry.symbologyStack.stack || [],
+                    blockType: LegendBlock.TYPES.INFO
+                })
         }
 
-        // TODO: decide if symbology from the controlled layers should be included in the export image
         // TODO: decide if symbology from the duplicated layer should be included in the export image
-        // TODO: decide if unbound layers and info sections should be included in the export image
         const legendTreeData = legendBlock
-            .walk(entry =>
-                entry.visibility && !entry.hidden && entry.opacity !== 0 &&               // opacity can be undefined or > 0
-                (entry.state === 'rv-refresh' || entry.state === 'rv-loaded') &&
-                (typeof entry.scale === 'undefined' || !entry.scale.offScale) ?           // scale only defined for nodes
+            .walk(entry => _showBlock(entry) ?
                     TYPE_TO_SYMBOLOGY[entry.blockType](entry) : null,
                 entry => entry.blockType === LegendBlock.TYPES.GROUP ? false : true)      // don't walk entry's children if it's a group
             .filter(a =>
                 a !== null);
+        return legendTreeData.filter(entry => entry.blockType === LegendBlock.TYPES.INFO || entry.items.length > 0);
+    }
 
-        return legendTreeData.filter(entry => entry.items.length > 0);
+    /**
+     * Identifies if legend block should be shown in export legend
+     *
+     * @function _showBlock
+     * @private
+     * @param {LegendBlock} entry the legend block to be checked whether it should be shown
+     * @return {Boolean} true if block should be shown in export legend
+     */
+    function _showBlock(entry) {
+        const showSymbology = configService.getSync.services.export.legend.showSymbology;
+
+        const visibility = entry.visibility && !entry.hidden && entry.opacity !== 0 &&      // opacity can be undefined or > 0
+            (entry.state === 'rv-refresh' || entry.state === 'rv-loaded') &&
+            (typeof entry.scale === 'undefined' || !entry.scale.offScale)                   // scale only defined for nodes
+
+        if (entry.blockType === LegendBlock.TYPES.INFO) {
+            return showSymbology
+        } else if (entry.controlled) {
+            return showSymbology && visibility;
+        }
+
+        return visibility;
     }
 }

--- a/src/app/ui/export/export-legend.service.js
+++ b/src/app/ui/export/export-legend.service.js
@@ -419,12 +419,22 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                     items: extractLegendTree(entry)
                 }),
             [LegendBlock.TYPES.SET]: () => null,
-            [LegendBlock.TYPES.INFO]: entry =>
-                ({
-                    name: entry.layerName || entry.content,
-                    items: entry.symbologyStack.stack || [],
-                    blockType: LegendBlock.TYPES.INFO
-                })
+            [LegendBlock.TYPES.INFO]: entry => {
+                if (entry.infoType === 'image') {
+                    const svgCode = _createSVGCode(entry.content);
+                    return {
+                        name: '',
+                        items: [{ name: '', svgcode: svgCode }],
+                        blockType: LegendBlock.TYPES.INFO
+                    }
+                } else {
+                    return {
+                        name: entry.layerName || entry.content,
+                        items: entry.symbologyStack.stack || [],
+                        blockType: LegendBlock.TYPES.INFO
+                    }
+                }
+            }
         }
 
         // TODO: decide if symbology from the duplicated layer should be included in the export image
@@ -446,18 +456,38 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
      * @return {Boolean} true if block should be shown in export legend
      */
     function _showBlock(entry) {
-        const showSymbology = configService.getSync.services.export.legend.showSymbology;
-
-        const visibility = entry.visibility && !entry.hidden && entry.opacity !== 0 &&      // opacity can be undefined or > 0
-            (entry.state === 'rv-refresh' || entry.state === 'rv-loaded') &&
-            (typeof entry.scale === 'undefined' || !entry.scale.offScale)                   // scale only defined for nodes
+        const showInfoAndControlledSymbology = configService.getSync.services.export.legend.showInfoAndControlledSymbology;
 
         if (entry.blockType === LegendBlock.TYPES.INFO) {
-            return showSymbology
+            return showInfoAndControlledSymbology
         } else if (entry.controlled) {
-            return showSymbology && visibility;
+            return showInfoAndControlledSymbology && entry.isVisibleOnExport;
         }
 
-        return visibility;
+        return entry.isVisibleOnExport;
+    }
+
+    /**
+     * Helper function to get HTML fragment of SVG element provided a URL
+     *
+     * @function _createSVGCode
+     * @private
+     * @param {String} link the link of an image
+     * @return {String} the HTML fragment of the SVG element created
+     */
+    function _createSVGCode(link) {
+        let svg = document.createElementNS('http://www.w3.org/2000/svg','svg');
+        svg.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+        svg.setAttribute('height','105');
+        svg.setAttribute('width','345');
+
+        let svgimg = document.createElementNS('http://www.w3.org/2000/svg','image');
+        svgimg.setAttribute('height','105');
+        svgimg.setAttribute('width','345');
+        svgimg.setAttributeNS('http://www.w3.org/1999/xlink','href', link);
+
+        svg.appendChild(svgimg);
+
+        return svg.outerHTML;
     }
 }

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -12,7 +12,7 @@ angular
     .factory('tocService', tocService);
 
 function tocService($q, $rootScope, $mdToast, $translate, referenceService, common, stateManager, graphicsService,
-    geoService, metadataService, errorService, LegendBlock, configService, legendService, layoutService) {
+    geoService, metadataService, errorService, LegendBlock, configService, legendService) {
 
     const service = {
         // method called by the options and flags set on the layer item
@@ -76,21 +76,7 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, comm
      * @param  {LegendBlock} legendBlock legend block to be remove from the layer selector
      */
     function removeLayer(legendBlock) {
-        let openPanelName;
-        let [resolve, reject] = legendService.removeLegendBlock(legendBlock);
-
-        // create notification toast
-        const toast = {
-            textContent: $translate.instant('toc.label.state.remove'),
-            action: $translate.instant('toc.label.action.remove'),
-            parent: layoutService.panes.toc,
-            position: 'bottom rv-flex'
-        };
-
-        // promise resolves with 'ok' when user clicks 'undo'
-        errorService.display(toast)
-            .then(response =>
-                response === 'ok' ? _restoreLegendBlock() : resolve());
+        let resolve, reject, openPanelName;
 
         // name mapping between true panel names and their short names
         const panelSwitch = {
@@ -412,7 +398,7 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, comm
 
                 errorToast = errorService.display({
                     textContent: $translate.instant('toc.error.resource.loadfailed'),
-                    parent: layoutService.panes.filter
+                    parent: referenceService.panes.filter
                 });
             });
     }
@@ -455,7 +441,7 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, comm
 
                 errorService.display({
                     textContent: $translate.instant('toc.error.resource.loadfailed'),
-                    parent: layoutService.panes.metadata
+                    parent: referenceService.panes.metadata
                 });
 
                 // display manager will stop the progress bar when datapromise is rejected

--- a/src/content/samples/config-mobile-2.json
+++ b/src/content/samples/config-mobile-2.json
@@ -37,7 +37,7 @@
     "exportMapUrl": "http://webservices.maps.canada.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
     "export": {
       "legend": {
-        "showSymbology": true
+        "showInfoAndControlledSymbology": true
       },
       "footnote": {
         "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."

--- a/src/content/samples/config-mobile-2.json
+++ b/src/content/samples/config-mobile-2.json
@@ -36,7 +36,9 @@
     "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
     "exportMapUrl": "http://webservices.maps.canada.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
     "export": {
-      "legend": {},
+      "legend": {
+        "showSymbology": true
+      },
       "footnote": {
         "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
       }

--- a/src/content/samples/config-mobile-2.json
+++ b/src/content/samples/config-mobile-2.json
@@ -37,7 +37,8 @@
     "exportMapUrl": "http://webservices.maps.canada.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
     "export": {
       "legend": {
-        "showInfoAndControlledSymbology": true
+        "showInfoSymbology": true,
+        "showControlledSymbology": true
       },
       "footnote": {
         "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."

--- a/src/content/samples/config/config-sample-01-structured-visibility-sets.json
+++ b/src/content/samples/config/config-sample-01-structured-visibility-sets.json
@@ -72,7 +72,8 @@
       },
       "overviewMap": {
         "enabled": true,
-        "layerType": "imagery"
+        "layerType": "imagery",
+        "initiallyExpanded": false
       },
       "scaleBar": {
         "enabled": true

--- a/src/content/samples/config/config-sample-47.json
+++ b/src/content/samples/config/config-sample-47.json
@@ -329,7 +329,7 @@
             "children": [
               {
                 "infoType": "text",
-                "content": "If a <abbr title='ESRI Dynamic Lyaer'>Dynamic layer</abbr> does not support children _opacity_ it is not a [not-true-dynamic Dynamic Layer](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2131#issuecomment-324723049), and all children will have their _opacity_ controls disabled and display a jump link to its parent unless it's single entry collapsed. \n\n #### Note \n\n Jump link should never point to group blocks not belonging to this layer record."
+                "content": "If a <abbr title='ESRI Dynamic Layer'>Dynamic layer</abbr> does not support children _opacity_ it is not a [not-true-dynamic Dynamic Layer](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2131#issuecomment-324723049), and all children will have their _opacity_ controls disabled and display a jump link to its parent unless it's single entry collapsed. \n\n #### Note \n\n Jump link should never point to group blocks not belonging to this layer record."
               },
               {
                 "infoType": "image",

--- a/src/content/samples/config/config-sample-47.json
+++ b/src/content/samples/config/config-sample-47.json
@@ -36,7 +36,7 @@
       "map": {},
       "mapElements": {},
       "legend":{
-        "showInfoAndControlledSymbology": true
+        "showInfoSymbology": true
       },
       "footnote": {
         "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."

--- a/src/content/samples/config/config-sample-47.json
+++ b/src/content/samples/config/config-sample-47.json
@@ -35,7 +35,9 @@
       },
       "map": {},
       "mapElements": {},
-      "legend":{},
+      "legend":{
+        "showInfoAndControlledSymbology": true
+      },
       "footnote": {
         "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
       }


### PR DESCRIPTION
## Description
Closes #2367 - added option to include info sections and controlled layers to export legend

Closes #2376 - added option to have overview map initially collapsed

Closes #2387 - notification toast restored

## Testing
Visually tested.

To test #2367 - `index-mobile` or `index-samples` Sample 47

To test #2376 - `index-samples` Sample 01

To test #2387 - Remove any layer from anywhere

## Documentation
JSDoc for `_showBlock` and `_createSVGCode`

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2389)
<!-- Reviewable:end -->
