### PR TITLE
fix missing IE text by instead stripping markdown altogether

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "marked": "0.3.6",
     "moment-timezone": "0.5.13",
     "rcolor": "1.0.1",
+    "remove-markdown": "^0.2.2",
     "screenfull": "3.3.1",
     "svg.textflow.js": "github:fgpv-vpgf/svg.textflow.js",
     "text-encoding": "0.6.4"

--- a/src/app/ui/export/export-legend.service.js
+++ b/src/app/ui/export/export-legend.service.js
@@ -1,4 +1,5 @@
 import marked from 'marked';
+import removeMd from 'remove-markdown';
 
 // margin of the legend container
 const LEGEND_MARGIN = {
@@ -431,6 +432,16 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                     }
                 } else {
                     const content = entry.layerName || entry.content;
+
+                    // ie can't handle fancy markdown image rendering so we strip markdown entirely
+                    if (RV.isIE) {
+                        return {
+                            name: removeMd(content),
+                            items: entry.symbologyStack.stack || [],
+                            blockType: LegendBlock.TYPES.INFO
+                        }
+                    }
+
                     const contentToHtml = marked(content);
 
                     // if no markdown was parsed, return as text


### PR DESCRIPTION
## Description
Related to PR https://github.com/fgpv-vpgf/fgpv-vpgf/pull/2402, @JahidAhmed noticed in IE that text was not displaying at all so markdown is stripped for IE instead. 

@JahidAhmed can you verify in IE, if it works ok to merge.

## Testing
No IE on linux, so tested in chrome and :pray: 

## Documentation
none

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2437)
<!-- Reviewable:end -->
