### PR TITLE
2396 filtering by extent and loader modifications

### DIFF
--- a/src/app/ui/common/stepper/stepper.class.js
+++ b/src/app/ui/common/stepper/stepper.class.js
@@ -154,7 +154,7 @@ function StepperFactory($q) {
          * @param  {Number} stepNumber                step id to jump to
          * @param  {Promise} isMoveCanceled [optional = false] true if the move was cancelled
          */
-        _moveStep(stepNumber, isMoveCanceled = false, ) {
+        _moveStep(stepNumber, isMoveCanceled = false) {
             const currentStepNumber = this.currentStep._index;
 
             if (!isMoveCanceled) {

--- a/src/app/ui/common/stepper/stepper.class.js
+++ b/src/app/ui/common/stepper/stepper.class.js
@@ -156,8 +156,11 @@ function StepperFactory($q) {
                     this.currentStep = this.steps[stepNumber];
                     this._configureStep(this.currentStep, false, true);
                 }
-            })).finally(() =>
-                this._think(currentStep, false)); // in any outcome, restore `continue` button to default state
+            })).finally(() => {
+                if (!isMoveCanceled) {
+                    this._think(currentStep, false); // restore `continue` button to default state if move was not cancelled
+                }
+            });
 
             return this;
         }

--- a/src/app/ui/loader/loader-file.directive.js
+++ b/src/app/ui/loader/loader-file.directive.js
@@ -242,6 +242,11 @@ function Controller($scope, $q, $timeout, $http, stateManager, Stepper, LayerBlu
      */
     function uploadFilesSubmitted(files) {
         if (files.length > 0) {
+            // reset any fields and move back to the first step (in the case where we drag-and-drop from a different step)
+            // after moving back to the first step, we can continue with the file uploading
+            uploadReset();
+            stepper.moveToStep(0);
+
             const file = files[0];
             self.upload.file = file; // store the first file from the array;
 

--- a/src/app/ui/loader/loader-file.directive.js
+++ b/src/app/ui/loader/loader-file.directive.js
@@ -38,7 +38,7 @@ function Controller($scope, $q, $timeout, $http, stateManager, Stepper, LayerBlu
     self.closeLoaderFile = closeLoaderFile;
     self.dropActive = false; // flag to indicate if file drop zone is active
 
-    // create three steps: upload data, selecct data type, and configure layer
+    // create three steps: upload data, select data type, and configure layer
     self.upload = {
         step: {
             titleValue: 'import.file.upload.title',
@@ -178,19 +178,23 @@ function Controller($scope, $q, $timeout, $http, stateManager, Stepper, LayerBlu
             isFileUploadAborted = true;
         };
 
-        _loadFile(self.upload.fileUrl).then(arrayBuffer =>
-            isFileUploadAborted ?
-                $q.reject({ reason: 'abort', message: 'User canceled file upload.' }) :
-                onLayerBlueprintReady(self.upload.fileUrl, arrayBuffer).then(() => (self.upload.httpProgress = false))
-        ).catch(error => {
-            if (error.reason === 'abort') {
-                RV.logger.log('loaderFileDirective', 'file upload has been aborted by the user', error.message);
-                return;
-            }
+        const loaderPromise = _loadFile(self.upload.fileUrl).then(arrayBuffer =>
+                isFileUploadAborted ?
+                    $q.reject({ reason: 'abort', message: 'User canceled file upload.' }) :
+                    onLayerBlueprintReady(self.upload.fileUrl, arrayBuffer).then(() => (self.upload.httpProgress = false))
+            ).catch(error => {
+                if (error.reason === 'abort') {
+                    RV.logger.log('loaderFileDirective', 'file upload has been aborted by the user', error.message);
+                    return;
+                }
 
-            RV.logger.error('loaderFileDirective', 'problem retrieving file link with error', error.message);
-            toggleErrorMessage(self.upload.form, 'fileUrl', 'upload-error', false);
-        });
+                RV.logger.error('loaderFileDirective', 'problem retrieving file link with error', error.message);
+                toggleErrorMessage(self.upload.form, 'fileUrl', 'upload-error', false);
+            });
+
+        // add some delay before going to the next step
+        stepper.nextStep($timeout(() =>
+            loaderPromise, 300));
 
         /**
          * Tries to load a file specified using $http service.
@@ -208,7 +212,7 @@ function Controller($scope, $q, $timeout, $http, stateManager, Stepper, LayerBlu
                             const units = event.loaded < 1048576 ? 'KB' : 'MB';
 
                             let loaded = Math.round(event.loaded / (units === 'KB' ? 1024 : 1048576));
-                            const total = Math.round(event.total / 1048576);
+                            const total = Math.ceil(event.total / 1048576);
 
                             self.upload.fileStatus = `${loaded}${units} / ${total}MB`;
 
@@ -248,17 +252,22 @@ function Controller($scope, $q, $timeout, $http, stateManager, Stepper, LayerBlu
             self.upload.fileUploadAbort = () =>
                 reader.abort();
 
-            _readFile(reader, file.file, _updateProgress).then(arrayBuffer =>
-                onLayerBlueprintReady(file.name, arrayBuffer)
-            ).catch(error => {
-                if (error.reason === 'abort') {
-                    RV.logger.log('loaderFileDirective', 'file upload has been aborted by the user', error.message);
-                    return;
-                }
+            const readerPromise = _readFile(reader, file.file, _updateProgress).then(arrayBuffer =>
+                    onLayerBlueprintReady(file.name, arrayBuffer)
+                ).catch(error => {
+                    if (error.reason === 'abort') {
+                        RV.logger.log('loaderFileDirective', 'file upload has been aborted by the user', error.message);
+                        return;
+                    }
 
-                RV.logger.error('loaderFileDirective', 'file upload has failed with error', error.message);
-                toggleErrorMessage(self.upload.form, 'fileSelect', 'upload-error', false);
-            });
+                    RV.logger.error('loaderFileDirective', 'file upload has failed with error', error.message);
+                    toggleErrorMessage(self.upload.form, 'fileSelect', 'upload-error', false);
+                });
+
+            // add some delay before going to the next step
+            // explicitly move to step 1 (select); if the current step is not 0 (upload), drag-dropping a file may advance farther than needed when using just `stepper.nextStep()`
+            stepper.moveToStep(1, $timeout(() =>
+                readerPromise, 300));
         }
 
         /**
@@ -326,11 +335,6 @@ function Controller($scope, $q, $timeout, $http, stateManager, Stepper, LayerBlu
                 self.layerSourceOptions = layerSourceOptions;
                 self.layerSource = layerSourceOptions[preselectedIndex];
             });
-
-        // add some delay before going to the next step
-        // explicitly move to step 1 (select); if the current step is not 0 (upload), drag-dropping a file may advance farther than needed when using just `stepper.nextStep()`
-        stepper.moveToStep(1, $timeout(() =>
-            layerSourcePromise, 300));
 
         return layerSourcePromise;
     }

--- a/src/app/ui/loader/loader-service.directive.js
+++ b/src/app/ui/loader/loader-service.directive.js
@@ -59,7 +59,10 @@ function Controller($q, $timeout, stateManager, geoService, Geo, Stepper, LayerB
             isActive: false,
             isCompleted: false,
             onContinue: connectOnContinue,
-            onCancel: () => onCancel(self.connect.step),
+            onCancel: () => {
+                connectReset();
+                onCancel(self.connect.step);
+            },
             onKeypress: event => {
                 const connect = self.connect;
                 // prevent enter presses from triggering service handshake if the input value is not validated
@@ -153,13 +156,8 @@ function Controller($q, $timeout, stateManager, geoService, Geo, Stepper, LayerB
     function onCancel(step) {
         if (step.isThinking) {
             stepper.cancelMove();
-            stepper.currentStep.reset();
         } else {
             stepper.previousStep(); // going to the previous step will auto-reset the current one (even if there is no previous step to go to)
-
-            if (stepper.currentStep.stepNumber !== 1) {
-                stepper.previousStep().reset();
-            }
         }
     }
 

--- a/src/app/ui/loader/loader-service.directive.js
+++ b/src/app/ui/loader/loader-service.directive.js
@@ -153,8 +153,13 @@ function Controller($q, $timeout, stateManager, geoService, Geo, Stepper, LayerB
     function onCancel(step) {
         if (step.isThinking) {
             stepper.cancelMove();
+            stepper.currentStep.reset();
         } else {
             stepper.previousStep(); // going to the previous step will auto-reset the current one (even if there is no previous step to go to)
+
+            if (stepper.currentStep.stepNumber !== 1) {
+                stepper.previousStep().reset();
+            }
         }
     }
 

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -614,7 +614,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
      * @private
      */
     function onExtentChange() {
-        if (!service.filter.isActive) { // no DataTable is active - ignore
+        if (!service.filter.isActive || !stateManager.display.table.requester) { // filter by extent disabled or no DataTable is active - ignore
             return;
         }
 
@@ -666,7 +666,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
      */
     function queryMapserver(lastOID = 0) {
         const state = stateManager.display.table;
-        const legEntry =state.requester.legendEntry;
+        const legEntry = state.requester.legendEntry;
         const layerRecId = layerRegistry.getLayerRecord(legEntry.layerRecordId);
 
         const queryOpts = {
@@ -675,10 +675,10 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         };
 
         // query the layer itself instead of making a mapserver request
-        if (legEntry.parentLayerType === 'esriFeature' && legEntry.layerType === 'esriFeature') {
-            queryOpts.featureLayer = layerRecId._layer;
+        if (legEntry.parentLayerType === 'esriFeature' && legEntry.layerType === 'esriFeature' && layerRecId.isFileLayer()) {
+            queryOpts.featureLayer = layerRecId._layer;         // file based layer
         } else {
-            queryOpts.url = legEntry.mainProxy.queryUrl;
+            queryOpts.url = legEntry.mainProxy.queryUrl;        // server based layer
         }
 
         // only include oidField values after previous mapserver query resulted in a exceededTransferLimit exception


### PR DESCRIPTION
## Description
Closes #2396

Also made changes to the loader functionality;
- when importing a file, if you drag and drop on any step, it'll reset to first step and then continue the upload
- when importing a service, cancelling on the first step will clear the field

Fixed small undocumented bug when filtering by extent and table is not open (`table.service`)

## Testing
Visually tested

Sample 1 can be used to test #2396 (and the loader too)

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2403)
<!-- Reviewable:end -->
