### PR TITLE
WMS Layer Styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.1.0-17",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.1.0-19",
     "gsap": "1.20.2",
     "jquery": "2.2.4",
     "jquery-hoverintent": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "1.2.2",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.1.0-15",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.1.0-17",
     "gsap": "1.20.2",
     "jquery": "2.2.4",
     "jquery-hoverintent": "1.8.2",

--- a/schema.json
+++ b/schema.json
@@ -270,7 +270,11 @@
             "properties": {
                 "id": { "type": "string", "description": "The id of the layer entry in the WMS" },
                 "name": { "type": "string", "description": "A descriptive name for the layer.  To be used in the legend." },
-                "allStyles": { "type": "array", "description": "All the styles for the layer entry in the WMS" },
+                "allStyles": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "All the styles for the layer entry in the WMS"
+                },
                 "currentStyle": { "type": "string", "description": "The current style for the layer entry in the WMS" },
                 "controls": { "$ref": "#/definitions/legendEntryControls" },
                 "state": { "$ref": "#/definitions/initialLayerSettings" }

--- a/schema.json
+++ b/schema.json
@@ -271,7 +271,6 @@
                 "id": { "type": "string", "description": "The id of the layer entry in the WMS" },
                 "name": { "type": "string", "description": "A descriptive name for the layer.  To be used in the legend." },
                 "allStyles": { "type": "array", "description": "All the styles for the layer entry in the WMS" },
-                "styleToURL": { "type": "object", "description": "A mapping of all the styles to their respective URL"},
                 "currentStyle": { "type": "string", "description": "The current style for the layer entry in the WMS" },
                 "controls": { "$ref": "#/definitions/legendEntryControls" },
                 "state": { "$ref": "#/definitions/initialLayerSettings" }

--- a/schema.json
+++ b/schema.json
@@ -252,6 +252,29 @@
             "uniqueItems": true,
             "description": "A list of all controls to be enabled on the specified layer"
         },
