### PR TITLE
fix(plugin): fix plugin to not throw an error when not in use

### DIFF
--- a/src/plugins/core/area-of-interest.js
+++ b/src/plugins/core/area-of-interest.js
@@ -99,10 +99,11 @@
             //also get option to enable/disable thumbnail pictures
             let zoneList = this.api.getConfig('map').components.areaOfInterest._source.areas;
             this.noPic = this.api.getConfig('map').components.areaOfInterest._source.noPicture;
-
-            zoneList = zoneList.enabled ? [] : zoneList;
-            for (let zone of zoneList) {
-                zones.push(zone);
+            if (zoneList) {
+                zoneList = zoneList.enabled ? [] : zoneList;
+                for (let zone of zoneList) {
+                    zones.push(zone);
+                }
             }
 
             this.name = 'areaButtonLabel';


### PR DESCRIPTION
## Description
Area of interest plugin threw error when not used on the map. This is now fixed.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Test sample 64 a and b (plugin defined) and compare it to rest of the samples. No errors from this file should be thrown. 

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Not applicable

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated ***(Not applicable)***

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2884)
<!-- Reviewable:end -->
