### PR TITLE
feat(ui): remove feature highligh on click

### DIFF
--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -65,7 +65,8 @@ function events($rootScope) {
         rvBasemapChange: 'rvBasemapChange', // Fired when basemap is changed
         rvHighlightDetailsItem: 'rvHighlightDetailsItem',
         rvGeosearchClose: 'rvGeosearchClose', // Fire when geosearch close
-        rvTableReady: 'rvTableReady'
+        rvTableReady: 'rvTableReady',
+        rvFeatureMouseOver: 'rvFeatureMouseOver'
     };
 }
 

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -425,6 +425,7 @@ function layerRegistryFactory($rootScope, $timeout, $filter, events, gapiService
             // for tooltips that are no longer active.
             const typeMap = {
                 mouseOver: e => {
+                    events.$broadcast(events.rvFeatureMouseOver, true);
 
                     // make the content and display the hovertip
                     tipContent = {
@@ -444,9 +445,10 @@ function layerRegistryFactory($rootScope, $timeout, $filter, events, gapiService
                     }
                     tooltipService.refreshHoverTooltip();
                 },
-                mouseOut: e =>
-                    tooltipService.removeHoverTooltip()
-                ,
+                mouseOut: e => {
+                    events.$broadcast(events.rvFeatureMouseOver, false);
+                    tooltipService.removeHoverTooltip();
+                },
                 // TODO: reattach this
                 forceClose: () => {
                     // if there is a hovertip, get rid of it


### PR DESCRIPTION
## Description
When a feature is highlighted, the next click will clear the highlight/haze without triggering identify, unless you click directly on another feature, in that case, the identify will trigger right away.

Relates #2395

## Testing
:eyes: 

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2413)
<!-- Reviewable:end -->
