### PR TITLE
Prevent legends with same layer from disappearing after layer was reloaded

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -276,29 +276,27 @@ function legendServiceFactory(Geo, ConfigObject, configService, stateManager, Le
 
             const layerRecord = layerRegistry.getLayerRecord(legendBlockConfig.layerId);
 
-            if (!promise) { // ensure only one promise is created
-                // need time to reload children for Dynamic layers
-                promise = common.$q((resolve, reject) => {
-                    layerRecord.addStateListener(_onLayerRecordLoad);
+            // need time to reload children for Dynamic layers
+            promise = common.$q((resolve, reject) => {
+                layerRecord.addStateListener(_onLayerRecordLoad);
 
-                    function _onLayerRecordLoad(state) {
-                        // add back entry
-                        if (state === 'rv-loaded' || state === 'rv-error') {
-                            layerRecord.removeStateListener(_onLayerRecordLoad);
+                function _onLayerRecordLoad(state) {
+                    // add back entry
+                    if (state === 'rv-loaded' || state === 'rv-error') {
+                        layerRecord.removeStateListener(_onLayerRecordLoad);
 
-                            _boundingBoxRemoval(legendBlock);
+                        _boundingBoxRemoval(legendBlock);
 
-                            legendBlockParent.addEntry(reloadedLegendBlock, index);
-                        }
-
-                        if (state === 'rv-loaded') {
-                            resolve(legendBlockParent);
-                        } else if (state === 'rv-error') {
-                            reject(layerRecord.name);
-                        }
+                        legendBlockParent.addEntry(reloadedLegendBlock, index);
                     }
-                });
-            }
+
+                    if (state === 'rv-loaded') {
+                        resolve(legendBlockParent);
+                    } else if (state === 'rv-error') {
+                        reject(layerRecord.name);
+                    }
+                }
+            });
         });
 
         return promise;


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2657 

Fix the issue where Legends with the same layers would disappear if one of them was reloaded through the UI setting.
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Reload [sample 8](http://fgpv.cloudapp.net/demo/users/barryytm/2657/dev/samples/index-samples.html)
## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers
