### PR TITLE
fix(geo): WFS layers appear in Mercator Basemaps

### DIFF
--- a/src/app/geo/layer-blueprint.class.js
+++ b/src/app/geo/layer-blueprint.class.js
@@ -359,7 +359,7 @@ function LayerBlueprintFactory($q, gapiService, Geo, ConfigObject, configService
 
     const service = {
         buildLayer: layerSource => {
-            if (layerSource.type && _isFileOrWFSLayer(layerSource)) {   // file or WFS added through importer
+            if (layerSource.type && _isFile(layerSource)) {   // file or WFS added through importer
                 return new LayerFileBlueprint(null, layerSource);
             } else if (layerSource.config) {                            // service added through importer
                 return new LayerServiceBlueprint(null, layerSource);
@@ -383,14 +383,17 @@ function LayerBlueprintFactory($q, gapiService, Geo, ConfigObject, configService
     };
 
     /**
-     * Checks if the layer being added is a file layer or a WFS layer based on its type.
-     * @function _isFileOrWFSLayer
+     * Checks if the layer being added is a file layer
+     * @function _isFile
      * @private
      * @param {String} source a string representing the type of layer being added
      * @return {Boolean} true if the layer type matches one of the file layer constants
      */
-    function _isFileOrWFSLayer(source) {
+    function _isFile(source) {
         const fileTypes = [Geo.Service.Types.CSV, Geo.Service.Types.GeoJSON, Geo.Service.Types.Shapefile];
+        if (source.layerType && source.layerType === 'ogcWfs'){
+            return false;
+        }
         return (fileTypes.indexOf(source.type) !== -1);
     }
 


### PR DESCRIPTION
## Description
Closes #2837 

## Testing
http://fgpv.cloudapp.net/demo/users/ShrutiVellanki/mercator-projection/prod/samples/index-samples.html (Sample 68 - WFS Layers Defined in the Config)

All layers in default pre-added to Lambert Maps should be visible upon switch to Mercator Basemaps. 

User added layers imported from wizard (GeoJSON, CSV, Shapefiles) should load properly.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated ***(Not applicable)***

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2862)
<!-- Reviewable:end -->