+        "wmslegendEntryControls": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "opacity",
+                    "visibility",
+                    "boundingBox",
+                    "query",
+                    "snapshot",
+                    "metadata",
+                    "boundaryZoom",
+                    "refresh",
+                    "reload",
+                    "remove",
+                    "settings",
+                    "data",
+                    "styles"
+                ]
+            },
+            "uniqueItems": true,
+            "description": "A list of all controls to be enabled on the specified wms layer"
+        },
         "initialLayerSettings": {
             "type": "object",
             "properties": {
@@ -269,6 +292,9 @@
             "properties": {
                 "id": { "type": "string", "description": "The id of the layer entry in the WMS" },
                 "name": { "type": "string", "description": "A descriptive name for the layer.  To be used in the legend." },
+                "allStyles": { "type": "array", "description": "All the styles for the layer entry in the WMS" },
+                "styleToURL": { "type": "object", "description": "A mapping of all the styles to their respective URL"},
+                "currentStyle": { "type": "string", "description": "The current style for the layer entry in the WMS" },
                 "controls": { "$ref": "#/definitions/legendEntryControls" },
                 "state": { "$ref": "#/definitions/initialLayerSettings" }
             },
@@ -580,8 +606,8 @@
                 "featureInfoMimeType": { "type": "string", "enum": [ "text/html;fgpv=summary", "text/html", "text/plain", "application/json" ], "description": "If specified indicates that GetFeatureInfo should be enabled for this WMS and indicates the format that should be requested." },
                 "legendMimeType": { "type": "string", "enum": [ "image/png", "image/gif", "image/jpeg", "image/svg", "image/svg+xml" ], "description": "If specified indicates that GetLegendGraphic should be enabled for this WMS and indicates the format that should be requested.  FIXME check legendUrl for additional requirements" },
                 "extent": { "$ref": "#/definitions/extentWithReferenceNode" },
-                "controls": { "$ref": "#/definitions/legendEntryControls" },
-                "disabledControls": { "$ref": "#/definitions/legendEntryControls", "description": "A list of controls which are visible, but disabled for user modification" },
+                "controls": { "$ref": "#/definitions/wmslegendEntryControls" },
+                "disabledControls": { "$ref": "#/definitions/wmslegendEntryControls", "description": "A list of controls which are visible, but disabled for user modification" },
                 "state": { "$ref": "#/definitions/initialLayerSettings" }
             },
             "required": [ "id", "layerType", "layerEntries", "url" ],

--- a/schema.json
+++ b/schema.json
@@ -246,34 +246,12 @@
                     "reload",
                     "remove",
                     "settings",
-                    "data"
-                ]
-            },
-            "uniqueItems": true,
-            "description": "A list of all controls to be enabled on the specified layer"
-        },
-        "wmslegendEntryControls": {
-            "type": "array",
-            "items": {
-                "type": "string",
-                "enum": [
-                    "opacity",
-                    "visibility",
-                    "boundingBox",
-                    "query",
-                    "snapshot",
-                    "metadata",
-                    "boundaryZoom",
-                    "refresh",
-                    "reload",
-                    "remove",
-                    "settings",
                     "data",
                     "styles"
                 ]
             },
             "uniqueItems": true,
-            "description": "A list of all controls to be enabled on the specified wms layer"
+            "description": "A list of all controls to be enabled on the specified layer"
         },
         "initialLayerSettings": {
             "type": "object",
@@ -606,8 +584,8 @@
                 "featureInfoMimeType": { "type": "string", "enum": [ "text/html;fgpv=summary", "text/html", "text/plain", "application/json" ], "description": "If specified indicates that GetFeatureInfo should be enabled for this WMS and indicates the format that should be requested." },
                 "legendMimeType": { "type": "string", "enum": [ "image/png", "image/gif", "image/jpeg", "image/svg", "image/svg+xml" ], "description": "If specified indicates that GetLegendGraphic should be enabled for this WMS and indicates the format that should be requested.  FIXME check legendUrl for additional requirements" },
                 "extent": { "$ref": "#/definitions/extentWithReferenceNode" },
-                "controls": { "$ref": "#/definitions/wmslegendEntryControls" },
-                "disabledControls": { "$ref": "#/definitions/wmslegendEntryControls", "description": "A list of controls which are visible, but disabled for user modification" },
+                "controls": { "$ref": "#/definitions/legendEntryControls" },
+                "disabledControls": { "$ref": "#/definitions/legendEntryControls", "description": "A list of controls which are visible, but disabled for user modification" },
                 "state": { "$ref": "#/definitions/initialLayerSettings" }
             },
             "required": [ "id", "layerType", "layerEntries", "url" ],

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -113,7 +113,8 @@ function ConfigObjectFactory(Geo, gapiService, common) {
                     'remove',
                     'settings',
                     // 'data',
-                    'symbology'
+                    'symbology',
+                    'styles'
                 ],
                 disabledControls: [],
                 userDisabledControls: [],

