### PR TITLE
fix(ui): basemap load failed error toast fixed

### DIFF
--- a/src/app/geo/overview-toggle.directive.js
+++ b/src/app/geo/overview-toggle.directive.js
@@ -53,7 +53,7 @@ function rvOverviewToggle($compile, $rootScope, geoService, $timeout, $translate
         });
 
         events.$on(events.rvMapLoaded, (_, mapI) => {
-            mapI.basemapGallery.on('error', basemapToast);
+            mapI.basemapGallery.onError = basemapToast;
         });
 
         const self = scope.self;


### PR DESCRIPTION
## Description
Displays a toast when the default or selected basemap has failed to load.

Closes #107

## Testing
👀 

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2849)
<!-- Reviewable:end -->
