### PR TITLE
2544 identify, 2670 zoom, 2671 API removing layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "1.2.4",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.2.1-17",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.2.1-19",
     "gsap": "1.20.3",
     "jquery": "2.2.4",
     "jquery-hoverintent": "1.8.2",

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -344,6 +344,9 @@ function legendServiceFactory(Geo, ConfigObject, configService, stateManager, Le
 
             // remove any bounding box layers associated with this legend block
             _boundingBoxRemoval(legendBlock);
+
+            // TODO: modify the legend accordingly to update our api legend object as well, currently it never changes
+            mApi._legendStructure = configService.getSync.map.legend;
         }
 
         /**

--- a/src/app/ui/table/table-default.directive.js
+++ b/src/app/ui/table/table-default.directive.js
@@ -281,9 +281,7 @@ function rvTableDefault($timeout, $q, stateManager, $compile, geoService, $trans
 
                     if (button.name === 'rv-zoom-marker') {
                         // disabled zoom button if layer is not visible
-                        // TODO: fix
-                        // buttonScope.self.visibility = requester.legendEntry.options.visibility;
-                        buttonScope.self.visibility = true;
+                        buttonScope.self.visibility = requester.legendEntry.visibility;
                     }
 
                     button.scope = buttonScope;

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -12,7 +12,7 @@ angular
     .factory('tocService', tocService);
 
 function tocService($q, $rootScope, $mdToast, $translate, $timeout, referenceService, common, stateManager, graphicsService,
-    geoService, metadataService, errorService, LegendBlock, configService, legendService, Geo, events) {
+    geoService, metadataService, errorService, LegendBlock, configService, legendService, layerRegistry, Geo, events) {
 
     const service = {
         // method called by the options and flags set on the layer item
@@ -64,7 +64,7 @@ function tocService($q, $rootScope, $mdToast, $translate, $timeout, referenceSer
             let layerToRemove = legendBlocks.walk(l => l.layerRecordId === id ? l : null).filter(a => a);
 
             // TODO: fix this, will only remove 1 instance from legend if there are multiple legend blocks referencing it  ?
-            if (layerToRemove) {
+            if (layerToRemove.length > 0) {
                 if (index !== undefined) {
                     // in cases of dynamic, if index specified, remove only that child, otherwise we choose to remove entire group below
                     layerToRemove = layerToRemove.find(l => l.itemIndex === index);
@@ -76,6 +76,9 @@ function tocService($q, $rootScope, $mdToast, $translate, $timeout, referenceSer
                 if (layerToRemove) {
                     service.removeLayer(layerToRemove);
                 }
+            } else {
+                // layer is not in legend (or does not exist), try simply removing layer record
+                layerRegistry.removeLayerRecord(id);
             }
         }
     });


### PR DESCRIPTION
## Description
Closes #2544.
Closes #2670.
Closes #2671 - if the layer is not in the legend, directly remove the `layerRecord` if it exists.

## Testing
:eyes: 

## Documentation
In-line comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2672)
<!-- Reviewable:end -->
