### PR TITLE
fix(ui): tooltips are no longer linger after geoserach

### DIFF
--- a/src/content/styles/layout/_main.scss
+++ b/src/content/styles/layout/_main.scss
@@ -189,6 +189,11 @@ rv-panel[type='main'] {
         .rv-panel {
             background: transparent !important;
 
+            > * {
+                // without pointer events, newly generated or updated tooltips don't have a place to attach to and they end up attached to the edges of the parent container
+                pointer-events: all;
+            }
+
             &:after {
                 box-shadow: none !important;
             }

--- a/src/content/styles/modules/_geosearch.scss
+++ b/src/content/styles/modules/_geosearch.scss
@@ -50,7 +50,6 @@ $result-item-height-touch: rem(4.8);
         max-height: 100%;
 
         display: flex;
-        pointer-events: all;
 
         .rv-geosearch-content {
             background-color: white;


### PR DESCRIPTION
## Description
One of the most annoying bugs has fallen!

Tooltips are no longer getting stuck when using geo search and scale-dependent layers.

Closes #1760

## Testing
Visual.

## Documentation
Inline.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2391)
<!-- Reviewable:end -->
