### PR TITLE
Ability to toggle ranges via legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.1.0-19",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.1.0-20",
     "gsap": "1.20.2",
     "jquery": "2.2.4",
     "jquery-hoverintent": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#develop",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.1.0-20",
     "gsap": "1.20.2",
     "jquery": "2.2.4",
     "jquery-hoverintent": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.1.0-20",
+    "geoApi": "github:fgpv-vpgf/geoApi#develop",
     "gsap": "1.20.2",
     "jquery": "2.2.4",
     "jquery-hoverintent": "1.8.2",

--- a/schema.json
+++ b/schema.json
@@ -529,6 +529,7 @@
                 "name": { "type": "string", "description": "The display name of the layer.  If it is not present the viewer will make an attempt to scrape this information." },
                 "url": { "type": "string", "description": "The service endpoint of the layer.  It should match the type provided in layerType." },
                 "layerType": { "type": "string", "enum": [ "esriDynamic", "esriFeature", "esriImage", "esriTile", "ogcWms" ] },
+                "toggleSymbology": { "type": "boolean", "default": true, "description": "Allows individual symbols to have visibility toggled on/off."},
                 "extent": { "$ref": "#/definitions/extentWithReferenceNode" }
             },
             "required": [ "id", "layerType", "url" ]
@@ -560,6 +561,7 @@
                 "metadataUrl": { "type": "string", "default": null, "description": "The metadata url of the layer service" },
                 "catalogueUrl": { "type": "string", "default": null, "description": "The catalogue url of the layer service" },
                 "layerType": { "type": "string", "enum": [ "esriFeature" ] },
+                "toggleSymbology": { "type": "boolean", "default": true, "description": "Allows individual symbols to have visibility toggled on/off."},
                 "tolerance": { "type": "number", "default": 5, "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer" },
                 "extent": { "$ref": "#/definitions/extentWithReferenceNode" },
                 "controls": { "$ref": "#/definitions/legendEntryControls" },
@@ -603,6 +605,7 @@
                 "metadataUrl": { "type": "string", "default": null, "description": "The metadata url of the layer service" },
                 "catalogueUrl": { "type": "string", "default": null, "description": "The catalogue url of the layer service" },
                 "layerType": { "type": "string", "enum": [ "esriDynamic" ] },
