### PR TITLE
Structured legend revival

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -54,7 +54,10 @@ function legendServiceFactory(Geo, ConfigObject, configService, stateManager, Le
         configService.getSync.map.instance.setLegendConfig = legendStructure => {
             stateManager.setActive({ tableFulldata: false } , { sideMetadata: false }, { sideSettings: false });
 
-            const apiLayers = mApi.layers.allLayers.map(l => l._viewerLayer.config.source);
+            const apiLayers = mApi.layers.allLayers
+                                // filter on the existence of a viewerLayer config, this will strip out 'simpleLayer's
+                                .filter(l => l._viewerLayer.config)
+                                .map(l => l._viewerLayer.config.source);
             const viewerLayers = configService.getSync.map.layers;
             const layers = apiLayers.concat(
                 viewerLayers.filter(layer => apiLayers.indexOf(layer) < 0)


### PR DESCRIPTION
## Description
Fixes:
#2776 
#2716 

North pole layer is now created directly instead of relying on the API, and the structured legend config swap is now simpleLayer proof.

## Testing
No unit tests.

```
RZ.mapInstances[0].mapI.setLegendConfig({"root": {
                "name": "root",
                "children": []
            }})
```

The above will now run with no errors, north pole/arrow still exist, everything is happy. :smile: 

## Documentation
Any in-line comments that needed updating have been updated.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2778)
<!-- Reviewable:end -->
