### PR TITLE
fix(core): broken reorder for auto legends #2536

### DIFF
--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -18,7 +18,7 @@ angular
     .module('app.geo')
     .factory('layerRegistry', layerRegistryFactory);
 
-function layerRegistryFactory($rootScope, $timeout, $filter, events, gapiService, Geo, configService, tooltipService, common) {
+function layerRegistryFactory($rootScope, $timeout, $filter, events, gapiService, Geo, configService, tooltipService, common, ConfigObject) {
     const service = {
         getLayerRecord,
         makeLayerRecord,
@@ -287,9 +287,16 @@ function layerRegistryFactory($rootScope, $timeout, $filter, events, gapiService
             .reduce((a, b) =>
                 a.concat(a.indexOf(b) < 0 ? b : []), []); // remove duplicates (dynamic group and its children with have the same layer id)
 
-        const orderedLayerRecords = configService.getSync.map.layers
-            .map(layer => layer.id)
-            .filter(id => layerRecordIDsInLegend.indexOf(id) !== -1)
+        // if structured legend, take the layer order from the config as the authoritative source
+        // TODO:? user-added layers are not added to `configService.getSync.map.layers`; they will be always added at the top of the stack for structured legend, so this is not an immediate concern;
+        // if auto legend, take the legend block order from the legend panel
+        const orderedLayerRecords =
+            (configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE ?
+                layerRecordIDsInLegend :
+                configService.getSync.map.layers
+                    .map(layer => layer.id)
+                    .filter(id => layerRecordIDsInLegend.indexOf(id) !== -1)
+            )
             .map(getLayerRecord); // get appropriate layer records
 
         const mapLayerStacks = {


### PR DESCRIPTION
## Description

Layer reorder was broken by the sync function always referring to the original layer order from the config file. Now the original layer order from the config is used only for structured legends; auto legends use legend block order.

Closes #2536

## Testing
Eyeballs.

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2537)
<!-- Reviewable:end -->