--- a/src/app/ui/loader/loader-service.directive.js
+++ b/src/app/ui/loader/loader-service.directive.js
@@ -34,6 +34,7 @@ function Controller($q, $timeout, stateManager, geoService, Geo, Stepper, LayerB
     const self = this;
 
     self.closeLoaderService = closeLoaderService;
+    self.isWMSLayerWithMultipleStyles = isWMSLayerWithMultipleStyles;
 
     self.serviceTypes = [
         Geo.Service.Types.FeatureLayer,
@@ -349,6 +350,16 @@ function Controller($q, $timeout, stateManager, geoService, Geo, Stepper, LayerB
         } else if (selectedLayers.length >= 0) {
             self.layerSource.config.layerEntries = self.layerSource.layers.slice(0);
         }
+    }
+
+    /**
+     * Checks if any of the selected wms layers have more than one style
+     *
+     * @function isWMSLayerWithMultipleStyles
+     * @return {Boolean} true if at least one with multiple styles
+     */
+    function isWMSLayerWithMultipleStyles() {
+        return self.layerSource && self.layerSource.config.layerEntries.some((entry) => entry.allStyles.length > 1);
     }
 
     /**

--- a/src/app/ui/loader/loader-service.directive.js
+++ b/src/app/ui/loader/loader-service.directive.js
@@ -359,7 +359,8 @@ function Controller($q, $timeout, stateManager, geoService, Geo, Stepper, LayerB
      * @return {Boolean} true if at least one with multiple styles
      */
     function isWMSLayerWithMultipleStyles() {
-        return self.layerSource && self.layerSource.config.layerEntries.some((entry) => entry.allStyles.length > 1);
+        return self.layerSource && self.layerSource.config.layerType === Geo.Layer.Types.OGC_WMS &&
+            self.layerSource.config.layerEntries.some((entry) => entry.allStyles.length > 1);
     }
 
     /**

--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -174,6 +174,14 @@
                 </div-->
             </md-input-container>
 
+            <h4 translate ng-if="self.isWMSLayerWithMultipleStyles()" class="md-body-2 styles-header">settings.label.styles</h4>
+            <md-input-container class="wms-styles" ng-repeat="entry in self.layerSource.config.layerEntries" ng-if="::(entry.allStyles.length > 1)">
+                <label>{{ entry.desc }}</label>
+                <md-select ng-model="entry.currentStyle">
+                    <md-option ng-value="style" ng-repeat="style in entry.allStyles">{{ style }}</md-option>
+                </md-select>
+            </md-input-container>
+
             <p class="md-caption">{{ 'stepper.unresponsive' | translate }}</p>
 
         </rv-stepper-item>

--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -174,15 +174,28 @@
                 </div-->
             </md-input-container>
 
-            <div ng-if="self.isWMSLayerWithMultipleStyles()" class="rv-subheader">
-                <h4 translate class="md-subhead">settings.label.styles</h4>
+            <div ng-if="self.isWMSLayerWithMultipleStyles()" class="rv-styles-list">
+                <md-button
+                    class="rv-group-body-button rv-button-square style-title"
+                    ng-click="section.isExpanded = !section.isExpanded">
+
+                    {{ 'settings.label.styles' | translate }}
+
+                    <div class="rv-icon-24 rv-group-toggle-icon">
+                        <md-icon
+                            class="md-toggle-icon"
+                            ng-class="{ 'rv-toggled' : section.isExpanded }"
+                            md-svg-src="hardware:keyboard_arrow_down"></md-icon>
+                    </div>
+                </md-button>
+
+                <md-input-container ng-show="section.isExpanded" class="wms-styles" ng-repeat="entry in self.layerSource.config.layerEntries" ng-if="::(entry.allStyles.length > 1)">
+                    <label>{{ entry.desc }}</label>
+                    <md-select ng-model="entry.currentStyle">
+                        <md-option ng-value="style" ng-repeat="style in entry.allStyles">{{ style }}</md-option>
+                    </md-select>
+                </md-input-container>
             </div>
-            <md-input-container class="wms-styles" ng-repeat="entry in self.layerSource.config.layerEntries" ng-if="::(entry.allStyles.length > 1)">
-                <label>{{ entry.desc }}</label>
-                <md-select ng-model="entry.currentStyle">
-                    <md-option ng-value="style" ng-repeat="style in entry.allStyles">{{ style }}</md-option>
-                </md-select>
-            </md-input-container>
 
             <p class="md-caption">{{ 'stepper.unresponsive' | translate }}</p>
 

--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -174,7 +174,9 @@
                 </div-->
             </md-input-container>
 
-            <h4 translate ng-if="self.isWMSLayerWithMultipleStyles()" class="md-body-2 styles-header">settings.label.styles</h4>
+            <div ng-if="self.isWMSLayerWithMultipleStyles()" class="rv-subheader">
+                <h4 translate class="md-subhead">settings.label.styles</h4>
+            </div>
             <md-input-container class="wms-styles" ng-repeat="entry in self.layerSource.config.layerEntries" ng-if="::(entry.allStyles.length > 1)">
                 <label>{{ entry.desc }}</label>
                 <md-select ng-model="entry.currentStyle">

--- a/src/app/ui/settings/settings-content.directive.js
+++ b/src/app/ui/settings/settings-content.directive.js
@@ -78,6 +78,7 @@ function Controller(common, Geo) {
     const self = this;
 
     self.checkAvailableControls = checkAvailableControls;
+    self.checkDisabledControls = checkDisabledControls;
     self.checkWMS = checkWMS;
     self.checkStylesLength = checkStylesLength;
 
@@ -89,6 +90,16 @@ function Controller(common, Geo) {
      */
     function checkAvailableControls(names) {
         return common.intersect(self.block.availableControls, names.split('|')).length > 0;
+    }
+
+    /**
+     * @function checkDisabledControls
+     * @private
+     * @param {String} names
+     * @return {Boolean} true if at least one of the supplied control names is disabled in block
+     */
+    function checkDisabledControls(names) {
+        return common.intersect(self.block.disabledControls, names.split('|')).length > 0;
     }
 
     /**

--- a/src/app/ui/settings/settings-content.html
+++ b/src/app/ui/settings/settings-content.html
@@ -32,7 +32,7 @@
     </div>
 </div>
 
-<div class="rv-subsection" ng-if="::(self.checkWMS() && self.checkStylesLength())">
+<div class="rv-subsection" ng-if="::(self.checkWMS() && !self.checkDisabledControls('styles') && self.checkStylesLength())">
     <div class="rv-subheader">
         <h4 translate class="md-subhead">settings.label.styles</h4>
     </div>
@@ -40,7 +40,7 @@
 
         <md-divider class="rv-settings-divider"></md-divider>
         <md-input-container ng-repeat="entry in self.block.mainProxyWrapper.layerConfig.layerEntries" ng-if="::(entry.allStyles.length > 1)">
-            <label>{{ entry.name }}</label>
+            <label>{{ entry.desc }}</label>
             <md-select ng-model="entry.currentStyle">
                 <md-option ng-value="style" ng-repeat="style in entry.allStyles">{{ style }}</md-option>
             </md-select>

--- a/src/content/samples/config/config-sample-01-structured-visibility-sets.json
+++ b/src/content/samples/config/config-sample-01-structured-visibility-sets.json
@@ -338,6 +338,9 @@
                   },
                   {
                     "layerId": "powerplant100mw-liquids"
+                  },
+                  {
+                    "layerId": "wms"
                   }
                 ]
               }
@@ -389,6 +392,26 @@
           "visibility": true
         },
         "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/3"
+      },
+      {
+        "id":"wms",
+        "name": "WMS Layer",
+        "layerType":"ogcWms",
+        "disabledControls": [ "styles" ],
+        "layerEntries": [
+            {
+              "id": "GDPS.ETA_UU",
+              "allStyles": [ "WINDARROW", "WINDARROWKMH", "WINDSPEED", "WINDSPEEDKMH" ],
+              "styleToURL": {
+                "WINDARROW": "http://geo.weather.gc.ca/geomet//?LANG=E%26SERVICE=WMS%26VERSION=1.1.1%26REQUEST=GetLegendGraphic%26STYLE=WINDARROW%26LAYER=GDPS.ETA_UU%26format=image/png",
+                "WINDARROWKMH": "http://geo.weather.gc.ca/geomet//?LANG=E%26SERVICE=WMS%26VERSION=1.1.1%26REQUEST=GetLegendGraphic%26STYLE=WINDARROWKMH%26LAYER=GDPS.ETA_UU%26format=image/png",
+                "WINDSPEED": "http://geo.weather.gc.ca/geomet//?LANG=E%26SERVICE=WMS%26VERSION=1.1.1%26REQUEST=GetLegendGraphic%26STYLE=WINDSPEED%26LAYER=GDPS.ETA_UU%26format=image/png",
+                "WINDSPEEDKMH": "http://geo.weather.gc.ca/geomet//?LANG=E%26SERVICE=WMS%26VERSION=1.1.1%26REQUEST=GetLegendGraphic%26STYLE=WINDSPEEDKMH%26LAYER=GDPS.ETA_UU%26format=image/png"
+              },
+              "currentStyle": "WINDSPEEDKMH"
+            }
+        ],
+        "url":"http://geo.weather.gc.ca/geomet/?lang=E&service=WMS&request=GetCapabilities"
       }
     ],
     "tileSchemas": [

--- a/src/content/samples/config/config-sample-01-structured-visibility-sets.json
+++ b/src/content/samples/config/config-sample-01-structured-visibility-sets.json
@@ -402,12 +402,6 @@
             {
               "id": "GDPS.ETA_UU",
               "allStyles": [ "WINDARROW", "WINDARROWKMH", "WINDSPEED", "WINDSPEEDKMH" ],
-              "styleToURL": {
-                "WINDARROW": "http://geo.weather.gc.ca/geomet//?LANG=E%26SERVICE=WMS%26VERSION=1.1.1%26REQUEST=GetLegendGraphic%26STYLE=WINDARROW%26LAYER=GDPS.ETA_UU%26format=image/png",
-                "WINDARROWKMH": "http://geo.weather.gc.ca/geomet//?LANG=E%26SERVICE=WMS%26VERSION=1.1.1%26REQUEST=GetLegendGraphic%26STYLE=WINDARROWKMH%26LAYER=GDPS.ETA_UU%26format=image/png",
-                "WINDSPEED": "http://geo.weather.gc.ca/geomet//?LANG=E%26SERVICE=WMS%26VERSION=1.1.1%26REQUEST=GetLegendGraphic%26STYLE=WINDSPEED%26LAYER=GDPS.ETA_UU%26format=image/png",
-                "WINDSPEEDKMH": "http://geo.weather.gc.ca/geomet//?LANG=E%26SERVICE=WMS%26VERSION=1.1.1%26REQUEST=GetLegendGraphic%26STYLE=WINDSPEEDKMH%26LAYER=GDPS.ETA_UU%26format=image/png"
-              },
               "currentStyle": "WINDSPEEDKMH"
             }
         ],

--- a/src/content/styles/modules/_loader.scss
+++ b/src/content/styles/modules/_loader.scss
@@ -47,12 +47,18 @@
                 color: rgb(221,44,0); /*color needs to be tied to theme*/
             }
 
