### PR TITLE
Ensure layer entry does not get removed when failed to reload

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -183,18 +183,23 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
             const layerRecord = layerRegistry.getLayerRecord(legendBlockConfig.layerId);
 
             // need time to reload children for Dynamic layers
-            promise = common.$q(resolve => {
+            promise = common.$q((resolve, reject) => {
                 layerRecord.addStateListener(_onLayerRecordLoad);
 
                 function _onLayerRecordLoad(state) {
-                    if (state === 'rv-loaded') {
+                    // add back entry
+                    if (state === 'rv-loaded' || state === 'rv-error') {
                         layerRecord.removeStateListener(_onLayerRecordLoad);
 
                         _boundingBoxRemoval(legendBlock);
 
                         legendBlockParent.addEntry(reloadedLegendBlock, index);
+                    }
 
+                    if (state === 'rv-loaded') {
                         resolve(legendBlockParent);
+                    } else if (state === 'rv-error') {
+                        reject(layerRecord.name);
                     }
                 }
             });

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -182,27 +182,29 @@ function legendServiceFactory(Geo, ConfigObject, configService, LegendBlock, Lay
 
             const layerRecord = layerRegistry.getLayerRecord(legendBlockConfig.layerId);
 
-            // need time to reload children for Dynamic layers
-            promise = common.$q((resolve, reject) => {
-                layerRecord.addStateListener(_onLayerRecordLoad);
+            if (!promise) { // ensure only one promise is created
+                // need time to reload children for Dynamic layers
+                promise = common.$q((resolve, reject) => {
+                    layerRecord.addStateListener(_onLayerRecordLoad);
 
-                function _onLayerRecordLoad(state) {
-                    // add back entry
-                    if (state === 'rv-loaded' || state === 'rv-error') {
-                        layerRecord.removeStateListener(_onLayerRecordLoad);
+                    function _onLayerRecordLoad(state) {
+                        // add back entry
+                        if (state === 'rv-loaded' || state === 'rv-error') {
+                            layerRecord.removeStateListener(_onLayerRecordLoad);
 
-                        _boundingBoxRemoval(legendBlock);
+                            _boundingBoxRemoval(legendBlock);
 
-                        legendBlockParent.addEntry(reloadedLegendBlock, index);
+                            legendBlockParent.addEntry(reloadedLegendBlock, index);
+                        }
+
+                        if (state === 'rv-loaded') {
+                            resolve(legendBlockParent);
+                        } else if (state === 'rv-error') {
+                            reject(layerRecord.name);
+                        }
                     }
-
-                    if (state === 'rv-loaded') {
-                        resolve(legendBlockParent);
-                    } else if (state === 'rv-error') {
-                        reject(layerRecord.name);
-                    }
-                }
-            });
+                });
+            }
         });
 
         return promise;

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -154,6 +154,8 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, comm
 
                 stateManager.toggleDisplayPanel(panel, data || legendBlock, openPanel.requester, 0);
             }
+        }, (layerName) => {
+            console.error('Failed to reload layer:', layerName);
         });
     }
 


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Ensure layer entry does not get removed when failed to reload as well as error out a customized message when in times of failure.

Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2425
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Try to reload the CESI layer
Before:
http://fgpv.cloudapp.net/demo/v2.1.0-daily02/dev/samples/index-fgp-en.html?keys=JOSM,EcoAction,CESI_Other,NPRI_CO
After:
http://fgpv.cloudapp.net/demo/users/barryytm/2.1.1-2425/dev/samples/index-fgp-en.html?keys=JOSM,EcoAction,CESI_Other,NPRI_CO
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2458)
<!-- Reviewable:end -->
