### PR TITLE
feat(legend): keep layers in map on legend change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -146,8 +146,7 @@
       }
     },
     "@claviska/jquery-minicolors": {
-      "version": "github:claviska/jquery-minicolors#ee633a109f4484b76403762b776333b909bc1446",
-      "dev": true
+      "version": "github:claviska/jquery-minicolors#ee633a109f4484b76403762b776333b909bc1446"
     },
     "@flowjs/ng-flow": {
       "version": "2.7.7",
@@ -5276,7 +5275,7 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#b635c930971a4c860bc89d09480d01c3108b5e2d",
+      "version": "github:fgpv-vpgf/geoApi#d8c14be4145f32836510c1ed75fe7299fdc30d67",
       "requires": {
         "babel-cli": "6.26.0",
         "babel-preset-latest": "6.24.1",
@@ -5299,13 +5298,6 @@
         "terraformer-arcgis-parser": "1.0.5",
         "terraformer-proj4js": "git+https://github.com/RAMP-PCAR/terraformer-proj4js.git#b2bac5f00e95cf37dd53d5c18821cfa429b9eaf4",
         "text-encoding": "0.6.4"
-      },
-      "dependencies": {
-        "jquery": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-          "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
-        }
       }
     },
     "get-caller-file": {

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -95,15 +95,8 @@ function legendServiceFactory(Geo, ConfigObject, configService, stateManager, Le
                     entry : null)
                 .filter(a => a)[0];
 
-            // if the item is not being added to the legend, remove it from the map and API layers list as well
-            if (!legendItem) {
-                layerRegistry.removeLayerRecord(ld.id);
-                if (index !== -1) {
-                    layerBlueprintsCollection.splice(index, 1);
-                }
-            }
             // if the layer is being readded to the legend, regenerate the layer record to have up-to-date settings
-            else if (index !== -1) {
+            if (index !== -1 && !legendItem) {
                 const blueprint = layerBlueprintsCollection[index];
                 layerRegistry.regenerateLayerRecord(blueprint);
             }

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -96,7 +96,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, stateManager, Le
                 .filter(a => a)[0];
 
             // if the layer is being readded to the legend, regenerate the layer record to have up-to-date settings
-            if (index !== -1 && !legendItem) {
+            if (index !== -1 && legendItem) {
                 const blueprint = layerBlueprintsCollection[index];
                 layerRegistry.regenerateLayerRecord(blueprint);
             }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Through using the API for CIP we came to the conclusion that keeping layers on the map when the structured legend changes is easier to manage.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
```
var mapInstance = RZ.mapInstances[0];
    var sLegend = [];
    sLegend.push({"layerId": "crops"});

    mapInstance.legendConfig = sLegend;
```

And then see the "liquids" features are still visible on the map.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
:speak_no_evil: 

No code added, no documentation to add.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2655)
<!-- Reviewable:end -->
