### PR TITLE
Unsubscribe feature hover events when destroying a map instance.

### DIFF
--- a/src/app/core/constant.service.js
+++ b/src/app/core/constant.service.js
@@ -40,6 +40,11 @@ function events($rootScope) {
             $rootScope.$on(...args),
         $broadcast: (...args) =>
             $rootScope.$broadcast(...args),
+        $unsubscribe: (...events) => {
+            events.forEach(event => {
+                $rootScope.$$listeners[event] = [];
+            });
+        },
 
         rvReady: 'rvReady', // Fired when map should be created the first time; should not be broadcasted more then once
         rvApiHalt: 'rvApiHalt', // Fired when API should be put back into 'queue' mode

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -105,6 +105,10 @@ function mapServiceFactory(
         mapConfig.reset();
 
         referenceService.mapNode.empty();
+
+        // unsubscribe events
+        events.$unsubscribe(events.rvFeatureMouseOver);
+
         // FIXME: do we need to destroy scalebar and overview map even after we empty the node
     }
 
@@ -384,7 +388,7 @@ function mapServiceFactory(
      */
     function addMarkerHighlight(mapPoint, showHaze = null) {
         const mapConfig = configService.getSync.map;
-        
+
         mapConfig.highlightLayer.addMarker(mapPoint);
         _toggleHighlightHaze(showHaze);
     }

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -388,7 +388,6 @@ function mapServiceFactory(
      */
     function addMarkerHighlight(mapPoint, showHaze = null) {
         const mapConfig = configService.getSync.map;
-
         mapConfig.highlightLayer.addMarker(mapPoint);
         _toggleHighlightHaze(showHaze);
     }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2596, #2644 

Remove "setMapCursor" of null errors by unsubscribing feature hover events when destroying a map instance.
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
1. Go to http://fgpv.cloudapp.net/demo/users/barryytm/2.3.0-2644/dev/samples/index-samples.html
2. Switch to another sample that with feature layers
3. Open Console
4. Hover over one of the features
5. Try to find "setMapCursor" of null errors

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2648)
<!-- Reviewable:end -->
