### PR TITLE
perf(plugin): thumbnails, noPicture opt in config

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -830,7 +830,7 @@
                 "scaleBar": { "type": "object" },
                 "basemap": { "type": "object" },
                 "areaOfInterest": {
-                     "type": "array",
+                     "type": "object",
                      "items": {
                          "type": "object",
                          "properties": {

--- a/src/content/samples/config/config-sample-64.json
+++ b/src/content/samples/config/config-sample-64.json
@@ -1,517 +1,524 @@
 {
-   "ui": {
-     "navBar": {
-       "zoom": "buttons",
-       "extra": [
-         "fullscreen",
-         "geoLocator",
-         "home",
-         "help"
-       ]
-     },
-     "sideMenu": {
-       "items":[["layers","basemap"],["fullscreen","export","share","touch","help","about"],["language"],["plugins"]],
-       "logo": true
-     },
-     "about":{ "content":"-- placeholder --" },
-     "help": { "folderName": "default" },
-     "legend": {
-       "isOpen": {
-         "large": false,
-         "medium": false,
-         "small": false
-       }
-     }
-   },
-   "version": "2.0",
-   "language": "en",
-   "services": {
-     "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-     "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-     "export": {
-       "title": {
-         "value": "Title"
-       },
-       "map": {},
-       "mapElements": {},
-       "legend":{},
-       "footnote": {
-         "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
-       }
-     },
-     "search": {
-       "serviceUrls": {
-         "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
-         "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
-         "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-         "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
-         "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
-       }
-     }
-   },
-   "map": {
-     "initialBasemapId": "baseNrCan",
-     "components": {
-       "geoSearch": {
-         "enabled": true,
-         "showGraphic": false,
-         "showInfo": false
-       },
-       "mouseInfo": {
-         "enabled": true,
-         "spatialReference": {
-           "wkid": 4326
-         }
-       },
-       "northArrow": {
-         "enabled": true
-       },
-       "basemap": {
-         "enabled": true
-       },
-       "overviewMap": {
-         "enabled": true,
-         "layerType": "imagery"
-       },
-       "scaleBar": {
-         "enabled": true
-     },
-     "areaOfInterest": [{
-        "title": "My first area",
-        "xmin": -100,
-        "xmax": -90,
-        "ymin": 50,
-        "ymax": 60,
-        "thumbnailUrl": ""
-     },
-     {
-        "title": "My second area",
-        "xmin": -76,
-        "xmax": -75,
-        "ymin": 45,
-        "ymax": 46,
-        "thumbnailUrl": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268"
-     },{
-        "title": "My third area",
-        "xmin": -76,
-        "xmax": -75,
-        "ymin": 45,
-        "ymax": 46,
-        "thumbnailUrl": ""
-     },{
-        "title": "My last area",
-        "xmin": -76,
-        "xmax": -75,
-        "ymin": 45,
-        "ymax": 46,
-        "thumbnailUrl": ""
-     }]
-     },
-     "extentSets": [
-       {
-         "id": "EXT_NRCAN_Lambert_3978",
-         "default": {
-           "xmax": 3549492,
-           "xmin": -2681457,
-           "ymax": 3482193,
-           "ymin": -883440
-         },
-         "spatialReference": {
-           "wkid": 3978
-         }
-       },
-       {
-         "id": "EXT_ESRI_World_AuxMerc_3857",
-         "default": {
-           "xmax": -5007771.626060756,
-           "xmin": -16632697.354854,
-           "ymax": 10015875.184845109,
-           "ymin": 5022907.964742964
-         },
-         "spatialReference": {
-           "wkid": 102100,
-           "latestWkid": 3857
-         }
-       }
-     ],
-     "lodSets": [
-       {
-         "id": "LOD_NRCAN_Lambert_3978",
-         "lods": [
-           {
-             "level": 0,
-             "resolution": 38364.660062653464,
-             "scale": 145000000
-           },
-           {
-             "level": 1,
-             "resolution": 22489.62831258996,
-             "scale": 85000000
-           },
-           {
-             "level": 2,
-             "resolution": 13229.193125052918,
-             "scale": 50000000
-           },
-           {
-             "level": 3,
-             "resolution": 7937.5158750317505,
-             "scale": 30000000
-           },
-           {
-             "level": 4,
-             "resolution": 4630.2175937685215,
-             "scale": 17500000
-           },
-           {
-             "level": 5,
-             "resolution": 2645.8386250105837,
-             "scale": 10000000
-           },
-           {
-             "level": 6,
-             "resolution": 1587.5031750063501,
-             "scale": 6000000
-           },
-           {
-             "level": 7,
-             "resolution": 926.0435187537042,
-             "scale": 3500000
-           },
-           {
-             "level": 8,
-             "resolution": 529.1677250021168,
-             "scale": 2000000
-           },
-           {
-             "level": 9,
-             "resolution": 317.50063500127004,
-             "scale": 1200000
-           },
-           {
-             "level": 10,
-             "resolution": 185.20870375074085,
-             "scale": 700000
-           },
-           {
-             "level": 11,
-             "resolution": 111.12522225044451,
-             "scale": 420000
-           },
-           {
-             "level": 12,
-             "resolution": 66.1459656252646,
-             "scale": 250000
-           },
-           {
-             "level": 13,
-             "resolution": 38.36466006265346,
-             "scale": 145000
-           },
-           {
-             "level": 14,
-             "resolution": 22.48962831258996,
-             "scale": 85000
-           },
-           {
-             "level": 15,
-             "resolution": 13.229193125052918,
-             "scale": 50000
-           },
-           {
-             "level": 16,
-             "resolution": 7.9375158750317505,
-             "scale": 30000
-           },
-           {
-             "level": 17,
-             "resolution": 4.6302175937685215,
-             "scale": 17500
-           }
-         ]
-       },
-       {
-         "id": "LOD_ESRI_World_AuxMerc_3857",
-         "lods": [
-           {
-             "level": 0,
-             "resolution": 19567.87924099992,
-             "scale": 73957190.948944
-           },
-           {
-             "level": 1,
-             "resolution": 9783.93962049996,
-             "scale": 36978595.474472
-           },
-           {
-             "level": 2,
-             "resolution": 4891.96981024998,
-             "scale": 18489297.737236
-           },
-           {
-             "level": 3,
-             "resolution": 2445.98490512499,
-             "scale": 9244648.868618
-           },
-           {
-             "level": 4,
-             "resolution": 1222.992452562495,
-             "scale": 4622324.434309
-           },
-           {
-             "level": 5,
-             "resolution": 611.4962262813797,
-             "scale": 2311162.217155
-           },
-           {
-             "level": 6,
-             "resolution": 305.74811314055756,
-             "scale": 1155581.108577
-           },
-           {
-             "level": 7,
-             "resolution": 152.87405657041106,
-             "scale": 577790.554289
-           },
-           {
-             "level": 8,
-             "resolution": 76.43702828507324,
-             "scale": 288895.277144
-           },
-           {
-             "level": 9,
-             "resolution": 38.21851414253662,
-             "scale": 144447.638572
-           },
-           {
-             "level": 10,
-             "resolution": 19.10925707126831,
-             "scale": 72223.819286
-           },
-           {
-             "level": 11,
-             "resolution": 9.554628535634155,
-             "scale": 36111.909643
-           },
-           {
-             "level": 12,
-             "resolution": 4.77731426794937,
-             "scale": 18055.954822
-           },
-           {
-             "level": 13,
-             "resolution": 2.388657133974685,
-             "scale": 9027.977411
-           },
-           {
-             "level": 14,
-             "resolution": 1.1943285668550503,
-             "scale": 4513.988705
-           },
-           {
-             "level": 15,
-             "resolution": 0.5971642835598172,
-             "scale": 2256.994353
-           },
-           {
-             "level": 16,
-             "resolution": 0.29858214164761665,
-             "scale": 1128.497176
-           },
-           {
-             "level": 17,
-             "resolution": 0.14929107082380833,
-             "scale": 564.248588
-           },
-           {
-             "level": 18,
-             "resolution": 0.07464553541190416,
-             "scale": 282.124294
-           },
-           {
-             "level": 19,
-             "resolution": 0.03732276770595208,
-             "scale": 141.062147
-           },
-           {
-             "level": 20,
-             "resolution": 0.01866138385297604,
-             "scale": 70.5310735
-           }
-         ]
-       }
-     ],
-     "legend": {
-       "type": "autopopulate"
-     },
-     "layers": [
-         {
-           "id": "powerplant100mw-electric",
-           "name": "Electric Transmission Line",
-           "layerType": "esriFeature",
-           "state": {
-             "visibility": false,
-             "boundingBox": false
-           },
-           "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/1"
-         }
-     ],
-     "tileSchemas": [
-       {
-         "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
-         "name": "Lambert Maps",
-         "extentSetId": "EXT_NRCAN_Lambert_3978",
-         "lodSetId": "LOD_NRCAN_Lambert_3978",
-        "hasNorthPole": true
-       },
-       {
-         "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-         "name": "Web Mercator Maps",
-         "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-         "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
-       }
-     ],
-     "baseMaps": [
-       {
-         "id": "baseNrCan",
-         "name": "Canada Base Map - Transportation (CBMT)",
-         "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-         "altText": "altText - The Canada Base Map - Transportation (CBMT)",
-         "layers": [
-           {
-             "id": "CBMT",
-             "layerType": "esriFeature",
-             "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
-           }
-         ],
-         "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-       },
-       {
-         "id": "baseSimple",
-         "name": "Canada Base Map - Simple",
-         "description": "Canada Base Map - Simple",
-         "altText": "altText - Canada base map - Simple",
-         "layers": [
-           {
-             "id": "SMR",
-             "layerType": "esriFeature",
-             "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
-           }
-         ],
-         "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-       },
-       {
-         "id": "baseCBME_CBCE_HS_RO_3978",
-         "name": "Canada Base Map - Elevation (CBME)",
-         "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
-         "altText": "altText - Canada Base Map - Elevation (CBME)",
-         "layers": [
-           {
-             "id": "CBME_CBCE_HS_RO_3978",
-             "layerType": "esriFeature",
-             "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
-           }
-         ],
-         "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-       },
-       {
-         "id": "baseCBMT_CBCT_GEOM_3978",
-         "name": "Canada Base Map - Transportation (CBMT)",
-         "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
-         "altText": "altText - Canada Base Map - Transportation (CBMT)",
-         "layers": [
-           {
-             "id": "CBMT_CBCT_GEOM_3978",
-             "layerType": "esriFeature",
-             "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
-           }
-         ],
-         "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
-       },
-       {
-         "id": "baseEsriWorld",
-         "name": "World Imagery",
-         "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
-         "altText": "altText - World Imagery",
-         "layers": [
-           {
-             "id": "World_Imagery",
-             "layerType": "esriFeature",
-             "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
-           }
-         ],
-         "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-       },
-       {
-         "id": "baseEsriPhysical",
-         "name": "World Physical Map",
-         "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
-         "altText": "altText - World Physical Map",
-         "layers": [
-           {
-             "id": "World_Physical_Map",
-             "layerType": "esriFeature",
-             "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
-           }
-         ],
-         "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-       },
-       {
-         "id": "baseEsriRelief",
-         "name": "World Shaded Relief",
-         "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
-         "altText": "altText - World Shaded Relief",
-         "layers": [
-           {
-             "id": "World_Shaded_Relief",
-             "layerType": "esriFeature",
-             "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
-           }
-         ],
-         "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-       },
-       {
-         "id": "baseEsriStreet",
-         "name": "World Street Map",
-         "description": "This worldwide street map presents highway-level data for the world.",
-         "altText": "altText - ESWorld Street Map",
-         "layers": [
-           {
-             "id": "World_Street_Map",
-             "layerType": "esriFeature",
-             "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
-           }
-         ],
-         "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-       },
-       {
-         "id": "baseEsriTerrain",
-         "name": "World Terrain Base",
-         "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
-         "altText": "altText - World Terrain Base",
-         "layers": [
-           {
-             "id": "World_Terrain_Base",
-             "layerType": "esriFeature",
-             "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
-           }
-         ],
-         "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-       },
-       {
-         "id": "baseEsriTopo",
-         "name": "World Topographic Map",
-         "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
-         "altText": "altText - World Topographic Map",
-         "layers": [
-           {
-             "id": "World_Topo_Map",
-             "layerType": "esriFeature",
-             "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-           }
-         ],
-         "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-       }
-     ]
-   }
- }
+  "ui": {
+    "navBar": {
+      "zoom": "buttons",
+      "extra": [
+        "fullscreen",
+        "geoLocator",
+        "home",
+        "help"
+      ]
+    },
+    "sideMenu": {
+      "items":[["layers","basemap"],["fullscreen","export","share","touch","help","about"],["language"],["plugins"]],
+      "logo": true
+    },
+    "about":{ "content":"-- placeholder --" },
+    "help": { "folderName": "default" },
+    "legend": {
+      "isOpen": {
+        "large": false,
+        "medium": false,
+        "small": false
+      }
+    }
+  },
+  "version": "2.0",
+  "language": "en",
+  "services": {
+    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+    "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+    "export": {
+      "title": {
+        "value": "Title"
+      },
+      "map": {},
+      "mapElements": {},
+      "legend":{},
+      "footnote": {
+        "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+      }
+    },
+    "search": {
+      "serviceUrls": {
+        "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
+        "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
+        "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+        "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
+        "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+      }
+    }
+  },
+  "map": {
+    "initialBasemapId": "baseNrCan",
+    "components": {
+      "geoSearch": {
+        "enabled": true,
+        "showGraphic": false,
+        "showInfo": false
+      },
+      "mouseInfo": {
+        "enabled": true,
+        "spatialReference": {
+          "wkid": 4326
+        }
+      },
+      "northArrow": {
+        "enabled": true
+      },
+      "basemap": {
+        "enabled": true
+      },
+      "overviewMap": {
+        "enabled": true,
+        "layerType": "imagery"
+      },
+      "scaleBar": {
+        "enabled": true
+    },
+    "areaOfInterest": {
+      "areas": [
+        {
+          "title": "Reservoir Manicougan, Quebec, Canada",
+          "xmin": -69,
+          "xmax": -68,
+          "ymin": 51,
+          "ymax": 53,
+          "thumbnailUrl": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268"
+        },
+        {
+          "title": "New Jersey, USA",
+          "xmin": -76,
+          "xmax": -72,
+          "ymin": 41,
+          "ymax": 41,
+          "thumbnailUrl": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/295/269"
+        },
+        {
+          "title": "Washington, DC, USA",
+          "xmin": -77,
+          "xmax": -77,
+          "ymin": 38,
+          "ymax": 40,
+          "thumbnailUrl": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/296/267"
+        },
+        {
+          "title": "Delaware, USA",
+          "xmin": -75,
+          "xmax": -75,
+          "ymin": 38,
+          "ymax": 40,
+          "thumbnailUrl": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/296/268"
+        }
+      ],
+      "noPicture": false
+    }
+    },
+    "extentSets": [
+      {
+        "id": "EXT_NRCAN_Lambert_3978",
+        "default": {
+          "xmax": 3549492,
+          "xmin": -2681457,
+          "ymax": 3482193,
+          "ymin": -883440
+        },
+        "spatialReference": {
+          "wkid": 3978
+        }
+      },
+      {
+        "id": "EXT_ESRI_World_AuxMerc_3857",
+        "default": {
+          "xmax": -5007771.626060756,
+          "xmin": -16632697.354854,
+          "ymax": 10015875.184845109,
+          "ymin": 5022907.964742964
+        },
+        "spatialReference": {
+          "wkid": 102100,
+          "latestWkid": 3857
+        }
+      }
+    ],
+    "lodSets": [
+      {
+        "id": "LOD_NRCAN_Lambert_3978",
+        "lods": [
+          {
+            "level": 0,
+            "resolution": 38364.660062653464,
+            "scale": 145000000
+          },
+          {
+            "level": 1,
+            "resolution": 22489.62831258996,
+            "scale": 85000000
+          },
+          {
+            "level": 2,
+            "resolution": 13229.193125052918,
+            "scale": 50000000
+          },
+          {
+            "level": 3,
+            "resolution": 7937.5158750317505,
+            "scale": 30000000
+          },
+          {
+            "level": 4,
+            "resolution": 4630.2175937685215,
+            "scale": 17500000
+          },
+          {
+            "level": 5,
+            "resolution": 2645.8386250105837,
+            "scale": 10000000
+          },
+          {
+            "level": 6,
+            "resolution": 1587.5031750063501,
+            "scale": 6000000
+          },
+          {
+            "level": 7,
+            "resolution": 926.0435187537042,
+            "scale": 3500000
+          },
+          {
+            "level": 8,
+            "resolution": 529.1677250021168,
+            "scale": 2000000
+          },
+          {
+            "level": 9,
+            "resolution": 317.50063500127004,
+            "scale": 1200000
+          },
+          {
+            "level": 10,
+            "resolution": 185.20870375074085,
+            "scale": 700000
+          },
+          {
+            "level": 11,
+            "resolution": 111.12522225044451,
+            "scale": 420000
+          },
+          {
+            "level": 12,
+            "resolution": 66.1459656252646,
+            "scale": 250000
+          },
+          {
+            "level": 13,
+            "resolution": 38.36466006265346,
+            "scale": 145000
+          },
+          {
+            "level": 14,
+            "resolution": 22.48962831258996,
+            "scale": 85000
+          },
+          {
+            "level": 15,
+            "resolution": 13.229193125052918,
+            "scale": 50000
+          },
+          {
+            "level": 16,
+            "resolution": 7.9375158750317505,
+            "scale": 30000
+          },
+          {
+            "level": 17,
+            "resolution": 4.6302175937685215,
+            "scale": 17500
+          }
+        ]
+      },
+      {
+        "id": "LOD_ESRI_World_AuxMerc_3857",
+        "lods": [
+          {
+            "level": 0,
+            "resolution": 19567.87924099992,
+            "scale": 73957190.948944
+          },
+          {
+            "level": 1,
+            "resolution": 9783.93962049996,
+            "scale": 36978595.474472
+          },
+          {
+            "level": 2,
+            "resolution": 4891.96981024998,
+            "scale": 18489297.737236
+          },
+          {
+            "level": 3,
+            "resolution": 2445.98490512499,
+            "scale": 9244648.868618
+          },
+          {
+            "level": 4,
+            "resolution": 1222.992452562495,
+            "scale": 4622324.434309
+          },
+          {
+            "level": 5,
+            "resolution": 611.4962262813797,
+            "scale": 2311162.217155
+          },
+          {
+            "level": 6,
+            "resolution": 305.74811314055756,
+            "scale": 1155581.108577
+          },
+          {
+            "level": 7,
+            "resolution": 152.87405657041106,
+            "scale": 577790.554289
+          },
+          {
+            "level": 8,
+            "resolution": 76.43702828507324,
+            "scale": 288895.277144
+          },
+          {
+            "level": 9,
+            "resolution": 38.21851414253662,
+            "scale": 144447.638572
+          },
+          {
+            "level": 10,
+            "resolution": 19.10925707126831,
+            "scale": 72223.819286
+          },
+          {
+            "level": 11,
+            "resolution": 9.554628535634155,
+            "scale": 36111.909643
+          },
+          {
+            "level": 12,
+            "resolution": 4.77731426794937,
+            "scale": 18055.954822
+          },
+          {
+            "level": 13,
+            "resolution": 2.388657133974685,
+            "scale": 9027.977411
+          },
+          {
+            "level": 14,
+            "resolution": 1.1943285668550503,
+            "scale": 4513.988705
+          },
+          {
+            "level": 15,
+            "resolution": 0.5971642835598172,
+            "scale": 2256.994353
+          },
+          {
+            "level": 16,
+            "resolution": 0.29858214164761665,
+            "scale": 1128.497176
+          },
+          {
+            "level": 17,
+            "resolution": 0.14929107082380833,
+            "scale": 564.248588
+          },
+          {
+            "level": 18,
+            "resolution": 0.07464553541190416,
+            "scale": 282.124294
+          },
+          {
+            "level": 19,
+            "resolution": 0.03732276770595208,
+            "scale": 141.062147
+          },
+          {
+            "level": 20,
+            "resolution": 0.01866138385297604,
+            "scale": 70.5310735
+          }
+        ]
+      }
+    ],
+    "legend": {
+      "type": "autopopulate"
+    },
+    "layers": [
+        {
+          "id": "powerplant100mw-electric",
+          "name": "Electric Transmission Line",
+          "layerType": "esriFeature",
+          "state": {
+            "visibility": false,
+            "boundingBox": false
+          },
+          "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/1"
+        }
+    ],
+    "tileSchemas": [
+      {
+        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+        "name": "Lambert Maps",
+        "extentSetId": "EXT_NRCAN_Lambert_3978",
+        "lodSetId": "LOD_NRCAN_Lambert_3978",
+       "hasNorthPole": true
+      },
+      {
+        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+        "name": "Web Mercator Maps",
+        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+      }
+    ],
+    "baseMaps": [
+      {
+        "id": "baseNrCan",
+        "name": "Canada Base Map - Transportation (CBMT)",
+        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+        "layers": [
+          {
+            "id": "CBMT",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseSimple",
+        "name": "Canada Base Map - Simple",
+        "description": "Canada Base Map - Simple",
+        "altText": "altText - Canada base map - Simple",
+        "layers": [
+          {
+            "id": "SMR",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseCBME_CBCE_HS_RO_3978",
+        "name": "Canada Base Map - Elevation (CBME)",
+        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+        "altText": "altText - Canada Base Map - Elevation (CBME)",
+        "layers": [
+          {
+            "id": "CBME_CBCE_HS_RO_3978",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseCBMT_CBCT_GEOM_3978",
+        "name": "Canada Base Map - Transportation (CBMT)",
+        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+        "altText": "altText - Canada Base Map - Transportation (CBMT)",
+        "layers": [
+          {
+            "id": "CBMT_CBCT_GEOM_3978",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseEsriWorld",
+        "name": "World Imagery",
+        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+        "altText": "altText - World Imagery",
+        "layers": [
+          {
+            "id": "World_Imagery",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriPhysical",
+        "name": "World Physical Map",
+        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+        "altText": "altText - World Physical Map",
+        "layers": [
+          {
+            "id": "World_Physical_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriRelief",
+        "name": "World Shaded Relief",
+        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+        "altText": "altText - World Shaded Relief",
+        "layers": [
+          {
+            "id": "World_Shaded_Relief",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriStreet",
+        "name": "World Street Map",
+        "description": "This worldwide street map presents highway-level data for the world.",
+        "altText": "altText - ESWorld Street Map",
+        "layers": [
+          {
+            "id": "World_Street_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriTerrain",
+        "name": "World Terrain Base",
+        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+        "altText": "altText - World Terrain Base",
+        "layers": [
+          {
+            "id": "World_Terrain_Base",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriTopo",
+        "name": "World Topographic Map",
+        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+        "altText": "altText - World Topographic Map",
+        "layers": [
+          {
+            "id": "World_Topo_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      }
+    ]
+  }
+}

--- a/src/content/samples/config/config-sample-73.json
+++ b/src/content/samples/config/config-sample-73.json
@@ -1,0 +1,547 @@
+{
+    "ui": {
+      "navBar": {
+        "zoom": "buttons",
+        "extra": [
+          "fullscreen",
+          "geoLocator",
+          "home",
+          "help"
+        ]
+      },
+      "sideMenu": {
+        "items": [
+          [
+            "layers",
+            "basemap"
+          ],
+          [
+            "fullscreen",
+            "export",
+            "share",
+            "touch",
+            "help",
+            "about"
+          ],
+          [
+            "language"
+          ],
+          [
+            "plugins"
+          ]
+        ],
+        "logo": true
+      },
+      "about": {
+        "content": "-- placeholder --"
+      },
+      "help": {
+        "folderName": "default"
+      },
+      "legend": {
+        "isOpen": {
+          "large": false,
+          "medium": false,
+          "small": false
+        }
+      }
+    },
+    "version": "2.0",
+    "language": "en",
+    "services": {
+      "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+      "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+      "export": {
+        "title": {
+          "value": "Title"
+        },
+        "map": {},
+        "mapElements": {},
+        "legend": {},
+        "footnote": {
+          "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+        }
+      },
+      "search": {
+        "serviceUrls": {
+          "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
+          "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
+          "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+          "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
+          "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+        }
+      }
+    },
+    "map": {
+      "initialBasemapId": "baseNrCan",
+      "components": {
+        "geoSearch": {
+          "enabled": true,
+          "showGraphic": false,
+          "showInfo": false
+        },
+        "mouseInfo": {
+          "enabled": true,
+          "spatialReference": {
+            "wkid": 4326
+          }
+        },
+        "northArrow": {
+          "enabled": true
+        },
+        "basemap": {
+          "enabled": true
+        },
+        "overviewMap": {
+          "enabled": true,
+          "layerType": "imagery"
+        },
+        "scaleBar": {
+          "enabled": true
+        },
+        "areaOfInterest": {
+          "areas": [
+            {
+              "title": "Reservoir Manicougan, Quebec, Canada",
+              "xmin": -69,
+              "xmax": -68,
+              "ymin": 51,
+              "ymax": 53,
+              "thumbnailUrl": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268"
+            },
+            {
+              "title": "New Jersey, USA",
+              "xmin": -76,
+              "xmax": -72,
+              "ymin": 41,
+              "ymax": 41,
+              "thumbnailUrl": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/295/269"
+            },
+            {
+              "title": "Washington, DC, USA",
+              "xmin": -77,
+              "xmax": -77,
+              "ymin": 38,
+              "ymax": 40,
+              "thumbnailUrl": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/296/267"
+            },
+            {
+              "title": "Delaware, USA",
+              "xmin": -75,
+              "xmax": -75,
+              "ymin": 38,
+              "ymax": 40,
+              "thumbnailUrl": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/296/268"
+            }
+          ],
+          "noPicture": true
+        }
+      },
+      "extentSets": [
+        {
+          "id": "EXT_NRCAN_Lambert_3978",
+          "default": {
+            "xmax": 3549492,
+            "xmin": -2681457,
+            "ymax": 3482193,
+            "ymin": -883440
+          },
+          "spatialReference": {
+            "wkid": 3978
+          }
+        },
+        {
+          "id": "EXT_ESRI_World_AuxMerc_3857",
+          "default": {
+            "xmax": -5007771.626060756,
+            "xmin": -16632697.354854,
+            "ymax": 10015875.184845109,
+            "ymin": 5022907.964742964
+          },
+          "spatialReference": {
+            "wkid": 102100,
+            "latestWkid": 3857
+          }
+        }
+      ],
+      "lodSets": [
+        {
+          "id": "LOD_NRCAN_Lambert_3978",
+          "lods": [
+            {
+              "level": 0,
+              "resolution": 38364.660062653464,
+              "scale": 145000000
+            },
+            {
+              "level": 1,
+              "resolution": 22489.62831258996,
+              "scale": 85000000
+            },
+            {
+              "level": 2,
+              "resolution": 13229.193125052918,
+              "scale": 50000000
+            },
+            {
+              "level": 3,
+              "resolution": 7937.5158750317505,
+              "scale": 30000000
+            },
+            {
+              "level": 4,
+              "resolution": 4630.2175937685215,
+              "scale": 17500000
+            },
+            {
+              "level": 5,
+              "resolution": 2645.8386250105837,
+              "scale": 10000000
+            },
+            {
+              "level": 6,
+              "resolution": 1587.5031750063501,
+              "scale": 6000000
+            },
+            {
+              "level": 7,
+              "resolution": 926.0435187537042,
+              "scale": 3500000
+            },
+            {
+              "level": 8,
+              "resolution": 529.1677250021168,
+              "scale": 2000000
+            },
+            {
+              "level": 9,
+              "resolution": 317.50063500127004,
+              "scale": 1200000
+            },
+            {
+              "level": 10,
+              "resolution": 185.20870375074085,
+              "scale": 700000
+            },
+            {
+              "level": 11,
+              "resolution": 111.12522225044451,
+              "scale": 420000
+            },
+            {
+              "level": 12,
+              "resolution": 66.1459656252646,
+              "scale": 250000
+            },
+            {
+              "level": 13,
+              "resolution": 38.36466006265346,
+              "scale": 145000
+            },
+            {
+              "level": 14,
+              "resolution": 22.48962831258996,
+              "scale": 85000
+            },
+            {
+              "level": 15,
+              "resolution": 13.229193125052918,
+              "scale": 50000
+            },
+            {
+              "level": 16,
+              "resolution": 7.9375158750317505,
+              "scale": 30000
+            },
+            {
+              "level": 17,
+              "resolution": 4.6302175937685215,
+              "scale": 17500
+            }
+          ]
+        },
+        {
+          "id": "LOD_ESRI_World_AuxMerc_3857",
+          "lods": [
+            {
+              "level": 0,
+              "resolution": 19567.87924099992,
+              "scale": 73957190.948944
+            },
+            {
+              "level": 1,
+              "resolution": 9783.93962049996,
+              "scale": 36978595.474472
+            },
+            {
+              "level": 2,
+              "resolution": 4891.96981024998,
+              "scale": 18489297.737236
+            },
+            {
+              "level": 3,
+              "resolution": 2445.98490512499,
+              "scale": 9244648.868618
+            },
+            {
+              "level": 4,
+              "resolution": 1222.992452562495,
+              "scale": 4622324.434309
+            },
+            {
+              "level": 5,
+              "resolution": 611.4962262813797,
+              "scale": 2311162.217155
+            },
+            {
+              "level": 6,
+              "resolution": 305.74811314055756,
+              "scale": 1155581.108577
+            },
+            {
+              "level": 7,
+              "resolution": 152.87405657041106,
+              "scale": 577790.554289
+            },
+            {
+              "level": 8,
+              "resolution": 76.43702828507324,
+              "scale": 288895.277144
+            },
+            {
+              "level": 9,
+              "resolution": 38.21851414253662,
+              "scale": 144447.638572
+            },
+            {
+              "level": 10,
+              "resolution": 19.10925707126831,
+              "scale": 72223.819286
+            },
+            {
+              "level": 11,
+              "resolution": 9.554628535634155,
+              "scale": 36111.909643
+            },
+            {
+              "level": 12,
+              "resolution": 4.77731426794937,
+              "scale": 18055.954822
+            },
+            {
+              "level": 13,
+              "resolution": 2.388657133974685,
+              "scale": 9027.977411
+            },
+            {
+              "level": 14,
+              "resolution": 1.1943285668550503,
+              "scale": 4513.988705
+            },
+            {
+              "level": 15,
+              "resolution": 0.5971642835598172,
+              "scale": 2256.994353
+            },
+            {
+              "level": 16,
+              "resolution": 0.29858214164761665,
+              "scale": 1128.497176
+            },
+            {
+              "level": 17,
+              "resolution": 0.14929107082380833,
+              "scale": 564.248588
+            },
+            {
+              "level": 18,
+              "resolution": 0.07464553541190416,
+              "scale": 282.124294
+            },
+            {
+              "level": 19,
+              "resolution": 0.03732276770595208,
+              "scale": 141.062147
+            },
+            {
+              "level": 20,
+              "resolution": 0.01866138385297604,
+              "scale": 70.5310735
+            }
+          ]
+        }
+      ],
+      "legend": {
+        "type": "autopopulate"
+      },
+      "layers": [
+        {
+          "id": "powerplant100mw-electric",
+          "name": "Electric Transmission Line",
+          "layerType": "esriFeature",
+          "state": {
+            "visibility": false,
+            "boundingBox": false
+          },
+          "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/1"
+        }
+      ],
+      "tileSchemas": [
+        {
+          "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+          "name": "Lambert Maps",
+          "extentSetId": "EXT_NRCAN_Lambert_3978",
+          "lodSetId": "LOD_NRCAN_Lambert_3978",
+          "hasNorthPole": true
+        },
+        {
+          "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+          "name": "Web Mercator Maps",
+          "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+          "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+        }
+      ],
+      "baseMaps": [
+        {
+          "id": "baseNrCan",
+          "name": "Canada Base Map - Transportation (CBMT)",
+          "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+          "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+          "layers": [
+            {
+              "id": "CBMT",
+              "layerType": "esriFeature",
+              "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseSimple",
+          "name": "Canada Base Map - Simple",
+          "description": "Canada Base Map - Simple",
+          "altText": "altText - Canada base map - Simple",
+          "layers": [
+            {
+              "id": "SMR",
+              "layerType": "esriFeature",
+              "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseCBME_CBCE_HS_RO_3978",
+          "name": "Canada Base Map - Elevation (CBME)",
+          "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+          "altText": "altText - Canada Base Map - Elevation (CBME)",
+          "layers": [
+            {
+              "id": "CBME_CBCE_HS_RO_3978",
+              "layerType": "esriFeature",
+              "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseCBMT_CBCT_GEOM_3978",
+          "name": "Canada Base Map - Transportation (CBMT)",
+          "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+          "altText": "altText - Canada Base Map - Transportation (CBMT)",
+          "layers": [
+            {
+              "id": "CBMT_CBCT_GEOM_3978",
+              "layerType": "esriFeature",
+              "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseEsriWorld",
+          "name": "World Imagery",
+          "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+          "altText": "altText - World Imagery",
+          "layers": [
+            {
+              "id": "World_Imagery",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriPhysical",
+          "name": "World Physical Map",
+          "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+          "altText": "altText - World Physical Map",
+          "layers": [
+            {
+              "id": "World_Physical_Map",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriRelief",
+          "name": "World Shaded Relief",
+          "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+          "altText": "altText - World Shaded Relief",
+          "layers": [
+            {
+              "id": "World_Shaded_Relief",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriStreet",
+          "name": "World Street Map",
+          "description": "This worldwide street map presents highway-level data for the world.",
+          "altText": "altText - ESWorld Street Map",
+          "layers": [
+            {
+              "id": "World_Street_Map",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriTerrain",
+          "name": "World Terrain Base",
+          "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+          "altText": "altText - World Terrain Base",
+          "layers": [
+            {
+              "id": "World_Terrain_Base",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriTopo",
+          "name": "World Topographic Map",
+          "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+          "altText": "altText - World Topographic Map",
+          "layers": [
+            {
+              "id": "World_Topo_Map",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        }
+      ]
+    }
+  }

--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -155,7 +155,8 @@
                 <option value="config/config-sample-61.json">61. Layer with fields not searchable and default values for filters</option>
                 <option value="config/config-sample-62.json">62. Custom attribution (text, image and link)</option>
                 <option value="config/config-sample-63.json">63. Tile layer</option>
-                <option value="config/config-sample-64.json">64. Side menu Area of interest plugin</option>
+                <option value="config/config-sample-64.json">64. a) Side menu Area of interest plugin (Pictures Enabled)</option>
+                <option value="config/config-sample-73.json">64. b) Side menu Area of interest plugin (No Pictures)</option>
                 <option value="config/config-sample-65.json">65. Basemap with opacity set on layers</option>
                 <option value="config/config-sample-66.json">66. Map with navigation restricted</option>
                 <option value="">67. Map with no config provided</option>

--- a/src/plugins/core/area-of-interest.js
+++ b/src/plugins/core/area-of-interest.js
@@ -17,13 +17,14 @@
     let dialogWindow;
     let addStyle = false;
     const zones = [];
+
     class AreaOfInterest extends RV.BasePlugins.MenuItem {
 
         /**
          * Returns a function to be executed when the link is clicked.
          * @return  {Function}    Callback to be executed when link is clicked
          */
-        onMenuItemClick () {
+        onMenuItemClick() {
             return () => {
                 this.api.toggleSideNav('close');
 
@@ -33,8 +34,23 @@
                     let img = (zone.thumbnailUrl !== '') ? zone.thumbnailUrl :
                         `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgpMwidZAAAD+UlEQVRoBe1YPWgUQRTO/aiVEPAwRbSx9g9TCWpzoiZg4Q9RSCUIp9hIQEkuuZDcJRG1i9UZsRBEjGgKwUQlBi3FHxQbg5pKMXIR5ZqQ4+78ns4kk2X29r3dbYI3sMybed/73nvzt7Pb0FAv9RH4v0cgElb6IyMj64rF4r5qtXooEonsBm8Tnma0y6jn0PcN9Us8E6VS6Xl/f/8i5MAllASGhobaEeg1RLORGdF34M739vbeZeJdYYESQOBNCPwm2NtcPdRWTGBmTvX09MzVhrlrfSeQy+UOwPltUCfc6VmaAgahI5PJPGGhHSBfCVDw0Wh0Eo592TtiaMBAVCuVShuSmHTqvNriAAYHB5tB+gFPoxe5UP8L+K3YF18ldlEJmLAYrTuowg6eqBsVN8nsIkpgeHj4OJbNXja7EEjcmOFjEjNRAnBwWULuB4tZuCKxYyeQzWZbkMAWJvk4AtmP9Ryhh2TYjXNsyQf54mAJE+cCEcRhDha4PpzrOROL9hTaU3hvZBBg1tTZZOXrtU3n7GPPAI7NPU5jS3vCGbyJUbpHZp9NRgLsfcZOAI4225yZfXB81WzbZMyAJwY8m2y2tj52AnDsSYpLmue0l8vlN7ZAHH30rmEVdgIYFfFLjxWBHcSOiw3EDBTsvpZ7Y7HYruWWXeJgOL40OzsBTMAnbeRWA3PRTaf7gbmgZbea40vbshPAqLzVRjXqVrxJ+9z0Sud59Wb6+uuG/R4A+gWeTrfgjP4BBLoTo5jHsfmY+nH+H0RQKYhHDFwtkXyxCntj5vP5NYVCYR6BrGcx+wQh8WIikdiQSqVKHAr2EiJCBB/4E9ArKPgY4wZPXOwElONRrwBC0F+XcLCXkCbF+n4Hebtuh1y/x+Vvh4RTOgP0QXNJ4kCC9cMtTgDXhTEENSsJjImdVdxM+D+YOAH8kKrgZso5TmWBgJO4RUYAi/eAdoC98BQyfaiEUZ5h7Sf9EIlnQDvBLJyDLB4xba9rrPsq7kf0kvNVfCeQTqdn4PGGL6+GEc790e7ubs97lmGyQvSdALHE43G6vM2vYJQ1fioOmZWBDpRAV1fXb3CdNfik4hnFIbVbwgdKgFiw+e5hHd9aYmQKZEO2TLgrLHACxIzzm2bho6sXhwLBzygbh0be9H2MOl3hX842nEyv0L/WqXO0F5FAC67a9H81cIkFZlAE09PTP5LJJO2JVg/OTiydhx4Ytjq0GdAe8fFyH0fjUd02a4z8A4y86N+naW+TQ9kDJjHWdgfan80+khH8F6VzqgK1Q08A95kFRHQSD9W6LGBWTiid7gulDj0BigprnDZzO0a9TA/Jqo/Uq6dgP5ymZ/VEXI+0PgKrbwT+AFIjLxu3HbkQAAAAAElFTkSuQmCC`;
 
-                    zoneList +=
-                        `<li class="rv-basemap-list-item" style="height: 300px;">
+                    //if thumbnail pictures disabled show list of areas as black buttons
+                    if (this.noPic) {
+                        zoneList +=
+                            `<li class="rv-basemap-list-item" style="height: 50px;">
+                            <div style="position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; height: 100%">
+                                <div style="max-height: 50px; max-width: 300px; text-align: center;"></div>
+                                <div class="rv-basemap-footer"><span>${zone.title}</span></div>
+                                    <button class="rv-body-button rv-button-square md-button md-ink-ripple"
+                                        type="button" aria-label="bookmark" ng-click="self.setExtent(${zone.xmin}, ${zone.xmax}, ${zone.ymin}, ${zone.ymax})">
+                                        <div class="md-ripple-container" style=""></div>
+                                    </button>
+                                </div>
+                        </li>`;
+                    }
+                    else {
+                        zoneList +=
+                            `<li class="rv-basemap-list-item" style="height: 300px;">
                             <div style="position: relative; display: flex; align-items: center; justify-content: center; overflow: hidden; height: 100%">
                                 <div style="max-height: 300px; max-width: 300px; text-align: center;"><img alt="" src="${img}"/></div>
                                 <div class="rv-basemap-footer"><span>${zone.title}</span></div>
@@ -44,6 +60,7 @@
                                     </button>
                                 </div>
                         </li>`;
+                    }
                 }
 
                 // set controller locals
@@ -74,12 +91,15 @@
             };
         }
 
-        init (template) {
+        init(template) {
             self = this.api;
 
             // get list of areas of interest on load
             // if there is no areaOfInterest inside config, object value is { enabled: true } so replace with []
-            let zoneList = this.api.getConfig('map').components.areaOfInterest._source;
+            //also get option to enable/disable thumbnail pictures
+            let zoneList = this.api.getConfig('map').components.areaOfInterest._source.areas;
+            this.noPic = this.api.getConfig('map').components.areaOfInterest._source.noPicture;
+
             zoneList = zoneList.enabled ? [] : zoneList;
             for (let zone of zoneList) {
                 zones.push(zone);
@@ -89,6 +109,7 @@
             this.translations = translations;
             this.action = this.onMenuItemClick();
         }
+
     }
 
     /**


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Addresses second and third bullet points in #2787. This PR is to be used as a "save point" before functionality is moved to an extension using the Panels API.

- `noPicture` option added to `areaOfInterest`
- Thumbnails and extents should work for Sample 64
- No thumbnails are shown for Sample 73 (but same extents/descriptions as 64)

## Testing
Samples 64 (Pictures enabled) and 73 (Pictures disabled)

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated ***(Not applicable)***

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2829)
<!-- Reviewable:end -->
