### PR TITLE
fix(ui): datatable renderes correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ typings/
 tsd.json
 .vagrant/
 apidocs/
+.vscode/
 
 # VIM files
 *~

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "cSpell.words": [
-        "bbox"
-    ]
+        "bbox",
+        "hardcoded"
+    ],
+    "editor.formatOnSave": false
 }

--- a/src/app/ui/table/default.html
+++ b/src/app/ui/table/default.html
@@ -8,7 +8,9 @@
         is-loading="self.display.isLoading"
         hide-when-loading="false"
         ng-class="{ 'rv-transparent': self.tableService.isSettingOpen }"
-        ng-if="!self.noData">
+        ng-show="!self.noData">
+
+        <!-- ng-show must be used here; if ng-if is used, datatable plugin refuses to render the table after `self.noData` cycles through `false` -->
 
         <div class="rv-table-splash rv-hide-animate"
             ng-if="!self.display.requester.error"
@@ -38,7 +40,7 @@
     </rv-content-pane>
 
     <rv-content-pane
-        ng-if="self.noData"
+        ng-show="self.noData"
         close-panel="self.closePanel()"
         title-style="title"
         title-value="{{ 'filter.title' | translate }} {{ self.title }}">


### PR DESCRIPTION
## Description
The datatable will not longer get stuck in a failed state after the data load errors or a user switches the table to a different layer while the table is still being rendered.

Closes #2410

## Testing
![](https://i.imgur.com/x6vSBeH.png)

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- ~~[ ] Release notes have been updated~~ not a released bug
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2441)
<!-- Reviewable:end -->
