### PR TITLE
feat(export): add support for specifying download file type.

### DIFF
--- a/src/app/ui/export/export.service.js
+++ b/src/app/ui/export/export.service.js
@@ -28,8 +28,10 @@ function exportService($mdDialog, $mdToast, referenceService, configService, eve
 
     // wire in a hook to any map for exporting.  this makes it available on the API
     events.$on(events.rvMapLoaded, (_, i) => {
-        configService.getSync.map.instance.export = () => {
-            service.open();
+        configService.getSync.map.instance.export = (fileType) => {
+            if (fileType && fileType !== 'png' && fileType !== 'jpg')
+                throw new Error(`Invalid or unsupported file type ${fileType}.`);
+            service.open(null, fileType);
         };
     });
 
@@ -42,12 +44,13 @@ function exportService($mdDialog, $mdToast, referenceService, configService, eve
      * @function open
      * @param {Object} event original click event
      */
-    function open(event) {
+    function open(event, fileType = 'png') {
         const shellNode = referenceService.panels.shell;
 
         $mdDialog.show({
             locals: {
-                shellNode
+                shellNode,
+                fileType
             },
             controller: ExportController,
             controllerAs: 'self',
@@ -275,7 +278,7 @@ function exportService($mdDialog, $mdToast, referenceService, configService, eve
             try {
                 if (!RV.isSafari) {
                     canvas.toBlob(blob => {
-                        FileSaver.saveAs(blob, `${fileName}.png`);
+                        FileSaver.saveAs(blob, `${fileName}.${self.fileType}`);
                     });
                 } else {
                     showToast('error.safari');


### PR DESCRIPTION
## Description
Adds ability to specify export extension type (png is default or jpg only) via the legacy API call:

```js
RZ.mapInstances[0].mapI.export(); // png (legacy support)
RZ.mapInstances[0].mapI.export('png'); // png
RZ.mapInstances[0].mapI.export('jpg'); // jpg
```
This is to support [CIP PBI 38424](http://tfs.int.ec.gc.ca:8080/tfs/DC/CCPED/_workitems?id=38424)

## Testing
👀 

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2667)
<!-- Reviewable:end -->