-            .rv-subheader {
-                border-bottom: 1px solid $divider-color-light;
-                display: flex;
-
-                h4, h5, h6 {
+            .rv-styles-list {
+                .style-title {
                     color: darken(#00BCD4, 20%);
+                    text-align: left;
+                    padding: 0;
+                    margin: 0;
+                    border-bottom: 1px solid $divider-color-light;
+                    width: 100%;
+
+                    .rv-icon-24 {
+                        float: right;
+                    }
                 }
 
                 @include include-size(rv-gt-sm) {
@@ -66,10 +72,15 @@
                     bottom: 0;
                 }
                 @include pane-title;
+
+                .rv-toggled.md-toggle-icon {
+                    transform: rotate(180deg) !important;
+                }
             }
 
             .wms-styles {
                 width: 100%;
+                margin-top: 25px;
             }
         }
 

--- a/src/content/styles/modules/_loader.scss
+++ b/src/content/styles/modules/_loader.scss
@@ -47,9 +47,25 @@
                 color: rgb(221,44,0); /*color needs to be tied to theme*/
             }
 
-            .styles-header {
-                margin-top: 10px;
-                margin-bottom: 10px;
+            .rv-subheader {
+                border-bottom: 1px solid $divider-color-light;
+                display: flex;
+
+                h4, h5, h6 {
+                    color: darken(#00BCD4, 20%);
+                }
+
+                @include include-size(rv-gt-sm) {
+                    margin: {
+                        top: rem(0.6);
+                        bottom: rem(0.6);
+                    }
+                }
+                padding: {
+                    top: 0;
+                    bottom: 0;
+                }
+                @include pane-title;
             }
 
             .wms-styles {

--- a/src/content/styles/modules/_loader.scss
+++ b/src/content/styles/modules/_loader.scss
@@ -46,6 +46,15 @@
                 padding-top: 5px;
                 color: rgb(221,44,0); /*color needs to be tied to theme*/
             }
+
+            .styles-header {
+                margin-top: 10px;
+                margin-bottom: 10px;
+            }
+
+            .wms-styles {
+                width: 100%;
+            }
         }
 
         // TODO: this is horrible; need to organize it better


### PR DESCRIPTION
## Description
Related to #332 

Allows users to choose styles for layers while importing (Step 3)
Also allows changing styles to be disabled (legendEntryControls).

## Testing
Visually tested.

Sample 1 can be used to test disabled styles control

This service can be used to test configuring styles when importing: http://geo.weather.gc.ca/geomet/?lang=E&service=WMS&request=GetCapabilities.

## Documentation
Comments, JSDoc

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2429)
<!-- Reviewable:end -->
