### PR TITLE
2404 clear filters and 2406 reopen panel on reload

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -817,7 +817,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
                 proxyPromise = common.$q.resolve([proxyWrapper]);
             }
 
-            return proxyPromise;        //
+            return proxyPromise;
 
             function _flattenTree(tree) {
                 const result = [].concat.apply([], tree.map(item => {

--- a/src/app/ui/table/table-default.directive.js
+++ b/src/app/ui/table/table-default.directive.js
@@ -472,23 +472,23 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
                     displayData.filter.globalSearch = config.search.enabled ? config.search.value || '' : '';
                 }
 
+                const filters = stateManager.display.table;
+                const query = filters.requester.legendEntry.mainProxyWrapper.layerConfig.initialFilteredQuery;
+
                 // apply filters on map
                 if (config.applyMap) {
-                    const filters = stateManager.display.table;
-                    const query = filters.requester.legendEntry.mainProxyWrapper.layerConfig.initialFilteredQuery;
-
                     // set isApplied to hide apply filters on map button
                     tableService.filter.isApplied = true;
                     filters.data.filter.isApplied = tableService.filter.isApplied;  // set on layer so it can persist when we change layer
 
-                    // update filter flag ( if data is filtered)
-                    tableService.filter.isMapFiltered = query !== "";
-                    filters.data.filter.isMapFiltered = tableService.filter.isMapFiltered;  // set on layer so it can persist when we change layer
-                    filters.requester.legendEntry.filter = tableService.filter.isMapFiltered;
-
                     // prevent entering to this block again
                     config.applyMap = false;
                 }
+
+                // update filter flag (if data is filtered)
+                tableService.filter.isMapFiltered = query ? query !== "" : false;
+                filters.data.filter.isMapFiltered = tableService.filter.isMapFiltered;  // set on layer so it can persist when we change layer
+                filters.requester.legendEntry.filter = tableService.filter.isMapFiltered;
             }
 
             /**

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -134,7 +134,7 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, comm
                         (node.parentLayerType ===  Geo.Layer.Types.ESRI_DYNAMIC ? entry.blockConfig.entryIndex === node.blockConfig.entryIndex :
                         entry.layerRecordId === node.layerRecordId) ?
                             entry : null)
-                    .filter(a => a)[0];
+                    .filter(a => a && a._isDynamicRoot === node._isDynamicRoot)[0]; // filter out hidden dynamic root if any
 
                 // update the requester accordingly for the reloaded legend block
                 openPanel.requester.id = legendBlock.id;


### PR DESCRIPTION
## Description
Closes #2404 - clearing filters functionality fixed

Closes #2406 - panel is reopened if it is connected to the layer being reloaded. Otherwise, it's closed

## Testing
Visually tested.

Any sample can be used to test. For #2406, you can use [this](http://section917.cloudapp.net/arcgis/rest/services/TestData/Nest/MapServer/0) service for dynamic groups.

## Documentation
Lots of comments added, some JSDoc changed

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2408)
<!-- Reviewable:end -->
