### PR TITLE
fix(table): table dates filtering

### DIFF
--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -553,7 +553,7 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
                 column.filter.type = 'string';
                 break;
             case 'esriFieldTypeDate':
-                column.filter.type = 'rv-date';
+                column.filter.type = 'date';
                 break;
             default:
                 column.filter.type = 'number';

--- a/src/app/geo/layer-blueprint.class.js
+++ b/src/app/geo/layer-blueprint.class.js
@@ -81,7 +81,7 @@ function LayerBlueprintFactory($q, $http, gapiService, Geo, ConfigObject, bookma
                 if (max !== '') {
                     defs.push(`${column.data} <= ${max}`);
                 }
-            } else if (column.type === 'rv-date') {
+            } else if (column.filter.type === 'date') {
                 const min = column.filter.value.min;
                 const max = column.filter.value.max;
 

--- a/src/app/ui/table/table-search.directive.js
+++ b/src/app/ui/table/table-search.directive.js
@@ -68,7 +68,7 @@ function rvTableSearch(tableService, stateManager, $rootScope, events) {
     }
 }
 
-function Controller(tableService, debounceService, $timeout, $rootElement, stateManager, $rootScope, events, $scope) {
+function Controller(tableService, debounceService, $timeout, $rootElement, stateManager, $rootScope, events, $scope, $filter) {
     'ngInject';
     const self = this;
 
@@ -217,9 +217,15 @@ function Controller(tableService, debounceService, $timeout, $rootElement, state
                 if (!userValue.some(isNaN)) {
                     // set filter type and if it is a date, create date object
                     filter.type = (userValue.length <= 2) ? 'number' : 'date';
-                    filter.searchTerm = (filter.type === 'number') ?
-                        userValue :
-                        [new Date(userValue.splice(0, 3).join('-')), new Date(userValue.splice(0, 3).join('-'))];
+
+                    if (filter.type === 'number') {
+                        filter.searchTerm = userValue;
+                    } else {
+                        const min = $filter('dateTimeZone')(userValue.splice(0, 3).join('-'), '');
+                        const max = $filter('dateTimeZone')(userValue.splice(0, 3).join('-'), '');
+
+                        filter.searchTerm = [new Date(min), new Date(max)];
+                    }
                 }
             }
         }
@@ -256,7 +262,8 @@ function Controller(tableService, debounceService, $timeout, $rootElement, state
                     if (filter.type === 'number') {
                         value = parseFloat(value);
                     } else if (filter.type === 'date') {
-                        value = new Date(value.split(' ')[0]);
+                        const time = $filter('dateTimeZone')(value.split(' ')[0], '')
+                        value = new Date(time);
                     }
 
                     // check if it pass the filter

--- a/src/app/ui/table/table.service.js
+++ b/src/app/ui/table/table.service.js
@@ -188,7 +188,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
                     } else if (column.type === 'number') {
                         column.filter.min = '';
                         column.filter.max = '';
-                    } else if (column.type === 'rv-date') {
+                    } else if (column.type === 'date') {
                         column.filter.min = null;
                         column.filter.max = null;
                     }
@@ -208,7 +208,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
                 if (!column.filter.static) {
                     if (column.filter.type === 'selector') {
                         column.filter.value = [];
-                    } else if (column.filter.type === 'rv-date') {
+                    } else if (column.filter.type === 'date') {
                         column.filter.value = {};
                     } else {
                         column.filter.value = '';
@@ -283,7 +283,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
                 if (typeof column.filter !== 'undefined') {
                     if (column.filter.type === 'selector') {
                         column.filter.value = [];
-                    } else if (column.filter.type === 'rv-date') {
+                    } else if (column.filter.type === 'date') {
                         column.filter.value = {};
                     } else {
                         column.filter.value = '';
@@ -349,9 +349,9 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
             if (max !== '') {
                 defs.push(`${column.name} <= ${max}`);
             }
-        } else if (column.type === 'rv-date') {
-            const min = column.filter.min;
-            const max = column.filter.max;
+        } else if (column.type === 'date') {
+            const min = new Date(column.filter.min);
+            const max = new Date(column.filter.max);
 
             if (min) {
                 const dateMin = `${min.getMonth() + 1}/${min.getDate()}/${min.getFullYear()}`;
@@ -493,7 +493,7 @@ function tableService(stateManager, geoService, $rootScope, $q, gapiService, deb
         // show processing
         $rootElement.find('.dataTables_processing').css('display', 'block');
 
-        // keep filter state to know when to show apply map button
+         // keep filter state to know when to show apply map button
         setFiltersState(column, `${min}${max}`);
 
         // redraw table to filter (filters for range date are added on the table itself in table-definition.directive)

--- a/src/content/samples/config/config-sample-61.json
+++ b/src/content/samples/config/config-sample-61.json
@@ -363,6 +363,33 @@
         }]
         },
         "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/1"
+      },
+      {
+        "id": "GeoChrone***33c61115",
+        "name": "Time filtering",
+        "url":"https://geoappext.nrcan.gc.ca/arcgis/rest/services/GSCC/Geochronology/MapServer",
+        "layerType": "esriDynamic",
+        "layerEntries": [{
+            "index": 0,
+            "table": {
+                "title": "",
+                "maximize": false,
+                "columns": [
+                    {
+                        "data": "OBJECTID",
+                        "title": "OBJECTID"
+                    },
+                    {
+                        "data": "LAST_UPDATED",
+                        "title": "LAST_UPDATED",
+                        "filter": {
+                            "type": "date",
+                            "value": "2005-02-22,2005-04-30"
+                        }
+                    }
+                ]
+            }
+        }]
       }
     ],
     "tileSchemas": [


### PR DESCRIPTION
Before: filter from config of type 'date' not filtering the table.
Values not loading properly. Confusion on type ('date' vs 'rv-date')
Filtering results from search, date picker and config not similar.
After: filter from config of type 'date' filtering the table.
Filtering results from search, date picker and config are similar.

Closes #2749

## Description
<!-- Link to an issue or include a description -->

## Testing
|Browser|Works as expected|
|---|---|
|Chrome| :white_check_mark: |
|Fox| :white_check_mark: |
|Edge| :white_check_mark: |
|IE11| ❌ see #2749 |

with service:
[https://geoappext.nrcan.gc.ca/arcgis/rest/services/GSCC/Geochronology/MapServer](https://geoappext.nrcan.gc.ca/arcgis/rest/services/GSCC/Geochronology/MapServer)
Double checked with the table which can be found [here](https://www.nrcan.gc.ca/earth-sciences/geography/atlas-canada/geochron/18211)

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2779)
<!-- Reviewable:end -->
