### PR TITLE
fix(ui): custom templating uses $watchCollection

### DIFF
--- a/api/src/schema.d.ts
+++ b/api/src/schema.d.ts
@@ -42,7 +42,7 @@ export type LegendEntryControls = (
   | "settings"
   | "data"
   | "styles")[];
-export type LayerNode = BasicLayerNode | FeatureLayerNode | WmsLayerNode | DynamicLayerNode;
+export type LayerNode = BasicLayerNode | FeatureLayerNode | WfsLayerNode | WmsLayerNode | DynamicLayerNode;
 export type SymbologyStack = {
   image: string;
   text: string;
@@ -71,6 +71,10 @@ export type InfoSection =
        * An optional style, describes how the symbology stack should be rendered
        */
       symbologyRenderStyle?: "icons" | "images";
+      /**
+       * Indicates if symbology stack is expand by default
+       */
+      symbologyExpanded?: boolean;
     }
   | {
       infoType?: "text";
@@ -193,6 +197,10 @@ export interface FgpvConfigSchema {
      * Google API key to enable geo location and share link shortening.
      */
     googleAPIKey?: string;
+    /**
+     * ESRI JavaSCript API endpoint. Note, we can't use a version greater than v3.22
+     */
+    esriLibUrl?: string;
     /**
      * FIXME
      */
@@ -620,6 +628,10 @@ export interface TileSchemaNode {
      */
     refreshInterval?: number;
     /**
+     * The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer.
+     */
+    expectedResponseTime?: number;
+    /**
      * The metadata url of the layer service
      */
     metadataUrl?: string;
@@ -648,7 +660,15 @@ export interface TileSchemaNode {
       | "data"
       | "styles")[];
     state?: InitialLayerSettings;
+    /**
+     * A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc.
+     */
+    templateUrl?: string;
   };
+  /**
+   * Indicates if the map projection includes a north pole.  Defaults to false to avoid errors.
+   */
+  hasNorthPole?: boolean;
 }
 export interface ExtentWithReferenceNode {
   xmin: number;
@@ -772,6 +792,10 @@ export interface BasicLayerNode {
    */
   refreshInterval?: number;
   /**
+   * The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer.
+   */
+  expectedResponseTime?: number;
+  /**
    * The metadata url of the layer service
    */
   metadataUrl?: string;
@@ -800,6 +824,10 @@ export interface BasicLayerNode {
     | "data"
     | "styles")[];
   state?: InitialLayerSettings;
+  /**
+   * A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc.
+   */
+  templateUrl?: string;
 }
 export interface FeatureLayerNode {
   /**
@@ -822,6 +850,10 @@ export interface FeatureLayerNode {
    * The automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes.
    */
   refreshInterval?: number;
+  /**
+   * The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer.
+   */
+  expectedResponseTime?: number;
   /**
    * The metadata url of the layer service
    */
@@ -887,6 +919,10 @@ export interface FeatureLayerNode {
      */
     columns?: ColumnNode[];
   };
+  /**
+   * A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc.
+   */
+  templateUrl?: string;
 }
 /**
  * Specifies option for each column. OID field must be present, if not data will not appear. The order they appears inside the table is the same as the order of this array.
@@ -939,6 +975,81 @@ export interface FilterNode {
    */
   static?: boolean;
 }
+export interface WfsLayerNode {
+  /**
+   * The id of the layer for referencing within the viewer (does not relate directly to any external service)
+   */
+  id: string;
+  /**
+   * The display name of the layer.  If it is not present the viewer will make an attempt to scrape this information.
+   */
+  name?: string;
+  /**
+   * The display field of the layer.  If it is not present the viewer will make an attempt to scrape this information.
+   */
+  nameField?: string;
+  /**
+   * The service endpoint of the layer.  It should match the type provided in layerType.
+   */
+  url: string;
+  /**
+   * The hex code representing the layer symbology colour.
+   */
+  colour?: string;
+  layerType: "ogcWfs";
+  /**
+   * Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer
+   */
+  tolerance?: number;
+  extent?: ExtentWithReferenceNode;
+  controls?: LegendEntryControls;
+  /**
+   * A list of controls which are visible, but disabled for user modification
+   */
+  disabledControls?: (
+    | "opacity"
+    | "visibility"
+    | "boundingBox"
+    | "query"
+    | "snapshot"
+    | "metadata"
+    | "boundaryZoom"
+    | "refresh"
+    | "reload"
+    | "remove"
+    | "settings"
+    | "data"
+    | "styles")[];
+  state?: InitialLayerSettings;
+  /**
+   * Settings for the table
+   */
+  table?: {
+    /**
+     * Specifies the table title to apply.
+     */
+    title?: string;
+    /**
+     * Specifies the additional information to display in the setting panel to give more information about a table.
+     */
+    description?: string;
+    /**
+     * Specifies the default table size when first open. True: maximize view; False: split view.
+     */
+    maximize?: boolean;
+    search?: {
+      [k: string]: any;
+    };
+    /**
+     * Specifies if the default filters (from columns filter) are apply to the map (definition query). True: it is applied; False: it is not applied.
+     */
+    applyMap?: boolean;
+    /**
+     * Specifies the array of columns for the table. When there is an item in this array, it will be use to define wich and how column will be set for the table. If a column is not in the array it will be assume as disabled.
+     */
+    columns?: ColumnNode[];
+  };
+}
 export interface WmsLayerNode {
   /**
    * The id of the layer for referencing within the viewer (does not relate directly to any external service)
@@ -956,6 +1067,10 @@ export interface WmsLayerNode {
    * The automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes.
    */
   refreshInterval?: number;
+  /**
+   * The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer.
+   */
+  expectedResponseTime?: number;
   /**
    * The metadata url of the layer service
    */
@@ -994,6 +1109,14 @@ export interface WmsLayerNode {
     | "data"
     | "styles")[];
   state?: InitialLayerSettings;
+  /**
+   * A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc.
+   */
+  templateUrl?: string;
+  /**
+   * A path to a javascript file with a function for parsing the layers identify output. Only needed if a custom template is being used.
+   */
+  parserUrl?: string;
 }
 export interface WmsLayerEntryNode {
   /**
@@ -1032,6 +1155,10 @@ export interface DynamicLayerNode {
    * The automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes.
    */
   refreshInterval?: number;
+  /**
+   * The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer.
+   */
+  expectedResponseTime?: number;
   /**
    * The metadata url of the layer service
    */
@@ -1078,6 +1205,10 @@ export interface DynamicLayerNode {
    * The format of the layer image output. It should only be in one of png, png8, png28, png32, jpg, pdf, bmp, gif, svg.  Defaults to png32 if not provided
    */
   imageFormat?: "png" | "png8" | "png24" | "png32" | "jpg" | "pdf" | "bmp" | "gif" | "svg";
+  /**
+   * A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc.
+   */
+  templateUrl?: string;
 }
 export interface DynamicLayerEntryNode {
   /**
@@ -1188,4 +1319,8 @@ export interface Entry {
    * An optional style, describes how the symbology stack should be rendered
    */
   symbologyRenderStyle?: "icons" | "images";
+  /**
+   * Indicates if symbology stack is expand by default
+   */
+  symbologyExpanded?: boolean;
 }

--- a/docs/user/details_templating.md
+++ b/docs/user/details_templating.md
@@ -20,10 +20,10 @@ Your template would include `<h1>{{ self.layer['Country'] }}</h1>`
 
 These are plain Javascript functions of the form
 ```
-function(*data*){
+function(*data*, *lang*){
     //...use data
     return *objectMadeFromData*
 }
 ```
 
-The function should expect the data in the form of a string, and whatever your function returns will be given to you on `self.layer` to use in your template.
+The function should expect the data in the form of a string, and whatever your function returns will be given to you on `self.layer` to use in your template. The current language code is passed to the parser function as the second argument and is also avaialbe on the scope as `self.lang`.

--- a/src/content/samples/templates/test-script.js
+++ b/src/content/samples/templates/test-script.js
@@ -1,1 +1,4 @@
-function parser(stuff) {return {"Country": "Canada"}}
+function parser(stuff, lang) {
+    console.log(lang);
+    return { Country: 'Canada' };
+}

--- a/src/content/samples/templates/test-template.1.html
+++ b/src/content/samples/templates/test-template.1.html
@@ -8,3 +8,4 @@
 <p>{{self.layer['Country']}}</p>
 
 
+{{ self.lang }}

--- a/src/content/samples/templates/test-template.html
+++ b/src/content/samples/templates/test-template.html
@@ -6,3 +6,5 @@
 <p>{{self.layer['Country']}}</p>
 
 <img src="./about/indexOne/images/canada.png"></img>
+
+{{ self.lang }}


### PR DESCRIPTION
## Description

Use $watchCollection to watch for resolving identify requests in custom templating directive. Using $watch on an array does not fire when elements are added or removed. Also pass the current language value to the parser function and its template, so the output can be tailored to the current locale.

Relates #2814

## Testing
:eye: 

## Documentation
Updated.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2836)
<!-- Reviewable:end -->
