### PR TITLE
chore(build): remove jQuery dependency

### DIFF
--- a/api/src/schema.d.ts
+++ b/api/src/schema.d.ts
@@ -66,6 +66,10 @@ export type InfoSection =
        * Optional description displayed above the symbology stack.
        */
       description?: string;
+      /**
+       * An optional icon, if present it will be used to primarily represent the layer
+       */
+      coverIcon?: string;
       symbologyStack?: SymbologyStack;
       /**
        * An optional style, describes how the symbology stack should be rendered

--- a/schema.json
+++ b/schema.json
@@ -384,6 +384,7 @@
                         "infoType": { "type": "string", "enum": [ "unboundLayer" ] },
                         "layerName": { "type": "string", "description": "Name to display in legend" },
                         "description": { "type": "string", "default": "", "description": "Optional description displayed above the symbology stack." },
+                        "coverIcon": { "type": "string", "description": "An optional icon, if present it will be used to primarily represent the layer" },
                         "symbologyStack": { "$ref": "#/definitions/symbologyStack" },
                         "symbologyRenderStyle": { "type": "string", "enum": [ "icons", "images" ], "description": "An optional style, describes how the symbology stack should be rendered" },
                         "symbologyExpanded": { "type": "boolean", "default": false, "description": "Indicates if symbology stack is expand by default" }

--- a/src/content/samples/index-fgp-en.tpl
+++ b/src/content/samples/index-fgp-en.tpl
@@ -508,6 +508,7 @@
     </footer>
 
     <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
+
     <script>
         // credit: http://stackoverflow.com/a/21903119
         function getUrlParameter(sParam) {

--- a/src/content/samples/index-many.tpl
+++ b/src/content/samples/index-many.tpl
@@ -82,6 +82,8 @@
             </div>
         </div>
 
+        <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+
         <script>
         var needIePolyfills = [
             'Promise' in window,

--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -191,6 +191,8 @@
         </noscript>
     </div>
 
+    <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+
     <script>
         var needIePolyfills = [
             'Promise' in window,

--- a/src/content/samples/index-theme.tpl
+++ b/src/content/samples/index-theme.tpl
@@ -36,6 +36,8 @@
         </noscript>
     </div>
 
+    <script src="https://code.jquery.com/jquery-3.3.1.js"></script>
+
     <script>
         var needIePolyfills = [
             'Promise' in window,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,30 +1,30 @@
-const webpack   = require('webpack');
-const path      = require('path');
-const fs        = require('fs');
-const glob      = require("glob");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const TranslationPlugin     = require('./scripts/webpack/translations_plugin.js');
+const webpack = require('webpack');
+const path = require('path');
+const fs = require('fs');
+const glob = require('glob');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const TranslationPlugin = require('./scripts/webpack/translations_plugin.js');
 const SchemaValidatorPlugin = require('./scripts/webpack/schema_validation_plugin.js');
-const CopyWebpackPlugin     = require('copy-webpack-plugin');
-const VersionPlugin         = require('./scripts/webpack/version_plugin.js');
-const WrapperPlugin         = require('wrapper-webpack-plugin');
-const CleanWebpackPlugin    = require('clean-webpack-plugin');
-const HtmlWebpackPlugin     = require('html-webpack-plugin');
-const WebpackShellPlugin    = require('webpack-shell-plugin');
-const BundleAnalyzerPlugin  = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const VersionPlugin = require('./scripts/webpack/version_plugin.js');
+const WrapperPlugin = require('wrapper-webpack-plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const WebpackShellPlugin = require('webpack-shell-plugin');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const babelPresets = {
     presets: ['env', 'stage-2'],
     cacheDirectory: true
-}
+};
 
-module.exports = function (env) {
-
-    const geoPath = env.geoLocal ?
-        env.geoLocal.length > 0 ?
-            env.geoLocal :
-            path.resolve(__dirname, '../', 'geoApi') :
-        path.resolve(__dirname, 'node_modules/geoApi');
+// eslint-disable-next-line complexity
+module.exports = function(env) {
+    const geoPath = env.geoLocal
+        ? env.geoLocal.length > 0
+            ? env.geoLocal
+            : path.resolve(__dirname, '../', 'geoApi')
+        : path.resolve(__dirname, 'node_modules/geoApi');
 
     const config = {
         entry: {
@@ -41,36 +41,46 @@ module.exports = function (env) {
                 {
                     test: /\.js$/,
                     include: [path.resolve(__dirname, 'src/app'), path.resolve(__dirname, 'src/plugins'), geoPath],
-                    use: [{
-                        loader: 'ng-annotate-loader'
-                    }, {
-                        loader: 'babel-loader',
-                        options: babelPresets
-                    }, {
-                        loader: 'eslint-loader'
-                    }]
-                },
-                {
-                    test: /\.ts$/,
-                    include: [path.resolve(__dirname, 'intention'), path.resolve(__dirname, 'api'), path.resolve(__dirname, 'src/app')],
-                    use: [{
-                        loader: 'babel-loader',
-                        options: babelPresets
-                    }, {
-                        loader: 'ts-loader'
-                    }]
-                },
-                {
-                    test: /\.s?[ac]ss$/,
                     use: [
-                        env.hmr ? 'style-loader' : MiniCssExtractPlugin.loader,
-                        'css-loader',
-                        'sass-loader'
+                        {
+                            loader: 'ng-annotate-loader'
+                        },
+                        {
+                            loader: 'babel-loader',
+                            options: babelPresets
+                        },
+                        {
+                            loader: 'eslint-loader'
+                        }
                     ]
                 },
                 {
+                    test: /\.ts$/,
+                    include: [
+                        path.resolve(__dirname, 'intention'),
+                        path.resolve(__dirname, 'api'),
+                        path.resolve(__dirname, 'src/app')
+                    ],
+                    use: [
+                        {
+                            loader: 'babel-loader',
+                            options: babelPresets
+                        },
+                        {
+                            loader: 'ts-loader'
+                        }
+                    ]
+                },
+                {
+                    test: /\.s?[ac]ss$/,
+                    use: [env.hmr ? 'style-loader' : MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader']
+                },
+                {
                     test: /\.html$/,
-                    use: ['ngtemplate-loader?relativeTo=' + (path.resolve(__dirname, './src/app')), 'html-loader?minimize=false']
+                    use: [
+                        'ngtemplate-loader?relativeTo=' + path.resolve(__dirname, './src/app'),
+                        'html-loader?minimize=false'
+                    ]
                 },
                 {
                     test: /\.(png|svg)$/,
@@ -85,29 +95,30 @@ module.exports = function (env) {
 
         plugins: [
             new MiniCssExtractPlugin({
-                filename: "rv-styles.css"
+                filename: 'rv-styles.css'
             }),
 
-            new webpack.ContextReplacementPlugin(
-                /moment[\/\\]locale$/,
-                /en|fr/
-            ),
+            new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en|fr/),
 
-            new CopyWebpackPlugin([{
-                context: 'src/content/samples',
-                from: '**/*.+(json|js|css|html)',
-                to: 'samples'
-            },{
-                from: 'src/locales/about',
-                to: 'samples/about'
-            },{
-                from: 'src/locales/help',
-                to: 'samples/help'
-            },
-            {
-                from: 'src/polyfill/ie-polyfills.js',
-                to: ''
-            }]),
+            new CopyWebpackPlugin([
+                {
+                    context: 'src/content/samples',
+                    from: '**/*.+(json|js|css|html)',
+                    to: 'samples'
+                },
+                {
+                    from: 'src/locales/about',
+                    to: 'samples/about'
+                },
+                {
+                    from: 'src/locales/help',
+                    to: 'samples/help'
+                },
+                {
+                    from: 'src/polyfill/ie-polyfills.js',
+                    to: ''
+                }
+            ]),
 
             new webpack.ProvidePlugin({
                 $: 'jquery',
@@ -118,8 +129,10 @@ module.exports = function (env) {
             new TranslationPlugin('./src/locales/translations.csv'),
 
             new WrapperPlugin({
-                header: fileName => /^rv-main\.js$/.test(fileName) ? fs.readFileSync('./scripts/webpack/header.js', 'utf8') : '',
-                footer: fileName => /^rv-main\.js$/.test(fileName) ? fs.readFileSync('./scripts/webpack/footer.js', 'utf8') : ''
+                header: fileName =>
+                    /^rv-main\.js$/.test(fileName) ? fs.readFileSync('./scripts/webpack/header.js', 'utf8') : '',
+                footer: fileName =>
+                    /^rv-main\.js$/.test(fileName) ? fs.readFileSync('./scripts/webpack/footer.js', 'utf8') : ''
             }),
 
             new VersionPlugin(),
@@ -130,7 +143,11 @@ module.exports = function (env) {
         ],
 
         resolve: {
-            modules: [path.resolve(__dirname, 'node_modules'), path.resolve(geoPath, 'node_modules'), path.resolve(__dirname, 'intention/node_modules')],
+            modules: [
+                path.resolve(__dirname, 'node_modules'),
+                path.resolve(geoPath, 'node_modules'),
+                path.resolve(__dirname, 'intention/node_modules')
+            ],
             alias: {
                 XSLT: path.resolve(__dirname, 'src/content/metadata/'),
                 jquery: 'jquery/src/jquery', // so webpack builds from src and not dist - optional but good to have
@@ -160,22 +177,29 @@ module.exports = function (env) {
             port: 6001,
             stats: { colors: true },
             compress: true
+        },
+
+        externals: {
+            jquery: 'jQuery'
         }
     };
 
-    const files = glob.sync("samples/**/*", {cwd: './src/content/', nodir: true});
-    config.plugins.push(...files.map(file => {
-        if (/\.tpl$/.test(file)) {
-            const filePath = file.split('/');
-            const fileName = filePath.pop();
-            return new HtmlWebpackPlugin({
-                inject: false,
-                filename: `${filePath.join('/')}/${fileName.replace(/\.[^/.]+$/, '.html')}`,
-                template: `src/content/${file}`,
-                excludeChunks: ['ie-polyfills']
-            });
-        }
-        }).filter(x => x)
+    const files = glob.sync('samples/**/*', { cwd: './src/content/', nodir: true });
+    config.plugins.push(
+        ...files
+            .map(file => {
+                if (/\.tpl$/.test(file)) {
+                    const filePath = file.split('/');
+                    const fileName = filePath.pop();
+                    return new HtmlWebpackPlugin({
+                        inject: false,
+                        filename: `${filePath.join('/')}/${fileName.replace(/\.[^/.]+$/, '.html')}`,
+                        template: `src/content/${file}`,
+                        excludeChunks: ['ie-polyfills']
+                    });
+                }
+            })
+            .filter(x => x)
     );
 
     // not supported while doing hmr - causes memory leaks and slows build time by ~40%
@@ -184,7 +208,7 @@ module.exports = function (env) {
     }
 
     if (env.inspect) {
-        config.plugins.push(new BundleAnalyzerPlugin({openAnalyzer: false, generateStatsFile: true}));
+        config.plugins.push(new BundleAnalyzerPlugin({ openAnalyzer: true, generateStatsFile: true }));
     }
 
     if (env.geoLocal) {
@@ -192,4 +216,4 @@ module.exports = function (env) {
     }
 
     return config;
-}
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,4 +9,4 @@
 */
 module.exports = function(env = {}) {
     return require(`./webpack.${env.prod ? 'prod' : 'dev'}.js`)(env);
-}
+};


### PR DESCRIPTION
## Description
Removes jQuery from the production bundle saving ~99 Kb. Adds jQuery scripts to sample pages; they don't work anymore otherwise.

- with jQuery: 2610 Kb
- without jQuery: 2511 Kb

This is pretty much a breaking change.

Relates #2562, #2554

## Testing
:roll_eyes: 

## Documentation
Not required.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~~[ ] Help files and documentation have been updated~~ (Not required)

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2883)
<!-- Reviewable:end -->
