### PR TITLE
fix(focus manager): Add MutationObserver for angular material menus

### DIFF
--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -179,8 +179,6 @@ function apiBlock($rootScope, globalRegistry, geoService, configService, events,
             globalRegistry.getMap(appInfo.id)._registerMap(service); // this enables the main API
             globalRegistry.getMap(appInfo.id)._applicationLoaded(service); // this triggers once
             RV.logger.log('apiBlock', `registered viewer with id *${appInfo.id}*`);
-
-            globalRegistry.focusManager.addViewer($rootElement, $mdDialog, configService.getSync.ui.fullscreen);
         });
 
         $rootScope.$on(events.rvApiHalt, () => {

--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -707,3 +707,28 @@ function disableCommonPrototypes(funcName) {
         };
     })();
 }
+
+// Watches body for element insertions for more "fine grained control" of host page elements.
+const bodyObserver = new MutationObserver(mutations => {
+    mutations
+        .filter(m => m.type === 'childList' && m.addedNodes && m.addedNodes.length > 0)
+        .forEach(m => {
+            const nodeList = m.addedNodes;
+            nodeList.forEach(node => {
+                /** ----- AM Menu Component -----
+                 * We allow the angular material menu component to set its own initial focus by default. However when there is no focusable
+                 * element in the component, AM does not set focus which leaves focus on the triggering element. This is turn makes it impossible to close
+                 * the menu using the escape key.
+                 * 
+                 * The solution is to predict if a focusable element exists, and if not to set focus on the overall menu element.
+                 */
+                const angularMenu = $(node).first().find('md-menu-content');
+                if (angularMenu.length > 0 && angularMenu.find(focusSelector).length === 0) {
+                    angularMenu.attr('tabindex', '-1');
+                    angularMenu.rvFocus();
+                }
+            });
+        });
+});
+
+bodyObserver.observe(document.body, { attributes: false, childList: true });

--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -16,7 +16,7 @@ angular
     .directive('rvInitMap', rvInitMap);
 
 function rvInitMap($rootScope, ConfigObject, configService, geoService, events, referenceService, $rootElement, $interval,
-    globalRegistry, identifyService, appInfo, gapiService) {
+    globalRegistry, identifyService, appInfo, gapiService, $mdDialog) {
 
     // key codes that are currently active
     let keyMap = [];
@@ -66,6 +66,11 @@ function rvInitMap($rootScope, ConfigObject, configService, geoService, events, 
                 apiMap.fgpMap = mapInstance;
                 apiMap._legendStructure = configService.getSync.map.legend;
                 appInfo.mapi = apiMap;
+
+                // Required for FM to function properly
+                globalRegistry.focusManager.addViewer($rootElement, $mdDialog, configService.getSync.ui.fullscreen);
+                $rootElement.attr('rv-trap-focus', $rootElement.attr('id'));
+
                 loadExtensions(apiMap);
                 events.$broadcast(events.rvApiMapAdded, apiMap);
                 window.RZ.mapAdded.next(apiMap);


### PR DESCRIPTION
## Description
From the code:

> We allow the angular material menu component to set its own initial focus by default. However when there is no focusable element in the component, AM does not set focus which leaves focus on the triggering element. This is turn makes it impossible to close the menu using the escape key.

> The solution is to predict if a focusable element exists, and if not to set focus on the overall menu element.

Minor fixes to apply FM specific logic to both programmatic and manually created maps at startup.
 
Future updates to FM will make more use of `MutationObserver` for improved performance and maintainability.

Closes http://tfs.int.ec.gc.ca:8080/tfs/DC/CCPED/_workitems?_a=edit&id=36428 when merged and `v3.1` is rebased on `develop`.

## Testing
Tested @ http://fgpv.cloudapp.net/demo/users/milesap/38968-fm/prod/samples/api/self-loading/api.html

![muffinengineer](https://user-images.githubusercontent.com/10187181/38567286-c38a9754-3cb3-11e8-8368-3ba527b844e7.png)

## Documentation
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2628)
<!-- Reviewable:end -->
