### PR TITLE
fix(ui): layer stack order

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "1.2.4",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.2.1-20",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.2.1-21",
     "gsap": "1.20.3",
     "jquery": "2.2.4",
     "jquery-hoverintent": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "datatables.net-select": "1.2.4",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.3",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.2.1-19",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.2.1-20",
     "gsap": "1.20.3",
     "jquery": "2.2.4",
     "jquery-hoverintent": "1.8.2",

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -2012,8 +2012,10 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
 
             if (this.legend.type === TYPES.legend.AUTOPOPULATE) {
                 // filter out layers that are not present in the bookmark preserving the bookmark layer order
-                this._layers = value.bookmarkLayers.map(bookmarkedLayer =>
-                    this._layers.find(layer => layer.id === bookmarkedLayer.id));
+                this._layers = value.bookmarkLayers
+                    .map(bookmarkedLayer =>
+                        this._layers.find(layer => layer.id === bookmarkedLayer.id))
+                    .filter(a => a);    // FIXME: layers added through API will be undefined in the array
             }
 
             // re-create the legend structure

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -58,19 +58,6 @@ function geoService($http, $q, $rootScope, events, mapService, layerRegistry, co
                 }
 
                 events.$on(events.rvApiMapAdded, (_, mapi) => {
-                    mapi.layers.addLayer({
-                        "id": "WindSpeed_2021_20yr_ANN_rcp85",
-                        "layerType": "esriTile",
-                        "url": "http://cipgis.canadaeast.cloudapp.azure.com/arcgis/rest/services/CMIP5_WindSpeed/WindSpeed_2021_20yr_ANN_rcp85/MapServer"
-                    });
-
-                    mapi.layers.addLayer({
-                        "id": "DynLayer",
-                        "layerType": "esriDynamic",
-                        "url": "http://cipgis.canadaeast.cloudapp.azure.com/arcgis/rest/services/SupportData/MapServer",
-                        "layerEntries": [{"index": 4}]
-                    });
-
                     intentionService.initialize(config.intentions, mapi);
                 });
                 events.$on(events.rvIntentionsPreInited, () => {

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -58,6 +58,19 @@ function geoService($http, $q, $rootScope, events, mapService, layerRegistry, co
                 }
 
                 events.$on(events.rvApiMapAdded, (_, mapi) => {
+                    mapi.layers.addLayer({
+                        "id": "WindSpeed_2021_20yr_ANN_rcp85",
+                        "layerType": "esriTile",
+                        "url": "http://cipgis.canadaeast.cloudapp.azure.com/arcgis/rest/services/CMIP5_WindSpeed/WindSpeed_2021_20yr_ANN_rcp85/MapServer"
+                    });
+
+                    mapi.layers.addLayer({
+                        "id": "DynLayer",
+                        "layerType": "esriDynamic",
+                        "url": "http://cipgis.canadaeast.cloudapp.azure.com/arcgis/rest/services/SupportData/MapServer",
+                        "layerEntries": [{"index": 4}]
+                    });
+
                     intentionService.initialize(config.intentions, mapi);
                 });
                 events.$on(events.rvIntentionsPreInited, () => {

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -186,8 +186,10 @@ function legendServiceFactory(Geo, ConfigObject, configService, stateManager, Le
         if (pos) {   // If the order from bookmark exists
             position = pos;
         } else if (configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE) {
+            const layerType = importedLegendBlock.layerType;
+            const sortGroup = layerType ? sortGroups[layerType] : 1;    // layerType doesn't exist, legend block is a group
             position = legendBlocks.entries.findIndex(block =>
-                sortGroups[block.layerType] === sortGroups[importedLegendBlock.layerType]);
+                sortGroups[block.layerType] === sortGroup);
 
             // FIXME: there might be an error here when importing a Feature layer to a legend with only WMS and Dynamic layers; need to check more;
             // if the sort group for this layer doesn't exist, insert at the bottom of the legend

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -299,13 +299,17 @@ function mapServiceFactory(
                     setAttribution(mapConfig.selectedBasemap);
 
                     // poke the server to see if basemap load errored. if so, initalize the map anyway to ensure all the layers still get added
+                    // this will handle only failure cases, the basemap success case is handled when the `layer-add` event is triggered
+                    // for the basemap layer (only the first time a basemap layer is added)
                     $http.get(mapConfig.selectedBasemap.url + '?f=json')
                         .then(response => {
+
+                            // response returned but its an error response since invalid URL, so initalize map
                             if (!response || typeof response.data.error !== 'undefined') {
                                 _initMap();
                             }
                         })
-                        .catch(() => _initMap());
+                        .catch(() => _initMap());   // promise rejected due to server issues, so initialize map
                 }
             },
             'update-start': () => {


### PR DESCRIPTION
## Description
Fix the layer stack order for autolegends and as a result, the map layer order 

## Testing
:eyes: - tested with both working and broken initial basemap by importing tile layer and then dynamic layer through API in both autolegend and structured legend

## Documentation
In-line comments, JSDoc

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2677)
<!-- Reviewable:end -->
