### PR TITLE
fix(details): fix digests clashing, items not showing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11576,7 +11576,7 @@
       "integrity": "sha512-yo6qTpBQXnxhcPopKJeVwwOBRzUpEa3vzSFlr38f5mF4Jnfb6NOL/ePIomefWiZmPgkUblHpcwnWVMB8FS3GKw==",
       "requires": {
         "mgrs": "1.0.0",
-        "wkt-parser": "1.2.1"
+        "wkt-parser": "1.2.2"
       }
     },
     "promise": {
@@ -17167,9 +17167,9 @@
       }
     },
     "wkt-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.1.tgz",
-      "integrity": "sha512-c6iNYzlbWNXwtcZ+0DMy1AOSHxVKFPR4a8EBVOgVbDSeSEnz2gpicmXSnuql1tKgS67CY+ughyjprP8pckk5jg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.2.tgz",
+      "integrity": "sha512-2aCAsY3VIKraNfMnAU2HYQyPQUnyeBvwXZofBXTR/Cev1vbL5Q4/Nw47JEFvkLtBm96RtK6fQbdPmc1kk8uhMw=="
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/src/app/ui/details/details-record-esrifeature-item.directive.js
+++ b/src/app/ui/details/details-record-esrifeature-item.directive.js
@@ -13,7 +13,7 @@ const templateUrl = require('./details-record-esrifeature-item.html');
  */
 angular.module('app.ui').directive('rvDetailsRecordEsrifeatureItem', rvDetailsRecordEsrifeatureItem);
 
-function rvDetailsRecordEsrifeatureItem(SymbologyStack, stateManager, detailService, $translate, events, $compile) {
+function rvDetailsRecordEsrifeatureItem(SymbologyStack, stateManager, detailService, $translate, events, $compile, $timeout) {
     const directive = {
         restrict: 'E',
         templateUrl,
@@ -90,10 +90,9 @@ function rvDetailsRecordEsrifeatureItem(SymbologyStack, stateManager, detailServ
 
                 function compileTemplate() {
                     // push update so that template gets the info from the parser
-                    scope.$apply(() => {
+                    $timeout(() => {
                         // compile the template with the scope and append it to the mount
                         el.find('.template-mount').append($compile(template)(scope));
-                        console.log("lang", self.lang);
                     });
                 }
             });

--- a/src/app/ui/details/details-record-text.directive.js
+++ b/src/app/ui/details/details-record-text.directive.js
@@ -17,11 +17,13 @@ angular.module('app.ui').directive('rvDetailsRecordText', rvDetailsRecordText);
  *
  * @function rvDetailsRecordText
  * @param {object} $translate translation service
+ * @param {object} $compile
+ * @param {object} $timeout
  * @param {object} events events list
  * @param {object} detailService details service
  * @returns {object} directive body
  */
-function rvDetailsRecordText($translate, $compile, $templateCache, events, detailService) {
+function rvDetailsRecordText($translate, $compile, $timeout, events, detailService) {
     const directive = {
         restrict: 'E',
         templateUrl,
@@ -40,45 +42,52 @@ function rvDetailsRecordText($translate, $compile, $templateCache, events, detai
     /*****/
 
     function link(scope, el) {
-        const self = scope.self;
+        scope.$watch('self.item', () => {
+            const self = scope.self;
 
-        const l = self.item.requester.proxy._source;
+            const l = self.item.requester.proxy._source;
 
-        self.lang = $translate.use();
-        events.$on(events.rvLanguageChanged, () => (self.lang = $translate.use()));
+            self.lang = $translate.use();
+            events.$on(events.rvLanguageChanged, () => (self.lang = $translate.use()));
 
-        // get template to override basic details output, null/undefined => show default
-        self.details = l.config.details;
+            // get template to override basic details output, null/undefined => show default
+            self.details = l.config.details;
 
-        detailService.getTemplate(l.layerId, self.details.template).then(template => {
-            if (!self.details.parser) {
-                compileTemplate();
+            if (!self.details || !self.details.template) {
                 return;
             }
 
-            detailService.getParser(l.layerId, self.details.parser).then(parseFunction => {
-                // if data is already retrieved
-                if (self.item.data.length > 0) {
-                    parse();
-                } else {
-                    // data not here yet, wait for it
-                    scope.$watchCollection('self.item.data', parse);
+            detailService.getTemplate(l.layerId, self.details.template).then(template => {
+                if (!self.details.parser) {
+                    compileTemplate();
+                    return;
                 }
 
-                function parse() {
-                    // TODO: maybe instead of passing just the language, pass the full config
-                    self.layer = eval(`${parseFunction}(self.item.data[0], self.lang);`);
-                    compileTemplate();
+                detailService.getParser(l.layerId, self.details.parser).then(parseFunction => {
+                    // if data is already retrieved
+                    if (self.item.data.length > 0) {
+                        parse();
+                    } else {
+                        // data not here yet, wait for it
+                        scope.$watchCollection('self.item.data', parse);
+                    }
+
+                    function parse() {
+                        // TODO: maybe instead of passing just the language, pass the full config
+                        self.layer = eval(`${parseFunction}(self.item.data[0], self.lang);`);
+                        compileTemplate();
+                    }
+                });
+
+                function compileTemplate() {
+                    // Causes the template compilation to wait for next digest cycle
+                    // this ensures we have the data and don't display and "{{ VARIABLE }}"s
+                    $timeout(() =>{
+                        // compile the template with the scope and append it to the mount
+                        el.find('.template-mount').empty().append($compile(template)(scope));
+                    });
                 }
             });
-
-            function compileTemplate() {
-                // push update so that template gets the info from the parser
-                scope.$apply(() => {
-                    // compile the template with the scope and append it to the mount
-                    el.find('.template-mount').append($compile(template)(scope));
-                });
-            }
         });
     }
 }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Angular digest cycles would clash when running the `scope.$apply` before compiling the details template; replaced that with a `$timeout` that runs as soon as the current cycle is over. Additionally, some wms layers would not update their templates correctly; added a watch to force the link function to actually do something.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Tested multiple configs

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
in-line
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2874)
<!-- Reviewable:end -->
