### PR TITLE
Fix bounding box when changing basemap with a different projection

### DIFF
--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -532,9 +532,13 @@ function LegendBlockFactory(common, Geo, layerRegistry, gapiService, configServi
          */
         _makeBbox () {
             if (!this._bboxProxy) {
+                const currentWkid = configService.getSync.map.selectedBasemap.spatialReference.wkid;
                 this._bboxProxy = layerRegistry.getBoundingBoxRecord(this.bboxID);
 
-                if (!this._bboxProxy) {
+                if (!this._bboxProxy) { // no cached bounding box found
+                    this._bboxProxy = layerRegistry.makeBoundingBoxRecord(this.bboxID, this.mainProxyWrapper.extent);
+                } else if (this._bboxProxy.spatialReference.wkid !== currentWkid) { // cached bbox projection not compatible
+                    this._bboxProxy = layerRegistry.removeBoundingBoxRecord(this.bboxID);
                     this._bboxProxy = layerRegistry.makeBoundingBoxRecord(this.bboxID, this.mainProxyWrapper.extent);
                 }
             }
@@ -555,7 +559,8 @@ function LegendBlockFactory(common, Geo, layerRegistry, gapiService, configServi
         }
 
         set boundingBox (value) {
-            if (!this._bboxProxy) {
+            const currentWkid = configService.getSync.map.selectedBasemap.spatialReference.wkid;
+            if (!this._bboxProxy || this._bboxProxy.spatialReference.wkid !== currentWkid) {
                 if (value) {
                     this._makeBbox();
                 } else {


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Fix bounding box not retaining/working when changing basemap with a different projection.

Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2468
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Manually, try enable bounding box then switch to a different base map with different projection
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2505)
<!-- Reviewable:end -->
