### PR TITLE
feat(details): allow parsers for feature layer details output

### DIFF
--- a/api/src/schema.d.ts
+++ b/api/src/schema.d.ts
@@ -661,6 +661,10 @@ export interface TileSchemaNode {
       | "styles")[];
     state?: InitialLayerSettings;
     /**
+     * A path to a javascript file with a function for parsing the layers identify output. Only needed if a custom template is being used.
+     */
+    parserUrl?: string;
+    /**
      * A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc.
      */
     templateUrl?: string;
@@ -825,6 +829,10 @@ export interface BasicLayerNode {
     | "styles")[];
   state?: InitialLayerSettings;
   /**
+   * A path to a javascript file with a function for parsing the layers identify output. Only needed if a custom template is being used.
+   */
+  parserUrl?: string;
+  /**
    * A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc.
    */
   templateUrl?: string;
@@ -919,6 +927,10 @@ export interface FeatureLayerNode {
      */
     columns?: ColumnNode[];
   };
+  /**
+   * A path to a javascript file with a function for parsing the layers identify output. Only needed if a custom template is being used.
+   */
+  parserUrl?: string;
   /**
    * A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc.
    */
@@ -1049,6 +1061,14 @@ export interface WfsLayerNode {
      */
     columns?: ColumnNode[];
   };
+  /**
+   * A path to a javascript file with a function for parsing the layers identify output. Only needed if a custom template is being used.
+   */
+  parserUrl?: string;
+  /**
+   * A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc.
+   */
+  templateUrl?: string;
 }
 export interface WmsLayerNode {
   /**

--- a/schema.json
+++ b/schema.json
@@ -555,6 +555,7 @@
                 "controls": { "$ref": "#/definitions/legendEntryControls" },
                 "disabledControls": { "$ref": "#/definitions/legendEntryControls", "description": "A list of controls which are blocked from modification either by the user or programmatically. These controls can be visible or not as defined in the `controls` array." },
                 "state": { "$ref": "#/definitions/initialLayerSettings" },
+                "parserUrl": {"type": "string", "description": "A path to a javascript file with a function for parsing the layers identify output. Only needed if a custom template is being used."},
                 "templateUrl": { "type": "string", "description": "A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc."}
             },
             "required": [ "id", "layerType", "url" ],
@@ -579,6 +580,7 @@
                 "disabledControls": { "$ref": "#/definitions/legendEntryControls", "description": "A list of controls which are visible, but disabled for user modification" },
                 "state": { "$ref": "#/definitions/initialLayerSettings" },
                 "table": { "$ref": "#/definitions/tableNode", "description": "Settings for the table" },
+                "parserUrl": {"type": "string", "description": "A path to a javascript file with a function for parsing the layers identify output. Only needed if a custom template is being used."},
                 "templateUrl": { "type": "string", "description": "A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc."}
             },
             "required": [ "id", "layerType", "url" ],
@@ -598,7 +600,9 @@
                 "controls": { "$ref": "#/definitions/legendEntryControls" },
                 "disabledControls": { "$ref": "#/definitions/legendEntryControls", "description": "A list of controls which are visible, but disabled for user modification" },
                 "state": { "$ref": "#/definitions/initialLayerSettings" },
-                "table": { "$ref": "#/definitions/tableNode", "description": "Settings for the table" }
+                "table": { "$ref": "#/definitions/tableNode", "description": "Settings for the table" },
+                "parserUrl": {"type": "string", "description": "A path to a javascript file with a function for parsing the layers identify output. Only needed if a custom template is being used."},
+                "templateUrl": { "type": "string", "description": "A path to an html template that will override default identify output. The template can contain angular bindings, directives, etc."}
             },
             "required": [ "id", "layerType", "url" ],
             "additionalProperties": false

--- a/src/content/samples/config/config-sample-70.json
+++ b/src/content/samples/config/config-sample-70.json
@@ -355,6 +355,7 @@
             "boundingBox": false
           },
           "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/1",
+          "parserUrl": "templates/test-script.js",
           "templateUrl": "templates/test-template.1.html"
         }
       ],

--- a/src/content/samples/templates/test-script.js
+++ b/src/content/samples/templates/test-script.js
@@ -1,4 +1,4 @@
-function parser(stuff, lang) {
+function parser(data, lang) {
     console.log(lang);
-    return { Country: 'Canada' };
+    return { Country: 'Canada', 'Name of Pipeline': 'Parser output' };
 }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Initially an assumption was made that feature layers wouldn't need a parser as they return JSON, but there is still value in allowing a function to run before details output (like getting translation strings for a template, etc.)

## Testing
Sample 70, the electricity layer now runs a parser before displaying details

## Documentation
N/A

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~Release notes have been updated~
- [x] PR targets the correct release version
- [ ] ~Help files and documentation have been updated~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2846)
<!-- Reviewable:end -->
