### PR TITLE
feat(ui): allow showing or hiding details fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6062,8 +6062,8 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#v2.5.0-3",
-      "from": "geoApi@github:fgpv-vpgf/geoApi#v2.5.0-3",
+      "version": "github:fgpv-vpgf/geoApi#v2.5.0-4",
+      "from": "geoApi@github:fgpv-vpgf/geoApi#v2.5.0-4",
       "requires": {
         "babel-cli": "^6.24.1",
         "babel-preset-env": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "datatables.net-select": "1.2.5",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.8",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-3",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-4",
     "imports-loader": "0.8.0",
     "linkifyjs": "2.1.6",
     "marked": "0.3.19",

--- a/src/app/ui/details/details-record-esrifeature-item.directive.js
+++ b/src/app/ui/details/details-record-esrifeature-item.directive.js
@@ -41,11 +41,11 @@ function rvDetailsRecordEsrifeatureItem(SymbologyStack, stateManager) {
         const index = self.requester.proxy.itemIndex
         // check for specified columns in config (in table)
         let includedColumns = [];
-        if (self.requester.proxy._source.initialConfig) {
-            const tableColumns = self.requester.proxy._source.initialConfig.table.columns;
+        if (self.requester.proxy._source.config) {
+            const tableColumns = self.requester.proxy._source.config.table.columns;
             includedColumns = tableColumns.map(col => col.data);
         }
-        let excludedColumns = ['SHAPE', 'rvSymbol', 'rvInteractive']; // anything that should be hidden by default
+        let excludedColumns = ['SHAPE', 'Shape', 'rvSymbol', 'rvInteractive']; // anything that should be hidden by default
         if (stateManager.display.details.hidden) {
             excludedColumns = excludedColumns.concat(stateManager.display.details.hidden[index]);
         }

--- a/src/app/ui/details/details-record-esrifeature-item.directive.js
+++ b/src/app/ui/details/details-record-esrifeature-item.directive.js
@@ -13,7 +13,7 @@ const templateUrl = require('./details-record-esrifeature-item.html');
  */
 angular.module('app.ui').directive('rvDetailsRecordEsrifeatureItem', rvDetailsRecordEsrifeatureItem);
 
-function rvDetailsRecordEsrifeatureItem(SymbologyStack) {
+function rvDetailsRecordEsrifeatureItem(SymbologyStack, stateManager) {
     const directive = {
         restrict: 'E',
         templateUrl,
@@ -38,15 +38,32 @@ function rvDetailsRecordEsrifeatureItem(SymbologyStack) {
     function link(scope, el) {
         const self = scope.self;
 
-        const excludedColumns = ['rvSymbol', 'rvInteractive'];
+        const index = self.requester.proxy.itemIndex
+        // check for specified columns in config (in table)
+        let includedColumns = [];
+        if (self.requester.proxy._source.initialConfig) {
+            const tableColumns = self.requester.proxy._source.initialConfig.table.columns;
+            includedColumns = tableColumns.map(col => col.data);
+        }
+        let excludedColumns = ['SHAPE', 'rvSymbol', 'rvInteractive']; // anything that should be hidden by default
+        if (stateManager.display.details.hidden) {
+            excludedColumns = excludedColumns.concat(stateManager.display.details.hidden[index]);
+        }
 
         self.isExpanded = self.solorecord;
         self.isRendered = self.solorecord;
 
         // pre-filter the columns used by the datagrid out of the returned data
-        self.item.data = self.item.data.filter(column => excludedColumns.indexOf(column.key) === -1);
+        // if there specific columns for the table set by the config use them
+        if (includedColumns.length) {
+            self.item.data = self.item.data.filter(column => includedColumns.indexOf(column.field) > -1);
+        }
+        // filter out any items hidden in the table
+        self.item.data = self.item.data.filter(column => excludedColumns.indexOf(column.field) === -1);
 
-        self.templateUrl = self.requester.proxy._source.config._source.templateUrl;
+        if (self.requester.proxy._source.config) {
+            self.templateUrl = self.requester.proxy._source.config._source.templateUrl;
+        }
         if (self.templateUrl) {
             // creates an object from the details array of {field.key: field.value, etc.}
             // for use in the template

--- a/src/app/ui/table/table-setting-panel.directive.js
+++ b/src/app/ui/table/table-setting-panel.directive.js
@@ -158,6 +158,7 @@ function Controller($scope, events, tableService, stateManager, $timeout) {
         $scope.columns = self.columns;
         self.title = stateManager.display.table.data.filter.title;
         self.tableService.isSettingOpen = false;
+        self.index = stateManager.display.table.requester.legendEntry.itemIndex;
 
         self.sortStatus = sortStatus;
         self.sortAll = sortAll;
@@ -175,13 +176,18 @@ function Controller($scope, events, tableService, stateManager, $timeout) {
      */
     function init() {
         sortColumns();
-
+        const index = self.index.toString();
         // toggle the visibility
+        // also toggles visisbility for details panel
+        let hiddenColumns = [];
         self.columns.forEach(column => {
             if (!column.display) {
                 self.tableService.getTable().column(`${column.name}:name`).visible(false);
+                hiddenColumns.push(column.data);
             }
         });
+        stateManager.display.details.hidden = stateManager.display.details.hidden || {};
+        stateManager.display.details.hidden[index] = hiddenColumns;
     }
 
     /**
@@ -275,6 +281,18 @@ function Controller($scope, events, tableService, stateManager, $timeout) {
     function onDisplay(columnInfo) {
         // get column
         const column = self.tableService.getTable().column(`${columnInfo.name}:name`);
+
+        // toggle the visibility in the details panel
+        const layerIndex = self.index.toString();
+        let hidden = stateManager.display.details.hidden[layerIndex];
+        if (!columnInfo.display) {
+            hidden.push(columnInfo.data);
+        } else {
+            let index = hidden.indexOf(columnInfo.data);
+            if (index > -1) {
+                hidden.splice(index, 1);
+            }
+        }
 
         // toggle the visibility and class name use to show/hide collumn when export or print
         column.visible(columnInfo.display);


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2485 #2803 

Allows showing or hiding details fields in the identify details. 
By default `SHAPE`, `Shape`, `rvSymbol`, `rvInteractive` are hidden.
The table columns specified to show in the config will also apply to the details in the details panel. 
Columns hidden using the table settings will also be hidden in the details panel. 

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
:eyes:
In `index.samples` configs `1, 6, 7, 40, and 68` are good for checking various cases. 

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
in-line commenting 
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2818)
<!-- Reviewable:end -->
