### PR TITLE
Plugins modifications and API mouseMove

### DIFF
--- a/api/src/events.ts
+++ b/api/src/events.ts
@@ -10,13 +10,14 @@
  *                ||
  *              ~~~~~~~
  * THE CODE HEREIN IS A WORK IN PROGRESS - DO NOT USE, BREAKING CHANGES WILL OCCUR FREQUENTLY.
- * 
+ *
  * THIS API IS NOT SUPPORTED.
  */
 
 
 
 import { XY } from 'api/geometry';
+import Map from 'api/map';
 import { Observable, Subject } from 'rxjs';
 
 /** Provides screen and geographic point information for most observable mouse actions. */
@@ -34,9 +35,14 @@ export class MouseEvent {
         return this.screenX === otherMouseEvent.screenX && this.screenY === otherMouseEvent.screenY;
     }
 
-    constructor(event: esriMouseEvent | MouseEvent) {
+    constructor(event: esriMouseEvent | MouseEvent, mapInstance: Map) {
         if (isEsriMouseEvent(event)) {
             this.xy = new XY(event.mapPoint.x, event.mapPoint.y, event.mapPoint.spatialReference.wkid);
+        } else {
+            // need to use screen point to convert to the map point used in creating the XY
+            // however, screenX/Y output the wrong map point value which is why layerX/Y needs to be used
+            const mapPoint = mapInstance.mapI.toMap({ x: (<any>event).layerX, y: (<any>event).layerY});
+            this.xy = new XY(mapPoint.x, mapPoint.y, mapPoint.spatialReference.wkid);
         }
 
         this.screenY = event.screenY;
@@ -50,9 +56,9 @@ export class MouseEvent {
 
 /**
  * Adds a `features` Observable to map clicks for supporting identify through the API
- * 
+ *
  * @example #### Subscribe to feature list
- * 
+ *
  * ```js
  * RZ.mapInstances[0].click.subscribe(a => {
  *     a.features.subscribe(featureList => {...});
@@ -64,8 +70,8 @@ export class MapClickEvent extends MouseEvent {
     _featureSubject: Subject<Object>;
     features: Observable<Object>;
 
-    constructor(event: esriMouseEvent) {
-        super(event);
+    constructor(event: esriMouseEvent, mapInstance: Map) {
+        super(event, mapInstance);
         this._featureSubject = new Subject();
         this.features = this._featureSubject.asObservable();
     }

--- a/api/src/map.ts
+++ b/api/src/map.ts
@@ -306,13 +306,13 @@ function initObservables(this: Map) {
     const esriMapElement = this.mapDiv.find('.rv-esri-map')[0];
     this.click = this._clickSubject.asObservable();
 
-    this.doubleClick = fromEvent<MouseEvent | esriMouseEvent>(esriMapElement, 'dblclick').pipe(map((evt) => new MouseEvent(evt)));
+    this.doubleClick = fromEvent<MouseEvent | esriMouseEvent>(esriMapElement, 'dblclick').pipe(map((evt) => new MouseEvent(evt, this)));
     this.mouseMove = fromEvent<MouseEvent | esriMouseEvent>(esriMapElement, 'mousemove').pipe(
-        map((evt: esriMouseEvent) => new MouseEvent(evt)),
+        map((evt: esriMouseEvent) => new MouseEvent(evt, this)),
         distinctUntilChanged((x, y) => x.equals(y))
     );
-    this.mouseDown = fromEvent<MouseEvent | esriMouseEvent>(esriMapElement, 'mousedown').pipe(map((evt) => new MouseEvent(evt)));
-    this.mouseUp = fromEvent<MouseEvent | esriMouseEvent>(esriMapElement, 'mouseup').pipe(map((evt) => new MouseEvent(evt)));
+    this.mouseDown = fromEvent<MouseEvent | esriMouseEvent>(esriMapElement, 'mousedown').pipe(map((evt) => new MouseEvent(evt, this)));
+    this.mouseUp = fromEvent<MouseEvent | esriMouseEvent>(esriMapElement, 'mouseup').pipe(map((evt) => new MouseEvent(evt, this)));
 }
 
 interface LegendStructure {

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -2167,7 +2167,8 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
             'share',
             'touch',
             'help',
-            'language'
+            'language',
+            'plugins'
         ];
 
         get source () { return this._source; }

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -56,7 +56,7 @@ function identifyService($q, configService, stateManager, events) {
 
         const allIdentifyResults = [].concat(...identifyInstances.map(({ identifyResults }) => identifyResults));
 
-        const mapClickEvent = new MapClickEvent(clickEvent);
+        const mapClickEvent = new MapClickEvent(clickEvent, mApi);
         mApi._clickSubject.next(mapClickEvent);
 
         const allLoadingPromises = identifyInstances.map(({ identifyPromise, identifyResults }) => {
@@ -93,7 +93,7 @@ function identifyService($q, configService, stateManager, events) {
         }
 
         // convert esri click event into the API mouse event and add to the identify session and all identify requests
-        const identifyMouseEvent = new MouseEvent(clickEvent);
+        const identifyMouseEvent = new MouseEvent(clickEvent, mApi);
 
         // map identify instances to identify requests
         const identifyRequests = identifyInstances.reduce((map, { identifyPromise, identifyResults }) => {

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -304,7 +304,10 @@ function mapServiceFactory(
 
         events.$on(events.rvFeatureMouseOver, (event, value) => {
             isFeatureMousedOver = value;
-            mapConfig.instance.setMapCursor(value ? 'pointer' : '');
+
+            if (mApi.identifyMode !== 'none') {
+                mapConfig.instance.setMapCursor(value ? 'pointer' : '');
+            }
         });
 
         /*

--- a/src/app/ui/sidenav/sidenav.service.js
+++ b/src/app/ui/sidenav/sidenav.service.js
@@ -180,6 +180,7 @@ function sideNavigationService($mdSidenav, $rootElement, globalRegistry, configS
         }
 
         mItem.label = mItem.name;
+        mItem.isChecked = () => mItem.isActive;
         service.controls.plugins.children.push(mItem);
     });
 
@@ -358,6 +359,10 @@ function sideNavigationService($mdSidenav, $rootElement, globalRegistry, configS
             $mdDateLocale.shortDays = localeData.weekdaysMin();
             $mdDateLocale.firstDayOfWeek = localeData._week.dow;
 
+            // mark each plugin inactive (unchecked) before loading the new language
+            service.controls.plugins.children.forEach(child => {
+                child.isActive = false;
+            });
         });
 
         /**

--- a/src/content/samples/config/config-sample-63.json
+++ b/src/content/samples/config/config-sample-63.json
@@ -10,7 +10,28 @@
         ]
       },
       "sideMenu": {
-        "logo": true
+        "logo": true,
+        "items": [
+        [
+            "layers",
+            "basemap",
+            "geoSearch"
+        ],
+        [
+            "fullscreen",
+            "export",
+            "share",
+            "touch",
+            "help",
+            "about"
+        ],
+        [
+            "language"
+        ],
+        [
+            "plugins"
+        ]
+      ]
       },
       "legend": {
         "isOpen": {

--- a/src/plugins/core/coord-info.js
+++ b/src/plugins/core/coord-info.js
@@ -67,14 +67,35 @@
          * @return  {Function}    Callback to be executed when map is clicked
          */
         onMenuItemClick () {
+            let identifySetting;
             return () => {
                 this.api.toggleSideNav('close');
 
                 // only set event if not already created
-                if (typeof handler === 'undefined') { handler = this.api.getMapClickInfo(this.clickHandlerBuilder); }
+                if (typeof handler === 'undefined') {
+                    handler = this.api.getMapClickInfo(this.clickHandlerBuilder);
 
-                // set cursor
-                self.setMapCursor('crosshair');
+                    // set cursor
+                    self.setMapCursor('crosshair');
+
+                    // set active (checked) in the side menu
+                    this.isActive = true;
+
+                    // store current identify value and then disable in viewer
+                    identifySetting = self.appInfo.mapi.identifyMode;
+                    self.appInfo.mapi.identifyMode = 'none';
+                } else {
+                    // remove the click handler and set the cursor
+                    handler.click.remove();
+                    handler = undefined;
+                    self.setMapCursor('');
+
+                    // set inactive (unchecked) in the side menu
+                    this.isActive = false;
+
+                    // reset identify value to stored value
+                    self.appInfo.mapi.identifyMode = identifySetting;
+                }
             };
         }
 
@@ -85,11 +106,6 @@
          * @param  {Object}  clickEvent the map click event
          */
         clickHandlerBuilder (clickEvent) {
-            // remove the click handler and set the cursor
-            handler.click.remove();
-            handler = undefined;
-            self.setMapCursor('');
-
             // get current language
             const lang = self.getCurrentLang();
 
@@ -269,8 +285,16 @@
      * @return {Object}   the utm information (zone {String} utm zone, x {Number} Easting, y {Number} Northing)
      */
     function parseUtm(utm, pt) {
+        if (utm.length === 0) {
+            return { zone: 'Error', outPt: { x: '-', y: '-' } };
+        }
+
         // set zone
-        const zone = utm.length > 0 ? utm[0].properties.identifier : '';
+        let zone = utm[0].properties.identifier;
+
+        if (zone < 10) {
+            zone = `0${zone}`;
+        }
 
         // set the UTM easting/northing information using a geometry service
         const outPt = self.projectGeometry(pt, parseInt('326' + zone));


### PR DESCRIPTION
## Description
Closes #2375 - plugins is an available item in side menu.
Closes #2625 - coords info active until manually disabled. also disabled identify which plugin active, and resets identify value to previous value after plugin disabled. also fix small bug with `parseUtm` function, when `zone < 10`.
Closes #2612 - create a `mapPoint` using screen point if it does not already exist.

## Testing
:eyes: 

## Documentation
In-line comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2721)
<!-- Reviewable:end -->