+                "toggleSymbology": { "type": "boolean", "default": true, "description": "Allows individual symbols to have visibility toggled on/off."},
                 "singleEntryCollapse": { "type": "boolean", "default": false, "description": "Indicates that the dynamic layer with a single layer entry should be rendered without the root group." },
                 "layerEntries": {
                     "type": "array",

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -547,6 +547,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
             this._disabledControls = defaultedSource.disabledControls;
             this._userDisabledControls = defaultedSource.userDisabledControls;
             this._initialFilteredQuery = defaultedSource.initialFilteredQuery;
+            this._toggleSymbology = typeof source.toggleSymbology === 'boolean' ? source.toggleSymbology : true;
 
             // remove metadata control if no metadata url is specified after applying defaults
             if (!source.metadataUrl) {
@@ -569,6 +570,7 @@ function ConfigObjectFactory(Geo, gapiService, common) {
 
         get initialFilteredQuery() { return this._initialFilteredQuery; }
         set initialFilteredQuery(value) { this._initialFilteredQuery = value; }
+        get toggleSymbology() { return this._toggleSymbology; }
 
         _hovertipEnabled = false;
         get hovertipEnabled () {        return this._hovertipEnabled; }

--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -66,7 +66,9 @@ function events($rootScope) {
         rvHighlightDetailsItem: 'rvHighlightDetailsItem',
         rvGeosearchClose: 'rvGeosearchClose', // Fire when geosearch close
         rvTableReady: 'rvTableReady',
-        rvFeatureMouseOver: 'rvFeatureMouseOver'
+        rvFeatureMouseOver: 'rvFeatureMouseOver',
+
+        rvLayerDefinitionClauseChanged: 'rvLayerDefinitionClauseChanged'
     };
 }
 

--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -20,7 +20,7 @@ const focusSelector = [
     'md-switch:not([disabled])',
     'md-slider:not([disabled])',
     'textarea:not([disabled])',
-    'button:not([disabled])',
+    'button:not([disabled]):not([nofocus])',
     '.rv-esri-map',
     '[tabindex=-2]',
     '[tabindex=-3]'
@@ -331,7 +331,8 @@ function elemIsFocusable(index, element) {
         el.css('opacity') !== 0 &&
         // avoid setting focus on closing menu items
         !el.parents().hasClass('md-leave') &&
-        !el.parents().hasClass('md-leave-add');
+        !el.parents().hasClass('md-leave-add') &&
+        !el.is('[nofocus]');
 }
 
 /**

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -91,7 +91,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
      */
     function init() {
 
-        events.$on('definitionClauseChgd', () => {
+        events.$on(events.rvLayerDefinitionClauseChanged, () => {
             if (filterTimeStamps.onCreated !== null) {
                 filteredState().then(() => {
                     filterTimeStamps.onChanged = Date.now();

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -653,7 +653,8 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
 
         // we're not filtering by either symbology or extent, so resolve with all oid's as valid
         if (!service.filter.isActive && typeof layerRecId.definitionClause !== 'string') {
-            return $q.resolve(stateManager.display.table.data.rows.map(row => parseInt(row[stateManager.display.table.data.oidField])));
+            validOIDs = stateManager.display.table.data.rows.map(row => parseInt(row[stateManager.display.table.data.oidField]));
+            return $q.resolve();
         }
 
         return queryMapserver().then(oids => (validOIDs = oids));

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -51,7 +51,7 @@ angular
     .directive('rvSymbologyStack', rvSymbologyStack)
     .factory('SymbologyStack', symbologyStack);
 
-function rvSymbologyStack($q, Geo, animationService) {
+function rvSymbologyStack($q, Geo, animationService, layerRegistry) {
     const directive = {
         require: '^?rvTocEntry', // need access to layerItem to get its element reference
         restrict: 'E',
@@ -91,23 +91,26 @@ function rvSymbologyStack($q, Geo, animationService) {
         // stores instances of ToggleSymbol as key value pairs (with symbol name as the key)
         self.toggleList = {};
         // triggered when the user clicks on a checkbox in the symbology stack
+
+        const layerRecord = layerRegistry.getLayerRecord(self.block.layerRecordId);
+        console.error('A layer record', layerRecord);
+        console.error('A legend block', self.block);
         self.onToggleClick = name => {
             self.toggleList[name].click();
-
             self.block.visibility = atLeastOneSymbolVisible();
 
-            console.error(self.block);
             self.block.definitionQuery = Object.keys(self.toggleList)
                 .map(key => self.toggleList[key].query)
                 .filter(q => q !== null)
                 .join(' OR ');
         };
-        // create a ToggleSymbol instance for each symbol
-        self.symbology.stack.forEach(s => {
-            if (s.name && self.block.mainProxyWrapper) {
+
+        if (layerRecord.config.toggleSymbology) {
+            // create a ToggleSymbol instance for each symbol
+            self.symbology.stack.forEach(s => {
                 self.toggleList[s.name] = new ToggleSymbol(self.block, s.name);
-            }
-        });
+            });
+        }
 
         //const proxy = layerRecord.getChildProxy(currentSubLayer.index);
         //proxy.setDefinitionQuery(currentSubLayer.initialFilteredQuery);

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -79,6 +79,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
         // if render style is not specified, symbology stack will not be interactive
         // self.isInteractive = typeof self.symbology.renderStyle !== 'undefined';
         self.isExpanded = false; // holds the state of symbology section
+        self.showSymbologyToggle = false;
 
         self.expandSymbology = expandSymbology;
         self.fanOutSymbology = fanOutSymbology;
@@ -160,6 +161,14 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             maxItemWidth: 350
         };
 
+        scope.$watch('self.showSymbologyToggle', value => {
+            if (value) {
+                element.find('.md-icon-button').addClass('show');
+            } else {
+                element.find('.md-icon-button').removeClass('show');
+            }
+        });
+
         // description persist, so need to store reference only once
         ref.descriptionItem = element.find(RV_DESCRIPTION_ITEM);
         ref.descriptionItem.css('width', ref.containerWidth)
@@ -183,7 +192,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
 
                     // Manually correct symbology boxes so they align with all other layer visibility boxes
                     const symbolButtonOffset = parseInt(element.closest('rv-legend-block').css('padding-left')) - 28;
-                    element.find('.md-icon-button').css({'position': 'absolute', 'right': `${symbolButtonOffset}px`});
+                    element.find('.md-icon-button').not('.rv-symbol-trigger').css({'position': 'absolute', 'right': `${symbolButtonOffset}px`});
                 }
             }
         });
@@ -215,6 +224,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             } else {
                 // collapse symbology items and forward play wiggle
                 ref.expandTimeline.reverse();
+                self.showSymbologyToggle = false;
                 ref.fanOutTimeline.play();
             }
 
@@ -283,10 +293,6 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                 ref.containerWidth
             );
 
-            // set label width to maximum which was calculated
-            ref.symbolItems.forEach(symbolItem =>
-                symbolItem.label.css('width', ref.maxItemWidth));
-
             // console.log('ref.maxItemWidth', ref.maxItemWidth);
 
             ref.expandTimeline = makeExpandTimeline();
@@ -299,6 +305,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             const timeline = animationService.timeLineLite({
                 paused: true,
                 onStart: () => { self.isExpanded = true; scope.$digest(); },
+                onComplete: () => { self.showSymbologyToggle = true; scope.$digest(); },
                 onReverseComplete: () => { self.isExpanded = false; scope.$digest(); }
             });
 

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -82,11 +82,20 @@ function rvSymbologyStack($q, Geo, animationService) {
         self.expandSymbology = expandSymbology;
         self.fanOutSymbology = fanOutSymbology;
 
+        function atLeastOneSymbolVisible() {
+            return Object.keys(self.toggleList)
+                .filter(key => self.toggleList[key].isSelected)
+                .length > 0;
+        }
+
         // stores instances of ToggleSymbol as key value pairs (with symbol name as the key)
         self.toggleList = {};
         // triggered when the user clicks on a checkbox in the symbology stack
         self.onToggleClick = name => {
             self.toggleList[name].click();
+
+            self.block.visibility = atLeastOneSymbolVisible();
+
             console.error(self.block);
             self.block.definitionQuery = Object.keys(self.toggleList)
                 .map(key => self.toggleList[key].query)
@@ -99,7 +108,7 @@ function rvSymbologyStack($q, Geo, animationService) {
                 self.toggleList[s.name] = new ToggleSymbol(self.block, s.name);
             }
         });
-        
+
         //const proxy = layerRecord.getChildProxy(currentSubLayer.index);
         //proxy.setDefinitionQuery(currentSubLayer.initialFilteredQuery);
 

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -66,6 +66,13 @@ function rvSymbologyStack($q, Geo, animationService) {
         self.expandSymbology = expandSymbology;
         self.fanOutSymbology = fanOutSymbology;
 
+        // see stateManager.display.table.requester.legendEntry.definitionQuery = OBJECTID >= 1 AND OBJECTID <= 2
+        self.toggleSymbology = {
+            isSelected: false,
+            onClick: () => {this.isSelected = !this.isSelected},
+            icon: () => this.isSelected ? "toggle:check_box" : "toggle:check_box_outline_blank"
+        };
+
         const ref = {
             isReady: false,
 

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -164,8 +164,11 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
         scope.$watch('self.showSymbologyToggle', value => {
             if (value) {
                 element.find('.md-icon-button').addClass('show');
+                $.link(element.find('.md-icon-button'));
+                element.find('button').not('.rv-symbol-trigger').removeAttr('nofocus');
             } else {
                 element.find('.md-icon-button').removeClass('show');
+                element.find('button').not('.rv-symbol-trigger').attr('nofocus', true);
             }
         });
 
@@ -349,7 +352,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             };
 
             // loop over ref.symbolItems, generate timeline for each one, increase total height
-            ref.symbolItems.reverse().forEach((symbolItem, index) => {
+            ref.symbolItems.forEach((symbolItem, index) => {
                 const heightIncrease = legendItemTLgenerator[self.symbology.renderStyle](timeline, symbolItem, totalHeight,
                     index === ref.symbolItems.length - 1);
 

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -187,15 +187,18 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
 
                 // A layer can have `toggleSymbology` set to false in the config, in which case we don't create checkboxes.
                 if (layerRecord.config.toggleSymbology && self.symbology.stack.length > 1) {
+                    const drawPromises = self.symbology.stack.map(s => s.drawPromise);
 
-                    // create a ToggleSymbol instance for each symbol
-                    self.symbology.stack.forEach(s => {
-                        self.toggleList[s.name] = new ToggleSymbol(s);
+                    $q.all(drawPromises).then(() => {
+                        // create a ToggleSymbol instance for each symbol
+                        self.symbology.stack.forEach(s => {
+                            self.toggleList[s.name] = new ToggleSymbol(s);
+                        });
+
+                        // Manually correct symbology boxes so they align with all other layer visibility boxes
+                        const symbolButtonOffset = parseInt(element.closest('rv-legend-block').css('padding-left')) - 28;
+                        element.find('.md-icon-button').not('.rv-symbol-trigger').css({'position': 'absolute', 'right': `${symbolButtonOffset}px`});
                     });
-
-                    // Manually correct symbology boxes so they align with all other layer visibility boxes
-                    const symbolButtonOffset = parseInt(element.closest('rv-legend-block').css('padding-left')) - 28;
-                    element.find('.md-icon-button').not('.rv-symbol-trigger').css({'position': 'absolute', 'right': `${symbolButtonOffset}px`});
                 }
             }
         });

--- a/src/app/ui/toc/templates/legend-info.html
+++ b/src/app/ui/toc/templates/legend-info.html
@@ -10,6 +10,7 @@
         <rv-symbology-stack
             description="self.block.description"
             symbology="self.block.symbologyStack"
+            block="self.block"
             container="self.element"></rv-symbology-stack>
 
         <md-tooltip md-delay="self.getTooltipDelay()" md-direction="{{ self.getTooltipDirection() }}">{{ self.block.layerName }}</md-tooltip>

--- a/src/app/ui/toc/templates/legend-node.html
+++ b/src/app/ui/toc/templates/legend-node.html
@@ -11,6 +11,7 @@
 <rv-symbology-stack
     description="self.block.description"
     symbology="self.block.symbologyStack"
+    block="self.block"
     container="self.element"></rv-symbology-stack>
 
 <div class="rv-list-item-content">

--- a/src/app/ui/toc/templates/symbology-stack.html
+++ b/src/app/ui/toc/templates/symbology-stack.html
@@ -11,6 +11,17 @@
         <div class="rv-symbol-label-container">
             <span class="rv-symbol-label">{{ symbol.name }}</span>
         </div>
+        
+        <md-button
+            class="md-icon-button rv-icon-20"
+            ng-class="{ selected: self.uiControl.isSelected }"
+            ng-click="self.toggleSymbology.onClick()"
+            ng-show="self.isExpanded">
+        
+            <md-icon md-svg-src="{{self.toggleSymbology.icon()}}"></md-icon>
+    
+        </md-button>
+
     </div>
 
     <md-button

--- a/src/app/ui/toc/templates/symbology-stack.html
+++ b/src/app/ui/toc/templates/symbology-stack.html
@@ -14,8 +14,7 @@
 
         <md-button
             class="md-icon-button rv-icon-20"
-            ng-click="self.onToggleClick(symbol.name)"
-            ng-show="self.isExpanded">
+            ng-click="self.onToggleClick(symbol.name)">
 
             <md-icon md-svg-src="{{self.toggleList[symbol.name].icon}}"></md-icon>
 

--- a/src/app/ui/toc/templates/symbology-stack.html
+++ b/src/app/ui/toc/templates/symbology-stack.html
@@ -11,14 +11,14 @@
         <div class="rv-symbol-label-container">
             <span class="rv-symbol-label">{{ symbol.name }}</span>
         </div>
-        
+
         <md-button
             class="md-icon-button rv-icon-20"
             ng-click="self.onToggleClick(symbol.name)"
             ng-show="self.isExpanded">
-        
+
             <md-icon md-svg-src="{{self.toggleList[symbol.name].icon}}"></md-icon>
-    
+
         </md-button>
 
     </div>

--- a/src/app/ui/toc/templates/symbology-stack.html
+++ b/src/app/ui/toc/templates/symbology-stack.html
@@ -14,11 +14,10 @@
         
         <md-button
             class="md-icon-button rv-icon-20"
-            ng-class="{ selected: self.uiControl.isSelected }"
-            ng-click="self.toggleSymbology.onClick()"
+            ng-click="self.onToggleClick(symbol.name)"
             ng-show="self.isExpanded">
         
-            <md-icon md-svg-src="{{self.toggleSymbology.icon()}}"></md-icon>
+            <md-icon md-svg-src="{{self.toggleList[symbol.name].icon}}"></md-icon>
     
         </md-button>
 

--- a/src/app/ui/toc/templates/symbology-stack.html
+++ b/src/app/ui/toc/templates/symbology-stack.html
@@ -6,7 +6,7 @@
         <span class="rv-description">{{ ::self.description }}</span>
     </div>
 
-    <div class="rv-symbol" ng-repeat="symbol in self.symbology.stack | rvReverse">
+    <div class="rv-symbol" ng-repeat="symbol in self.symbology.stack" ng-style="{'z-index': 100 + self.symbology.stack.length - $index }">
         <rv-svg class="rv-symbol-graphic" src="symbol.svgcode"></rv-svg>
         <div class="rv-symbol-label-container">
             <span class="rv-symbol-label">{{ symbol.name }}</span>
@@ -23,6 +23,7 @@
     </div>
 
     <md-button
+        ng-style="{'z-index': 100 + self.symbology.stack.length + 1 }"
         class="rv-symbol-trigger rv-button-32 rv-icon-24 md-icon-button"
         ng-if="self.symbology.isInteractive"
         ng-click="self.expandSymbology()"

--- a/src/content/styles/modules/_symbology.scss
+++ b/src/content/styles/modules/_symbology.scss
@@ -12,6 +12,10 @@
         position: relative;
         z-index: 0; // set up new stacking context
 
+        .md-button.md-icon-button {
+            margin: 0 5px;
+        }
+
         .rv-description-container {
             display: none;
             opacity: 0;

--- a/src/content/styles/modules/_symbology.scss
+++ b/src/content/styles/modules/_symbology.scss
@@ -36,6 +36,15 @@
             overflow: hidden;
             box-shadow: $icon-shadow;
 
+            > .md-icon-button {
+                opacity: 0;
+                transition: opacity $swift-ease-in-duration $swift-ease-in-out-timing-function;
+
+                &.show {
+                    opacity: 1;
+                }
+            }
+
             .rv-symbol-graphic {
                 flex-shrink: 0;
                 background-color: white;
@@ -55,6 +64,7 @@
 
                 // symbology label
                 span {
+                    width: calc(100% - 40px);
                     display: none;
                     opacity: 0;
                     font-size: 14px;
@@ -107,7 +117,7 @@
             // button which opens symbology section
             // transition: opacity $swift-ease-in-duration $swift-ease-in-out-timing-function;
             opacity: 0;
-            margin: 0;
+            margin: 0 !important;
         }
 
         // renders symbology as a list of icon-name pairs when expanded; symbol items remain 32x32 regardless of their actual size

--- a/src/content/styles/modules/_symbology.scss
+++ b/src/content/styles/modules/_symbology.scss
@@ -91,14 +91,33 @@
             visibility: hidden;
 
             // the following arranges the first three items in a visible stack
-            &:nth-of-type(2) {
+            /* &:nth-of-type(2) {
                 top: 3px;
                 left: 3px;
                 opacity: 1;
                 visibility: visible;
             }
-
             &:nth-of-type(3) {
+                top: 1px;
+                left: 1px;
+                opacity: 1;
+                visibility: visible;
+            }
+            &:last-of-type {
+                top: -1px;
+                left: -1px;
+                opacity: 1;
+                visibility: visible;
+            } */
+
+            &:nth-of-type(2) {
+                top: -1px;
+                left: -1px;
+                opacity: 1;
+                visibility: visible;
+            }
+
+            &:nth-last-of-type(2) {
                 top: 1px;
                 left: 1px;
                 opacity: 1;
@@ -106,8 +125,8 @@
             }
 
             &:last-of-type {
-                top: -1px;
-                left: -1px;
+                top: 3px;
+                left: 3px;
                 opacity: 1;
                 visibility: visible;
             }

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -215,11 +215,13 @@ Table of Content data filter flag tootlip,toc.tooltip.flag.data.filter,Layer dat
 Table of Content query flag label,toc.label.flag.query,Layer will be excluded from map click results,1,La couche sera exclue de la carte - cliquer sur les résultats,1
 Table of Content query flag tootlip,toc.tooltip.flag.query,Layer will be excluded from map click results,1,La couche sera exclue de la carte - cliquer sur les résultats,1
 Table of Content user flag label,toc.label.flag.user,Layer added by user,1,Couche ajoutée par l'utilisateur,1
-Table of Content filter by extent flag label,toc.label.flag.filter,Some features are hidden by filters,1,Certaines fonctionnalités sont cachées par des filtres,0
+Table of Content filter by extent flag label,toc.label.flag.filter,Some features are hidden by table filters,1,
+Certaines fonctionnalités sont masquées par des filtres de table,0
 Table of Content user flag tootlip,toc.tooltip.flag.user,Layer added by user,1,Couche ajoutée par l'utilisateur,1
 Table of Content filter by extent flag label,toc.label.flag.wrongprojection,Layer cannot be displayed in your current projection,1,Le calque ne peut pas être affiché dans votre projection actuelle et/ou les filtres,1
 Table of Content user flag tootlip,toc.tooltip.flag.wrongprojection,Current projection not supported,1,Projection actuelle non prise en charge,1
-Table of Content filter by extent flag tootlip,toc.tooltip.flag.filter,Some features are hidden by filters,1,Certaines fonctionnalités sont cachées par des filtres,0
+Table of Content filter by extent flag tootlip,toc.tooltip.flag.filter,Some features are hidden by table filters,1,
+Certaines fonctionnalités sont masquées par des filtres de table,0
 Table of Content error state label,toc.label.state.error,Error,1,Erreur,1
 Table of Content error state tootlip,toc.tooltip.state.error,Error,1,Erreur,1
 Table of Content loading state label,toc.label.state.loading,Updating,1,Mise à jour,1


### PR DESCRIPTION
## Description
Allows symbology to be toggled. New controls added when symbology is expanded. Symbology is filtered both on the map and table (if open).

Can be disabled in config under layer config as `toggleSymbology: false`. It's true by default.

Do not merge until James gives the :white_check_mark: since geoApi is being beefed up to handle more edge cases on the `definitionClause`.

@dan-bowerman got you on this as well to make sure this works for CESI.

Closes #2368

## Testing
46 `Dynamic Layer with only one child with filter -> Power Plants".  You can also test sample 1 crops but dt is very slow.

## Documentation
inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2418)
<!-- Reviewable:end -->
