### PR TITLE
Remove extra refresh interval clear cross in IE 11

### DIFF
--- a/src/content/styles/modules/_setting-controls.scss
+++ b/src/content/styles/modules/_setting-controls.scss
@@ -55,6 +55,13 @@
         }
 
         form {
+            md-input-container {
+                // remove clear button rendered by IE;
+                input::-ms-clear {
+                    display: none;
+                }
+            }
+
             .interval-value {
                 padding-right: 36px;
             }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2673

Remove extra refresh interval clear cross in IE
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Visually in IE 11.  
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
None
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2681)
<!-- Reviewable:end -->
