### PR TITLE
Add tool tip for truncated cells under column `Name` in datagrid setting

### DIFF
--- a/src/app/ui/table/setting-panel.html
+++ b/src/app/ui/table/setting-panel.html
@@ -61,7 +61,10 @@
                             </md-button>
                         </div>
 
-                        <span class="rv-filter-setting-name">{{ column.title }}</span>
+                        <div class="rv-filter-setting-name" ng-mouseenter="self.setNameTruncated($event)">
+                            {{ column.title }}
+                            <md-tooltip ng-show="self.isNameTruncated">{{ column.title }}</md-tooltip>
+                        </div>
 
                         <div rv-table-definition class="rv-filter-setting-item" info="column"></div>
 

--- a/src/app/ui/table/table-setting-panel.directive.js
+++ b/src/app/ui/table/table-setting-panel.directive.js
@@ -142,13 +142,15 @@ function rvTableSettingPanel(stateManager, dragulaService, animationService, tab
     }
 }
 
-function Controller($scope, events, tableService, stateManager) {
+function Controller($scope, events, tableService, stateManager, $timeout) {
     'ngInject';
     const self = this;
 
     self.sort = onSort;
     self.display = onDisplay;
     self.tableService = tableService;
+    self.isNameTruncated = false;
+    self.setNameTruncated = setNameTruncated;
 
     $scope.$on(events.rvTableReady, () => {
         self.description = stateManager.display.table.data.filter.description;
@@ -310,6 +312,20 @@ function Controller($scope, events, tableService, stateManager) {
                 onDisplay(col);
             }
         });
+    }
+
+    /**
+     * Set the indicated self.isNameTruncated to True if the name is truncated
+     *
+     * @function setNameTruncated
+     * @private
+     * @param{event} evt event when being hovered
+     */
+    function setNameTruncated(evt) {
+        self.isNameTruncated = false;
+        $timeout(() => {
+            self.isNameTruncated = evt.target.scrollWidth > evt.target.clientWidth;
+        }, 250);
     }
 }
 

--- a/src/content/styles/modules/_table.scss
+++ b/src/content/styles/modules/_table.scss
@@ -436,8 +436,8 @@ rv-table-setting-panel {
                 }
 
                 .rv-filter-setting-name {
-                    flex: 2 0 30%;
-                    padding-left: 25px;
+                    flex: 30%;
+                    padding: 15px;
                     overflow: hidden;
                     text-overflow: ellipsis;
                 }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Relates to #2649 

Add tooltip for truncated cells under column `Name` in datagrid setting
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Find a `Name`/`Nom` that is truncated in datagrid setting, then hover to see the tool tip.  If none was found, try shrinking the width of the window until one of the cells is truncated.

Sample: http://fgpv.cloudapp.net/demo/users/barryytm/2.3.0-2649/dev/samples/index-fgp-fr.html?keys=CESI_Other


## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2669)
<!-- Reviewable:end -->
