### PR TITLE
Reduce bundle size by removing unused locales in moment-timezone

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -88,6 +88,11 @@ module.exports = function (env) {
                 filename: "rv-styles.css"
             }),
 
+            new webpack.ContextReplacementPlugin(
+                /moment[\/\\]locale$/,
+                /en|fr/
+              ),
+
             new CopyWebpackPlugin([{
                 context: 'src/content/samples',
                 from: '**/*.+(json|js|css|html)',


### PR DESCRIPTION
## Description
Reduces moment-timezone bundle size from 528kb to 164kb by removing unused locales. Actual production bundle reduced by 197.3Kb. There is another library https://date-fns.org/ worth looking at in the future which is just as capable and smaller in size.

## Testing
![moment-before](https://user-images.githubusercontent.com/10187181/39939274-c422d2ca-5523-11e8-9411-a38ea1b963f6.png)
![moment-after](https://user-images.githubusercontent.com/10187181/39939275-c61c358a-5523-11e8-8070-e1240e18adcc.png)


## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2713)
<!-- Reviewable:end -->
