### PR TITLE
Api 01

### DIFF
--- a/api/src/geometry.ts
+++ b/api/src/geometry.ts
@@ -149,6 +149,8 @@ export class XYBounds {
 }
 
 // Descriptors -----------------------
+
+/** Guarantees functions with a parameter of type `XY | XYLiteral` to be of type XY. */
 export function XYLiteral(target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<any>) {
     const originalMethod = descriptor.value;
     descriptor.value = function(maybeXY: XY | XYLiteral): XY {

--- a/api/src/geometry.ts
+++ b/api/src/geometry.ts
@@ -4,7 +4,7 @@
 export class XY {
     /** Longitude in decimal degrees, bounded by ±360° */
     x: number;
-    /** Latitude in decimal degrees, bounded by ±90° */
+    /** Latitude in decimal degrees, bounded by ±180° */
     y: number;
 
     constructor(x: number, y: number) {

--- a/api/src/geometry.ts
+++ b/api/src/geometry.ts
@@ -4,20 +4,24 @@
 export class XY {
     /** Longitude in decimal degrees, bounded by ±360° */
     x: number;
-    /** Latitude in decimal degrees, bounded by ±180° */
+    /** Latitude in decimal degrees, bounded by ±90° */
     y: number;
 
     constructor(x: number, y: number) {
         x = x <= 180 && x >= -180 ? x : 360 % Math.abs(x) * (x < 0 ? 1 : -1);
 
-        if (x > 180 || x < -180) {
+        if (typeof x !== 'number' || x > 180 || x < -180) {
             throw new Error(`Longitude (x) provided is bounded to ±180°, ${x} given.`);
-        } else if (y > 90 || y < -90) {
+        } else if (typeof y !== 'number' || y > 90 || y < -90) {
             throw new Error(`Latitude (y) provided is bounded to ±90°, ${y} given.`);
         }
 
         this.x = x;
         this.y = y;
+    }
+
+    static confirm(maybeXY: XY | XYLiteral): XY {
+        return isXYLiteral(maybeXY) ? new XY(maybeXY[0], maybeXY[1]) : maybeXY;
     }
 
     /**
@@ -75,22 +79,41 @@ export class XYBounds {
     northEast: XY;
     southWest: XY;
 
-    constructor(northEast: XY | XYLiteral, southWest: XY | XYLiteral) {
-        if (isXYLiteral(southWest)) {
-            this.southWest = new XY(southWest[0], southWest[1]);
+    constructor(northEast: XY | XYLiteral | Extent, southWest?: XY | XYLiteral | undefined) {
+        if (isExtent(northEast)) {
+            const xy = (<any>window).RZ.GAPI.proj.localProjectExtent(northEast, 4326);
+            this.northEast = new XY(xy.x1, xy.y1);
+            this.southWest = new XY(xy.x0, xy.y0);
         } else {
-            this.southWest = southWest;
-        }
+            if (isXYLiteral(southWest)) {
+                this.southWest = new XY(southWest[0], southWest[1]);
+            } else if (typeof southWest === 'undefined') {
+                throw new Error("southWest parameter is required if northEast is not an extent");
+            } else {
+                this.southWest = southWest;
+            }
 
-        if (isXYLiteral(northEast)) {
-            this.northEast = new XY(northEast[0], northEast[1]);
-        } else {
-            this.northEast = northEast;
+            if (isXYLiteral(northEast)) {
+                this.northEast = new XY(northEast[0], northEast[1]);
+            } else {
+                this.northEast = northEast;
+            }
         }
 
         const centerX = this.southWest.x + ((this.northEast.x - this.southWest.x)/2);
         const centerY = this.southWest.y + ((this.northEast.y - this.southWest.y)/2);
         this.center = new XY(centerX, centerY);
+    }
+
+    get extent(): Extent {
+        const extentObj = {
+            xmin: this.southWest.x,
+            xmax: this.northEast.x,
+            ymax: this.southWest.y,
+            ymin: this.northEast.y,
+            spatialReference: { wkid: 4326 }
+        };
+        return (<any>window).RZ.GAPI.Map.getExtentFromJson(extentObj);
     }
 
     /** Returns true if the given XY point is contained within this boundary. */
@@ -120,6 +143,18 @@ export class XYBounds {
     toString(): string {
         return `${this.southWest.x},${this.southWest.y},${this.northEast.x},${this.northEast.y}`;
     }
+}
+
+export interface Extent {
+    xmin: number,
+    xmax: number,
+    ymax: number,
+    ymin: number,
+    spatialReference: { wkid: number }
+}
+
+export function isExtent(x: any): x is Extent {
+    return x.type === "extent";
 }
 
 export interface XYLiteral {

--- a/api/src/map.ts
+++ b/api/src/map.ts
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import { MouseEvent, esriMouseEvent } from 'api/event/MouseEvent';
 import * as geo from 'api/geometry';
 import { seeder } from 'app/app-seed';
-import { FgpvConfigSchema } from 'api/schema';
+import { FgpvConfigSchema as ViewerConfigSchema } from 'api/schema';
 
 /**
  * Provides controls for modifying the map, watching for changes, and to access map layers and UI properties.
@@ -23,7 +23,7 @@ export default class Map {
     private _boundsChanged: Observable<geo.XYBounds>;
 
     /** Creates a new map inside of the given HTML container, which is typically a DIV element. */
-    constructor(mapDiv: HTMLElement, config?: FgpvConfigSchema | string) {
+    constructor(mapDiv: HTMLElement, config?: ViewerConfigSchema | string) {
         this.mapDiv = $(mapDiv);
         this._id = this.mapDiv.attr('id') || '';
 
@@ -184,8 +184,8 @@ export default class Map {
     }
 }
 
-function isConfigSchema(config: FgpvConfigSchema | string): config is FgpvConfigSchema {
-    return (<FgpvConfigSchema>config).version !== undefined;
+function isConfigSchema(config: ViewerConfigSchema | string): config is ViewerConfigSchema {
+    return (<ViewerConfigSchema>config).version !== undefined;
 }
 
 function initObservables(this: Map) {

--- a/api/src/map.ts
+++ b/api/src/map.ts
@@ -162,9 +162,10 @@ export default class Map {
     }
 
     /** Pans the map to the center point provided. */
+    setCenter(xy: geo.XY | geo.XYLiteral): void;
     @geo.XYLiteral
-    setCenter(xy: geo.XY | geo.XYLiteral): void {
-        this.mapI.centerAt((<geo.XY>xy).projectToPoint(3978));
+    setCenter(xy: geo.XY): void {
+        this.mapI.centerAt(xy.projectToPoint(3978));
     }
 
     /** Returns the current zoom level applied on the map */

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1880,19 +1880,27 @@ function ConfigObjectFactory(Geo, gapiService, common, events) {
                     }
                 });
 
-                mapInstance.centerChanged = Observable.create(subscriber => {
-                    events.$on(events.rvExtentChange, (_, d) => subscriber.next(extentToApi(d.extent).center));
-                });
-
                 mapInstance.boundsChanged = Observable.create(subscriber => {
                     events.$on(events.rvExtentChange, (_, d) => subscriber.next(extentToApi(d.extent)));
+                });
+
+                mapInstance.centerChanged = Observable.create(subscriber => {
+                    events.$on(events.rvExtentChange, (_, d) => {
+                        const centerXY = d.extent.getCenter();
+
+                        subscriber.next(pointToApi(centerXY.x, centerXY.y));
+                    });
                 });
             });
 
             function extentToApi(extent) {
                 const xy = gapiService.gapi.proj.localProjectExtent(extent, 4326);
-                console.error(extent, xy);
                 return new XYBounds([xy.x1, xy.y1], [xy.x0, xy.y0]);
+            }
+
+            function pointToApi(x, y) {
+                const xy = gapiService.gapi.proj.localProjectPoint(instance.spatialReference.wkid, 4326, [x, y]);
+                return new XY(xy[0], xy[1]);
             }
 
             this._instance = instance;

--- a/src/app/ui/common/full-screen.service.js
+++ b/src/app/ui/common/full-screen.service.js
@@ -18,7 +18,7 @@ angular
     .module('app.ui')
     .factory('fullScreenService', fullScreenService);
 
-function fullScreenService($rootElement, configService, $interval, $rootScope, events) {
+function fullScreenService($rootElement, configService, $interval, events) {
     const service = {
         toggle,
         isExpanded: () => screenfull.isFullscreen && $(screenfull.element).is($rootElement)
@@ -30,7 +30,7 @@ function fullScreenService($rootElement, configService, $interval, $rootScope, e
 
     screenfull.on('change', onChange);
 
-    $rootScope.$on(events.rvMapLoaded, (_, i) => {
+    events.$on(events.rvMapLoaded, (_, i) => {
         configService.getSync.map.instance.fullscreen = fs => {
             if ((service.isExpanded() && !fs) || (!service.isExpanded() && fs)) {
                 service.toggle();

--- a/src/app/ui/common/full-screen.service.js
+++ b/src/app/ui/common/full-screen.service.js
@@ -18,7 +18,7 @@ angular
     .module('app.ui')
     .factory('fullScreenService', fullScreenService);
 
-function fullScreenService($rootElement, configService, $interval) {
+function fullScreenService($rootElement, configService, $interval, $rootScope, events) {
     const service = {
         toggle,
         isExpanded: () => screenfull.isFullscreen && $(screenfull.element).is($rootElement)
@@ -29,6 +29,14 @@ function fullScreenService($rootElement, configService, $interval) {
     let stopInterval;
 
     screenfull.on('change', onChange);
+
+    $rootScope.$on(events.rvMapLoaded, (_, i) => {
+        configService.getSync.map.instance.fullscreen = fs => {
+            if ((service.isExpanded() && !fs) || (!service.isExpanded() && fs)) {
+                service.toggle();
+            }
+        };
+    });
 
     return service;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "strictNullChecks": true,
-        "allowSyntheticDefaultImports": true
+        "allowSyntheticDefaultImports": true,
+        "experimentalDecorators": true
     }
 }


### PR DESCRIPTION
- `XYBounds` can be initialised by any proj4 supported extent object.
- Added `projectToPoint` for `XY` which returns a `Point` object in API projection (4326)
- Added descriptor `XYLiteral` to force `XY | XYLiteral` types to `XY`.

```js
@geo.XYLiteral
    setCenter(xy: geo.XY | geo.XYLiteral): void {
        this.mapI.centerAt((<geo.XY>xy).projectToPoint(3978));
    }
``` 
Unfortunately TS doesn't see this conversion (at runtime) so we maybe force the type to be `(<geo.XY>xy)`.

- fixed `centerChanged` bug providing incorrect values
- Added `boundsChanged` observable 

## Testing
![2e639765de8370ccc4b625c65b587c7267f92fd5a3c063bd049ce500974ce119](https://user-images.githubusercontent.com/10187181/32966201-03b0d466-cba7-11e7-828b-a44fd5f0fd62.jpg)


## Documentation
Not much, inline - will need to update some

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2482)
<!-- Reviewable:end -->
