### PR TITLE
Force invisible local wms to load

### DIFF
--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -295,9 +295,18 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
             layerRecord.addAttribListener(_onLayerAttribDownload);
             mapBody.addLayer(layerRecord._layer);
             ref.loadingCount ++;
-    
+
+            // TODO need better solution for local wms layers that don't "load" when invisible.
+            const localWms = layerRecord.dataSource() === 'wms' && layerRecord.config.suppressGetCapabilities;
+            if (localWms) {
+                layerRecord.onLoad();
+            }
+
             // HACK: for a file-based layer, call onLoad manually since such layers don't emmit events
-            if (layerRecord.state === Geo.Layer.States.LOADED || (layerRecord.dataSource() !== 'esri' && layerRecord._layer.loaded)) {
+            //       extending the hack to wms layers who are supressing a server handshake.
+            if (layerRecord.state === Geo.Layer.States.LOADED ||
+               (layerRecord.dataSource() !== 'esri' && layerRecord._layer.loaded) ||
+               (localWms)) {
                 isRefreshed = true;
                 _onLayerRecordInitialLoad('rv-loaded');
             }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->

WMS layers that omit a GetCapabilities, and initialize to invisible, never get to the `loaded` state.  The legend will show them as always loading (and not offer a visibility control).

Added some hack code to force it to loaded.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tested against RAMP samples (both auto & structured), and against CCCS viewer.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2873)
<!-- Reviewable:end -->
