### PR TITLE
feat(analytics): integrate google tag manager

### DIFF
--- a/src/app/api-loader.ts
+++ b/src/app/api-loader.ts
@@ -12,6 +12,9 @@ class RZ {
      * */
     mapAdded: Subject<Map> = new Subject();
 
+    // Google tag manager dataLayer
+    gtmDL: Array<any> = (<any>window).dataLayer;
+
     /** Loads and executes a javascript file from the provided url. */
     loadExtension(url: string): void {
         $.getScript(url);

--- a/src/app/startup.ts
+++ b/src/app/startup.ts
@@ -6,6 +6,16 @@ const customAttrs = ['config', 'langs', 'service-endpoint', 'restore-bookmark', 
 const nIdList: Array<string> = RV._nodeIdList = [];
 const nodeList: Array<Node> = [];
 
+// Google tag manager loading
+(<any>window).dataLayer = (<any>window).dataLayer ? (<any>window).dataLayer : [];
+const gtmScript = document.createElement("script");
+gtmScript.innerHTML = `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl+ '&gtm_auth=sX_2blCxbksFO5zU3FzkJA&gtm_preview=env-10&gtm_cookies_win=x';f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-KQCZGMF');`;
+$("head").append(gtmScript);
+
 domNodes.each((i, node) => {
     let appId = node.getAttribute('id') || 'rv-app-' + i;
 

--- a/src/app/tag-manager.js
+++ b/src/app/tag-manager.js
@@ -1,0 +1,23 @@
+import { skip } from 'rxjs/operators';
+
+const dataLayer = window.RZ.gtmDL;
+
+
+export default function(api) {
+    api.boundsChanged.pipe(skip(1)).subscribe(() => {
+        dataLayer.push({
+            event : 'extentChanged',
+            category : 'map',
+            action : 'interaction',
+            label : 'extentChanged'
+        });
+    });
+
+    api.ui.basemaps.click.subscribe(() => {
+        dataLayer.push({
+            event : 'basemapChanged',
+            category : 'map',
+            action : 'basemapChanged'
+        });
+    });
+}


### PR DESCRIPTION
## Description
Adds [Google Tag Manager](https://developers.google.com/tag-manager/quickstart) code programmatically on RAMP startup. Adds the GTM dataLayer on our api.  `tag-manager.js` will contain push events triggered by api observations and consolidates tracking into one central location. Most tracking is configured within GTM console. The one's that aren't are included in this PR:

-  tracking the time it takes from page landing to when `events.rvMapLoaded` is fired. This is passed through to analytics user speed analysis. 
- extent changes (pan/zoom)
- basemap changes

## Testing
Tags firing as expected when tested in preview mode in GTM.

## Documentation
None yet

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2751)
<!-- Reviewable:end -->
