### PR TITLE
Make legend wait for api layer blueprints

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -23,6 +23,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, stateManager, Le
     };
 
     let mApi = null;
+    const apiBlueprints = []; // blueprint promises from nonstandard sources. enables us to block legend on them as well
     events.$on(events.rvApiMapAdded, (_, api) => (mApi = api));
 
     // wire in a hook to any map for adding a layer through a JSON snippet. this makes it available on the API
@@ -110,7 +111,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, stateManager, Le
         });
 
         // all layer defintions are passed as config fragments - turning them into layer blueprints
-        const blueprintPromises = newDefinitions.map(createBlueprint);
+        const blueprintPromises = newDefinitions.map(createBlueprint).concat(apiBlueprints);
 
         // wait for all promises to resolve then show info
         Promise.all(blueprintPromises).then(() => {
@@ -134,6 +135,7 @@ function legendServiceFactory(Geo, ConfigObject, configService, stateManager, Le
      */
     function addLayerDefinition(layerDefinition, pos = null, addToLegend = true) {
         const blueprintPromise = createBlueprint(layerDefinition);
+        apiBlueprints.push(blueprintPromise);
         blueprintPromise.then(def => importLayerBlueprint(def, pos, addToLegend));
     }
 


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->

Legend waits on blueprints to be created. Layers added via the api had their blueprint promises lost.
Made change to catch them and make legend respect them

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Testing on viewer and CCCS


## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2867)
<!-- Reviewable:end -->
