### PR TITLE
Fix race condition on wfs load

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "datatables.net-select": "1.2.5",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.8",
-    "geoApi": "github:fgpv-vpgf/geoApi#d34b27e",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-7",
     "imports-loader": "0.8.0",
     "linkifyjs": "2.1.6",
     "marked": "0.3.19",

--- a/src/app/ui/details/details-record-esrifeature-item.directive.js
+++ b/src/app/ui/details/details-record-esrifeature-item.directive.js
@@ -67,7 +67,7 @@ function rvDetailsRecordEsrifeatureItem(SymbologyStack, stateManager, detailServ
         if (self.requester.proxy._source.config) {
             self.details = self.requester.proxy._source.config.details;
         }
-        if (self.details.template) {
+        if (self.details && self.details.template) {
             detailService.getTemplate(self.requester.proxy._source.layerId, self.details.template).then(template => {
                 if (self.details.parser) {
                     detailService


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->

Fixes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2859 and a pile of other broken cases.

Recognizes when a WFS is loading from the config.
Pushes the service data requests to a separate thread (not on the Blueprint constructor thread).
Updates WFS Layer Record with real layer once separate thread finishes.
Layer loader will avoid attempting to add layer to map until things are actually ready.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Tested in RAMP - autolegend and structured legend.  Tested in CCCS viewer.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2865)
<!-- Reviewable:end -->
