### PR TITLE
chore(readme): point to schema reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Running a local build:
 
 We use a fork and pull model for contributions, see our [contributing guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/develop/CONTRIBUTING.md) for more details.
 
-## Gulp Tasks
+### [Schema Reader](https://milesap.github.io/schema-to-docs/)
+
 
 ### Generating Local Builds
 


### PR DESCRIPTION
## Description
Links to "human readable" config viewer in readme file. (https://milesap.github.io/schema-to-docs/)

- Currently grabs `develop` branch schema. Append `?v=master` or `?v=2.0.0` to read those versions respectively.

- Changes to our schema will need to be made for it to become more useful, I'll open a separate issue in the near future to outline these steps. Briefly:
    - Update some descriptions to be more verbose, accurate, and/or helpful
    - Set `type` properties where missing
    - Move `definitions` that are defined in `properties` back to `definitions`. Possibly split schema into multiple files as needed since internal `$ref` parser can resolve these. `definitions` defined in `properties` do not get auto generated examples, so the examples currently shown are not fully defined.

- Does not work in IE - but it will when I have time to update in between API work. Requires files to be babelified and such.

## Testing
Chrome is good

## Documentation
No

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2523)
<!-- Reviewable:end -->
