### PR TITLE
Prevent the north pole icon being set when the spatial reference is not Lambert

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -126,7 +126,8 @@
                 "name": { "type": "string", "description": "The name to display in the basemap selector for the set of basemaps referencing this schema" },
                 "extentSetId": { "type": "string", "description": "The extent set to be used for this basemap (should reference map.extentSets.id)" },
                 "lodSetId": { "type": "string", "description": "Optional.  The level of details set to be used for this basemap (should reference map.lod.id)" },
-                "overviewUrl": { "$ref": "#/definitions/basicLayerNode", "description": "Optional. If set, the overview map will use this layer instead of the active basemap" }
+                "overviewUrl": { "$ref": "#/definitions/basicLayerNode", "description": "Optional. If set, the overview map will use this layer instead of the active basemap" },
+                "hasNorthPole": { "type": "boolean", "default": false, "description": "Indicates if the map projection includes a north pole.  Defaults to false to avoid errors." }
             },
             "required": [ "extentSetId", "lodSetId", "id", "name" ],
             "additionalProperties": false

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1120,7 +1120,7 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
      * @class TileSchema
      */
     class TileSchema {
-        constructor ({ id, lodSetId, name, overviewUrl }, extentSet, lodSet) {
+        constructor ({ id, lodSetId, name, overviewUrl, hasNorthPole }, extentSet, lodSet) {
             this._id = id;
             this._name = name;
             this._lodSetId = lodSetId;
@@ -1129,6 +1129,8 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
 
             this._extentSet = extentSet;
             this._lodSet = lodSet;
+
+            this._hasNorthPole = hasNorthPole || false;
         }
 
         get name () { return this._name; }
@@ -1138,6 +1140,8 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
 
         get extentSet () { return this._extentSet; }
         get lodSet () { return this._lodSet; }
+
+        get hasNorthPole() { return this._hasNorthPole; }
 
         /**
          * Create a blank basemap from a basemap with the same tile schema.
@@ -1177,7 +1181,8 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
                 id: this.id,
                 name: this.name,
                 extentSetId: this.extentSet.id,
-                lodSetId: this.lodSet.id
+                lodSetId: this.lodSet.id,
+                hasNorthPole: this.hasNorthPole
             };
         }
     }

--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -38,7 +38,7 @@ angular
     .module('app.core')
     .factory('configService', configService);
 
-function configService($q, $rootElement, $timeout, $http, $translate, $mdToast, events, gapiService, errorService, ConfigObject) {
+function configService($q, $rootElement, $timeout, $http, $translate, $mdToast, events, gapiService, errorService, ConfigObject, Geo) {
     const DEFAULT_LANGS = ['en-CA', 'fr-CA'];
 
     const States = {
@@ -443,7 +443,7 @@ function configService($q, $rootElement, $timeout, $http, $translate, $mdToast, 
                     "mouseInfo": {
                         "enabled": false,
                         "spatialReference": {
-                            "wkid": 102100
+                            "wkid": Geo.SpatialReference.WEB_MERCATOR.latestWkid
                         }
                     },
                     "northArrow": {
@@ -470,7 +470,7 @@ function configService($q, $rootElement, $timeout, $http, $translate, $mdToast, 
                             "ymin": -883440
                         },
                         "spatialReference": {
-                            "wkid": 3978
+                            "wkid": Geo.SpatialReference.CAN_ATLAS_LAMBERT.wkid
                         }
                     }
                 ],

--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -470,7 +470,7 @@ function configService($q, $rootElement, $timeout, $http, $translate, $mdToast, 
                             "ymin": -883440
                         },
                         "spatialReference": {
-                            "wkid": Geo.SpatialReference.CAN_ATLAS_LAMBERT.wkid
+                            "wkid": Geo.SpatialReference.CAN_ATLAS_LAMBERT.latestWkid
                         }
                     }
                 ],
@@ -508,7 +508,8 @@ function configService($q, $rootElement, $timeout, $http, $translate, $mdToast, 
                         "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
                         "name": "Lambert Maps",
                         "extentSetId": "EXT_NRCAN_Lambert_3978",
-                        "lodSetId": "LOD_NRCAN_Lambert_3978"
+                        "lodSetId": "LOD_NRCAN_Lambert_3978",
+                        "hasNorthPole": true
                     }
                 ],
                 "baseMaps": [

--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -443,7 +443,7 @@ function configService($q, $rootElement, $timeout, $http, $translate, $mdToast, 
                     "mouseInfo": {
                         "enabled": false,
                         "spatialReference": {
-                            "wkid": Geo.SpatialReference.WEB_MERCATOR.latestWkid
+                            "wkid": Geo.SpatialReference.WEB_MERCATOR.wkids[1]
                         }
                     },
                     "northArrow": {

--- a/src/app/geo/geo.constant.service.js
+++ b/src/app/geo/geo.constant.service.js
@@ -52,6 +52,15 @@ const GEO = {
             Unknown: 'unknown',
             Error: 'error'
         }
+    },
+    SpatialReference: {
+        CAN_ATLAS_LAMBERT: {
+            wkid: 3978
+        },
+        WEB_MERCATOR: {
+            wkid: 3857,
+            latestWkid: 102100
+        }
     }
 };
 

--- a/src/app/geo/geo.constant.service.js
+++ b/src/app/geo/geo.constant.service.js
@@ -55,11 +55,12 @@ const GEO = {
     },
     SpatialReference: {
         CAN_ATLAS_LAMBERT: {
-            wkid: 3978
+            wkids: [3978],
+            latestWkid: 3978
         },
         WEB_MERCATOR: {
-            wkid: 3857,
-            latestWkid: 102100
+            wkids: [3857, 102100],
+            latestWkid: 3857
         }
     }
 };

--- a/src/app/geo/map-tools.service.js
+++ b/src/app/geo/map-tools.service.js
@@ -9,7 +9,7 @@ angular
     .module('app.geo')
     .factory('mapToolService', mapToolService);
 
-function mapToolService(configService, geoService, gapiService, $translate) {
+function mapToolService(configService, geoService, gapiService, $translate, Geo) {
 
     const service = {
         northArrow,
@@ -56,7 +56,7 @@ function mapToolService(configService, geoService, gapiService, $translate) {
         let angleDegrees = null;
         let rotationAngle = null;
 
-        if (wkid === 102100) { // mercator
+        if (wkid === Geo.SpatialReference.WEB_MERCATOR.latestWkid) { // mercator
             // always in center of viewer with no rotation
             screenX = mapScrnCntr.x;
             rotationAngle = 0;

--- a/src/app/geo/map-tools.service.js
+++ b/src/app/geo/map-tools.service.js
@@ -56,7 +56,7 @@ function mapToolService(configService, geoService, gapiService, $translate, Geo)
         let angleDegrees = null;
         let rotationAngle = null;
 
-        if (wkid === Geo.SpatialReference.WEB_MERCATOR.latestWkid) { // mercator
+        if (Geo.SpatialReference.WEB_MERCATOR.wkids.includes(wkid)) { // mercator
             // always in center of viewer with no rotation
             screenX = mapScrnCntr.x;
             rotationAngle = 0;

--- a/src/app/ui/common/north-arrow.directive.js
+++ b/src/app/ui/common/north-arrow.directive.js
@@ -9,7 +9,7 @@ const flagIcon = 'M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z';
  *
  * @return {object} directive body
  */
-function rvNorthArrow(configService, $rootScope, $rootElement, events, mapToolService, $interval, $compile) {
+function rvNorthArrow(configService, $rootScope, $rootElement, events, mapToolService, $interval, $compile, Geo) {
     const directive = {
         restrict: 'E',
         link
@@ -28,12 +28,14 @@ function rvNorthArrow(configService, $rootScope, $rootElement, events, mapToolSe
                 let deregisterMapAddedListener = events.$on(events.rvApiMapAdded, (_, mApi) => {
                     deregisterMapAddedListener();
                     // create new layer for north pole
-                    mApi.layers.addLayer('northPoleLayer').then(layer => {
-                        // create north pole as point object and add to north pole layer
-                        const poleSource = mapConfig.northArrow.poleIcon || flagIcon;
-                        let northPole = new Point('northPole', poleSource, new XY(-96, 90));
-                        layer[0].addGeometry(northPole);
-                    });
+                    if (mApi.mapI.spatialReference.wkid === Geo.SpatialReference.CAN_ATLAS_LAMBERT.wkid) {
+                        mApi.layers.addLayer('northPoleLayer').then(layer => {
+                            // create north pole as point object and add to north pole layer
+                            const poleSource = mapConfig.northArrow.poleIcon || flagIcon;
+                            let northPole = new Point('northPole', poleSource, new XY(-96, 90));
+                            layer[0].addGeometry(northPole);
+                        });
+                    }
 
                     updateNorthArrow(); // set initial position
                     $rootScope.$on(events.rvExtentChange, updateNorthArrow); // update on extent changes

--- a/src/app/ui/common/north-arrow.directive.js
+++ b/src/app/ui/common/north-arrow.directive.js
@@ -21,6 +21,7 @@ function rvNorthArrow(configService, $rootScope, $rootElement, events, mapToolSe
         const self = scope.self;
 
         $rootScope.$on(events.rvApiReady, () => {
+            const hasNorthPole = configService.getSync.map.selectedBasemap.tileSchema.hasNorthPole;
             const mapConfig = configService.getSync.map.components;
             if (mapConfig.northArrow && mapConfig.northArrow.enabled) {
                 // required so that arrow moves behind overview map instead of in front
@@ -28,7 +29,7 @@ function rvNorthArrow(configService, $rootScope, $rootElement, events, mapToolSe
                 let deregisterMapAddedListener = events.$on(events.rvApiMapAdded, (_, mApi) => {
                     deregisterMapAddedListener();
                     // create new layer for north pole
-                    if (mApi.mapI.spatialReference.wkid === Geo.SpatialReference.CAN_ATLAS_LAMBERT.wkid) {
+                    if (hasNorthPole) {
                         mApi.layers.addLayer('northPoleLayer').then(layer => {
                             // create north pole as point object and add to north pole layer
                             const poleSource = mapConfig.northArrow.poleIcon || flagIcon;

--- a/src/content/samples/config/config-sample-44.json
+++ b/src/content/samples/config/config-sample-44.json
@@ -327,7 +327,8 @@
         "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
         "name": "Lambert Maps",
         "extentSetId": "EXT_NRCAN_Lambert_3978",
-        "lodSetId": "LOD_NRCAN_Lambert_3978"
+        "lodSetId": "LOD_NRCAN_Lambert_3978",
+        "hasNorthPole": true
       },
       {
         "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",

--- a/src/content/samples/config/config-sample-44.json
+++ b/src/content/samples/config/config-sample-44.json
@@ -50,7 +50,7 @@
     }
   },
   "map": {
-    "initialBasemapId": "baseNrCan",
+    "initialBasemapId": "baseEsriWorld",
     "components": {
       "geoSearch": {
         "enabled": true,


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2771 

Prevent the north pole icon being set when the spatial reference is not Lambert and add some constants.
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
sample 44
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2772)
<!-- Reviewable:end -->
