### PR TITLE
fix(docs): correct links to technical docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,9 @@
   <script src="https://unpkg.com/docute@3/dist/docute.js"></script>
   <script src="https://unpkg.com/prismjs@1.11.0/components/prism-typescript.js"></script>
   <script>
+      var tag = window.location.href.match(/\.com\/([\d|\w|\.|-]+)/);
+      var url = tag ? `https://ramp-docs.fgpv-vpgf.com/${tag[1]}/` : window.location.href;
+
     docute.init({
         nav: [
             {title: 'Home', path: '/'},
@@ -22,7 +25,7 @@
             {title: 'API', type: 'dropdown', items: [
                 {title: 'An Introduction', path: '/api/welcome'},
                 {title: 'Core extensions', path: '/api/core-extensions'},
-                {title: 'Technical Documentation', path: 'http://fgpv-vpgf.github.io/fgpv-vpgf/api/developer/index.html'}
+                {title: 'Technical Documentation', path: `${url}api/developer`}
             ]},
             {title: 'Intentions', type: 'dropdown', items: [
                 {title: 'An Introduction', path: '/intentions/introduction'},
@@ -32,7 +35,7 @@
                 {title: 'An overview', path: '/developer/getting_started'},
                 {title: 'How to contribute', path: '/developer/contributing_guide'},
                 {title: 'Writing extensions', path: '/developer/plugins'},
-                {title: 'Technical JSDocs', path: 'https://ramp-docs.fgpv-vpgf.com/v2.4.0/developer/jsDocs/'},
+                {title: 'Technical JSDocs', path: `${url}developer/jsDocs/`},
                 {title: 'Release Tutorial', path: '/developer/release_tutorial'}
             ]}
         ],

--- a/src/app/ui/common/error.service.js
+++ b/src/app/ui/common/error.service.js
@@ -24,7 +24,6 @@ function errorService($mdToast, $q) {
      *
      * @param {String | null} [id=null] id of the toast to remove; if not specified, the toast currently displayed will be removed
      * @param {Object} toastMsg is a promise object returned by the display function
-     * @returns
      */
     function remove(id = null, toastMsg) {
         // if the current toast is not defined, the queue is empty; return


### PR DESCRIPTION
## Description

Corrected technical documentation links in our hosted documentation. Bonus points for using regex 🏆 

Closes #2812

## Testing
https://ramp-docs.fgpv-vpgf.com/doc-test-01

## Documentation
None added

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2813)
<!-- Reviewable:end -->
