### PR TITLE
Fix the blank issue of area of interest 

### DIFF
--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -301,10 +301,10 @@
 
         // change and load the new config
         function changeConfig() {
-            var selectedConfig = document.getElementById('selectConfig').value;
+            var selectedConfig = document.getElementById('selectConfig').value; // load existing config
             document.getElementById('sample-map').setAttribute('rv-config', selectedConfig);
-            RV.getMap('sample-map').reInitialize();
-            sessionStorage.setItem('sampleConfig', selectedConfig);
+            sessionStorage.setItem('sampleConfig', selectedConfig); // store new config
+            location.reload();
         }
     </script>
 </body>


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2767 

Fix the problem where the plugin - area of interest would not fresh if the corresponding config was not initially selected nor not reloaded.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Try load a sample other than 64 initially, then load sample 64 and open area of interest.  Tested in IE as well.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2769)
<!-- Reviewable:end -->
