### PR TITLE
Broken opacity setting when initial opacity is 0

### DIFF
--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -1127,6 +1127,13 @@ function LegendBlockFactory(
 
             this._aggregateStates = ref.aggregateStates;
             this._walk = ref.walkFunction.bind(this);
+
+            if (this._rootProxyWrapper) {
+                // Set LegendGroup's opacity to 1 to ensure opacity of children
+                // is calculated relative to fully opaque.
+                // The expected opacity is still applied to children values
+                this._rootProxyWrapper.opacity = 1;
+            }
         }
 
         get blockType() {

--- a/src/content/samples/config/config-sample-11-structured-legend-opacity-disable.json
+++ b/src/content/samples/config/config-sample-11-structured-legend-opacity-disable.json
@@ -80,15 +80,27 @@
         "name": "root",
         "children": [
           {
-            "layerId": "somepowerplants"
+            "layerId": "Opacity 0"
+          },
+          {
+            "layerId": "Opacity 1"
+          },
+          {
+            "layerId": "Opacity 2"
+          },
+          {
+            "layerId": "Opacity 3"
+          },
+          {
+            "layerId": "Opacity 4"
           }
         ]
       }
     },
     "layers": [
       {
-        "id": "somepowerplants",
-        "name": "Power Plants with opacity disabled initially",
+        "id": "Opacity 0",
+        "name": "Opacity disabled initially",
         "layerType": "esriDynamic",
         "layerEntries": [
           {
@@ -103,6 +115,86 @@
         ],
         "state": {
           "opacity": 0
+        },
+        "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer"
+      },
+      {
+        "id": "Opacity 1",
+        "name": "Opacity 0.12 initially",
+        "layerType": "esriDynamic",
+        "layerEntries": [
+            {
+            "index": 21
+            },
+            {
+            "index": 17
+            },
+            {
+            "index": 19
+            }
+        ],
+        "state": {
+            "opacity": 0.12
+        },
+        "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer"
+      },
+      {
+        "id": "Opacity 2",
+        "name": "Opacity 0.5 initially",
+        "layerType": "esriDynamic",
+        "layerEntries": [
+            {
+            "index": 21
+            },
+            {
+            "index": 17
+            },
+            {
+            "index": 19
+            }
+        ],
+        "state": {
+            "opacity": 0.5
+        },
+        "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer"
+      },
+      {
+        "id": "Opacity 3",
+        "name": "Opacity 0.705 initially",
+        "layerType": "esriDynamic",
+        "layerEntries": [
+            {
+            "index": 21
+            },
+            {
+            "index": 17
+            },
+            {
+            "index": 19
+            }
+        ],
+        "state": {
+            "opacity": 0.705
+        },
+        "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer"
+      },
+      {
+        "id": "Opacity 4",
+        "name": "Opacity full initially",
+        "layerType": "esriDynamic",
+        "layerEntries": [
+            {
+            "index": 21
+            },
+            {
+            "index": 17
+            },
+            {
+            "index": 19
+            }
+        ],
+        "state": {
+            "opacity": 1
         },
         "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer"
       }

--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -105,7 +105,7 @@
                 <option value="config/config-sample-08-structured-legend-one-layer-muti-legends.json">08. Layer with single entry collapsed set </option>
                 <option value="config/config-sample-09-structured-legend-opacity-visibility-disable-locked.json">09. Multiple layers with opacity, visibility both disabled and locked</option>
                 <option value="config/config-sample-10-structured-legend-opacity-disable-locked.json">10. Multiple layers with opacity disabled and locked</option>
-                <option value="config/config-sample-11-structured-legend-opacity-disable.json">11. Multiple layers with opacity disabled initially</option>
+                <option value="config/config-sample-11-structured-legend-opacity-disable.json">11. Dynamic layers with many different inital opacities</option>
                 <option value="config/config-sample-12-structured-legend-opacity-locked.json">12. Multiple layers with opacity locked</option>
                 <option value="config/config-sample-13-structured-legend-visibility-disable-locked.json">13. Multiple layers with visibility disabled and locked</option>
                 <option value="config/config-sample-14-structured-legend-visibility-disable.json">14. Multiple layers with visibility disabled initially</option>


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2594 #2658

_**Update:** Sample 11 now has multiple dynamic layers with various initial opacities._ 

Fixes issue where opacity would not apply for dynamic layers where initial opacity was set to 0. 
Changes were made in line with [this comment](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2594#issuecomment-381215002) going with the option to fix the initially outlined expected behaviour. 

Also Barry's [comment](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2594#issuecomment-384373771) is no longer an issue since a label has been added to show child values differ from parent.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
:eyes: 
Sample 11 - Finally working when you change opacity


## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
In-line comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2925)
<!-- Reviewable:end -->
