### PR TITLE
2859 wfs loading restructuring backwards - Part 2 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6330,8 +6330,7 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#v2.5.0-14",
-      "from": "github:fgpv-vpgf/geoApi#v2.5.0-14",
+      "version": "github:fgpv-vpgf/geoApi#614d5dd5735bc379428ef0c6152c4ae231e49bd7",
       "requires": {
         "babel-cli": "6.26.0",
         "babel-preset-env": "1.6.1",

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -50,6 +50,8 @@ function identifyService($q, configService, gapiService, referenceService, state
             mapExtent: mapInstance.extent
         };
 
+        // TODO: the order of layerRecords might not match the order of the legend block; best to use the order of the layers from the config file
+        // see `synchronizeLayerOrder` function in the `layer-registry` for more details on sorting
         const identifyInstances = configService.getSync.map.layerRecords
             // TODO: can we expose identify on all layer record types and vet in geoapi for consistency
             .filter(layerRecord => typeof layerRecord.identify !== 'undefined')

--- a/src/app/geo/layer-blueprint.class.js
+++ b/src/app/geo/layer-blueprint.class.js
@@ -13,7 +13,7 @@ angular
     .module('app.geo')
     .factory('LayerBlueprint', LayerBlueprintFactory);
 
-function LayerBlueprintFactory($q, gapiService, Geo, ConfigObject, configService, bookmarkService, appInfo,
+function LayerBlueprintFactory(common, gapiService, Geo, ConfigObject, configService, bookmarkService, appInfo,
     layerSource, LayerSourceInfo) {
 
     let idCounter = 0; // layer counter for generating layer ids
@@ -35,7 +35,7 @@ function LayerBlueprintFactory($q, gapiService, Geo, ConfigObject, configService
         // no validation required for services. mock a vlidation process for consistency.
         // only instances of LayerFileBlueprint required validation; that class overrides this function
         validateLayerSource() {
-            return $q.resolve();
+            return common.$q.resolve();
         }
 
         set config(value) {
@@ -147,8 +147,8 @@ function LayerBlueprintFactory($q, gapiService, Geo, ConfigObject, configService
          */
         generateLayer() {
             const epsg = appInfo.plugins.find(x => x.intention === 'epsg');
-            return LayerBlueprint.LAYER_TYPE_TO_LAYER_RECORD[this.config.layerType](
-                this.config, undefined, epsg.lookup);
+            return common.$q.resolve(LayerBlueprint.LAYER_TYPE_TO_LAYER_RECORD[this.config.layerType](
+                this.config, undefined, epsg.lookup));
         }
     }
 
@@ -262,7 +262,7 @@ function LayerBlueprintFactory($q, gapiService, Geo, ConfigObject, configService
                 this._configSourceDelayedServer.then(() => layerRecord.updateWfsSource(this.__layer__));
             }
 
-            return layerRecord;
+            return common.$q.resolve(layerRecord);
         }
     }
 

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -19,11 +19,22 @@ const THROTTLE_TIMEOUT = 3000;
  * The `layerRegistry` factory tracks active layers and constructs legend, provide all layer-related functionality like registering, removing, changing visibility, changing opacity, etc.
  *
  */
-angular
-    .module('app.geo')
-    .factory('layerRegistry', layerRegistryFactory);
+angular.module('app.geo').factory('layerRegistry', layerRegistryFactory);
 
-function layerRegistryFactory($rootScope, $filter, $translate, shellService, errorService, events, gapiService, Geo, configService, tooltipService, common, ConfigObject) {
+function layerRegistryFactory(
+    $rootScope,
+    $filter,
+    $translate,
+    shellService,
+    errorService,
+    events,
+    gapiService,
+    Geo,
+    configService,
+    tooltipService,
+    common,
+    ConfigObject
+) {
     const service = {
         getLayerRecord,
         getLayerRecordPromise,
@@ -118,13 +129,12 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
     function getLayerRecord(id) {
         const layerRecords = configService.getSync.map.layerRecords;
 
-        return layerRecords.find(layerRecord =>
-            layerRecord.layerId === id);
+        return layerRecords.find(layerRecord => layerRecord.layerId === id);
     }
 
     /**
      * Finds and returns a promise of layer record either already generated or in the process of being generated.
-     * If no layer record with such an id found, returns `udnefined`.
+     * If no layer record with such an id found, returns `undefined`.
      *
      * @param {String} id the id of the layer record to be returned
      * @return {Promise<LayerRecord>} promise of layer record with the id specified; undefined if not found
@@ -144,14 +154,15 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
      */
     function makeLayerRecord(layerBlueprint) {
         // check if the record is already created (generated or being generated)
-        let layerRecordPromise = getLayerRecordPromise(layerBlueprint.config.id)
+        let layerRecordPromise = getLayerRecordPromise(layerBlueprint.config.id);
 
         if (!layerRecordPromise) {
             layerRecordPromise = _startGeneratingLayerRecord(layerBlueprint);
         }
 
-        layerRecordPromise.then(layerRecord =>
-            (ref.refreshAttributes[layerRecord.layerId] = _attribsInvalidation(layerRecord)));
+        layerRecordPromise.then(
+            layerRecord => (ref.refreshAttributes[layerRecord.layerId] = _attribsInvalidation(layerRecord))
+        );
 
         /**
          * @function _attribsInvalidation
@@ -172,7 +183,9 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
                     if (layerRecord.layerType === Geo.Layer.Types.ESRI_DYNAMIC) {
                         const childIndices = _simpleWalk(layerRecord.getChildTree());
                         childIndices.forEach(idx => {
-                            configLayer = mapApi.layers.allLayers.find(layer => layer.id === layerRecord.layerId && layer.layerIndex === idx);
+                            configLayer = mapApi.layers.allLayers.find(
+                                layer => layer.id === layerRecord.layerId && layer.layerIndex === idx
+                            );
                             if (configLayer) {
                                 configLayer.removeAttributes();
                             }
@@ -267,10 +280,8 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
         }
 
         layerRecordPromise.then(layerRecord => {
-            const alreadyLoading = ref.loadingQueue.some(lr =>
-                lr === layerRecord);
-            const alreadyLoaded = map.graphicsLayerIds.concat(map.layerIds)
-                .indexOf(layerRecord.config.id) !== -1;
+            const alreadyLoading = ref.loadingQueue.some(lr => lr === layerRecord);
+            const alreadyLoaded = map.graphicsLayerIds.concat(map.layerIds).indexOf(layerRecord.config.id) !== -1;
 
             if (alreadyLoading || alreadyLoaded) {
                 return false;
@@ -314,7 +325,7 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
             return layerRecord;
         });
 
-        return layerRecordPromise
+        return layerRecordPromise;
     }
 
     /**
@@ -344,7 +355,7 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
             layerRecord.addStateListener(_onLayerRecordInitialLoad);
             layerRecord.addAttribListener(_onLayerAttribDownload);
             mapBody.addLayer(layerRecord._layer);
-            ref.loadingCount ++;
+            ref.loadingCount++;
 
             // TODO need better solution for local wms layers that don't "load" when invisible.
             const localWms = layerRecord.dataSource() === 'wms' && layerRecord.config.suppressGetCapabilities;
@@ -354,9 +365,11 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
 
             // HACK: for a file-based layer, call onLoad manually since such layers don't emmit events
             //       extending the hack to wms layers who are supressing a server handshake.
-            if (layerRecord.state === Geo.Layer.States.LOADED ||
-               (layerRecord.dataSource() !== 'esri' && layerRecord._layer.loaded) ||
-               (localWms)) {
+            if (
+                layerRecord.state === Geo.Layer.States.LOADED ||
+                (layerRecord.dataSource() !== 'esri' && layerRecord._layer.loaded) ||
+                localWms
+            ) {
                 isRefreshed = true;
                 _onLayerRecordInitialLoad('rv-loaded');
             }
@@ -383,14 +396,9 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
          * @private
          */
         function _onLayerRecordInitialLoad(state) {
-
             if (state === 'rv-refresh') {
                 isRefreshed = true;
-            } else if (
-                (isRefreshed && state === 'rv-loaded') ||
-                (state === 'rv-error')
-            ) {
-
+            } else if ((isRefreshed && state === 'rv-loaded') || state === 'rv-error') {
                 layerRecord.removeStateListener(_onLayerRecordInitialLoad);
 
                 events.$broadcast(events.rvLayerRecordLoaded, layerRecord.config.id);
@@ -428,13 +436,16 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
                 return;
             }
 
-            ref.mapLoadingWaitHandle = $rootScope.$watch(() => mapConfig.isLoaded, value => {
-                if (value) {
-                    ref.mapLoadingWaitHandle(); // de-register watch
-                    ref.mapLoadingWaitHandle = null;
-                    _loadNextLayerRecord();
+            ref.mapLoadingWaitHandle = $rootScope.$watch(
+                () => mapConfig.isLoaded,
+                value => {
+                    if (value) {
+                        ref.mapLoadingWaitHandle(); // de-register watch
+                        ref.mapLoadingWaitHandle = null;
+                        _loadNextLayerRecord();
+                    }
                 }
-            });
+            );
         }
     }
 
@@ -457,10 +468,12 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
             case 'rv-error':
                 shellService.clearLoadingFlag(layerRecord.config.id);
                 errorService.display({
-                    textContent: $translate.instant('toc.layer.longload.failed', { name: `"${layerRecord.config.name}"` })
+                    textContent: $translate.instant('toc.layer.longload.failed', {
+                        name: `"${layerRecord.config.name}"`
+                    })
                     // TODO: add reload action
                     // action: 'reload'
-                })// .then(response => response === 'ok' ? dostuff() : {});
+                }); // .then(response => response === 'ok' ? dostuff() : {});
                 break;
         }
     }
@@ -476,13 +489,12 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
             messageDelay: config.expectedResponseTime,
             message: $translate.instant('toc.layer.longload.message', { name: `"${config.name}"` }),
             action: $translate.instant('toc.layer.longload.hide')
-        })
+        });
         /* .then(response => {
             if (response === 'ok') {
                 // do stuff like reload layer or something
             }
         }) */
-        ;
     }
 
     /**
@@ -500,20 +512,17 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
         const layerRecordIDsInLegend = configService.getSync.map.legendBlocks
             .walk(lb => lb.layerRecordId) // get a flat list of layer record ids as they appear in UI
             .filter(id => id) // this will strip all falsy values like `undefined` and `null` since ids should be strings; filter out artificial groups that don't have ids set to null and legend info elements
-            .reduce((a, b) =>
-                a.concat(a.indexOf(b) < 0 ? b : []), []); // remove duplicates (dynamic group and its children with have the same layer id)
+            .reduce((a, b) => a.concat(a.indexOf(b) < 0 ? b : []), []); // remove duplicates (dynamic group and its children with have the same layer id)
 
         // if structured legend, take the layer order from the config as the authoritative source
         // TODO:? user-added layers are not added to `configService.getSync.map.layers`; they will be always added at the top of the stack for structured legend, so this is not an immediate concern;
         // if auto legend, take the legend block order from the legend panel
-        const orderedLayerRecords =
-            (configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE ?
-                layerRecordIDsInLegend :
-                configService.getSync.map.layers
-                    .map(layer => layer.id)
-                    .filter(id => layerRecordIDsInLegend.indexOf(id) !== -1)
-            )
-                .map(getLayerRecord); // get appropriate layer records
+        const orderedLayerRecords = (configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE
+            ? layerRecordIDsInLegend
+            : configService.getSync.map.layers
+                  .map(layer => layer.id)
+                  .filter(id => layerRecordIDsInLegend.indexOf(id) !== -1)
+        ).map(getLayerRecord); // get appropriate layer records
 
         const mapLayerStacks = {
             0: mapBody.graphicsLayerIds,
@@ -522,14 +531,12 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
 
         const sortGroups = [0, 1];
 
-        sortGroups.forEach(sortGroup =>
-            _syncSortGroup(sortGroup));
+        sortGroups.forEach(sortGroup => _syncSortGroup(sortGroup));
 
         // just in case the bbox layers got out of hand,
         // push them to the bottom of the map stack (high drawing order)
         const featureStackLastIndex = mapLayerStacks['0'].length - 1;
-        boundingBoxRecords.forEach(boundingBoxRecord =>
-            mapBody.reorderLayer(boundingBoxRecord, featureStackLastIndex));
+        boundingBoxRecords.forEach(boundingBoxRecord => mapBody.reorderLayer(boundingBoxRecord, featureStackLastIndex));
 
         // push the highlight layer on top of everything else
         if (highlightLayer) {
@@ -549,7 +556,7 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
             //
             // for example there are following layers on the map object:
             // ['basemap', 'one', 'two', 'three', 'bbox', 'highlight']
-            const mapLayerStack = mapLayerStacks[sortGroup.toString()]
+            const mapLayerStack = mapLayerStacks[sortGroup.toString()];
 
             // a filtered array of layer records that belong to the specified sort group and are in the map layer stack (not errored)
             // this represents a layer order as visible by the user in the layer selector UI component
@@ -557,19 +564,15 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
             // for example the user reorders a layer through UI:
             // ['three', 'one', 'two']
             const layerRecordStack = orderedLayerRecords
-                .filter(layerRecord =>
-                    Geo.Layer.SORT_GROUPS_[layerRecord.layerType] === sortGroup)
-                .filter(layerRecord =>
-                    mapLayerStack.indexOf(layerRecord.config.id) !== -1);
+                .filter(layerRecord => Geo.Layer.SORT_GROUPS_[layerRecord.layerType] === sortGroup)
+                .filter(layerRecord => mapLayerStack.indexOf(layerRecord.config.id) !== -1);
 
             // a sorted in decreasing order map stack index array of layers found in the previous step
             // this just reflects the positions or slots of the layers from the specified sort group on the map
             // for example: [3, 2, 1]
             const layerRecordIndexes = layerRecordStack
-                .map(layerRecord =>
-                    mapLayerStack.indexOf(layerRecord.config.id))
-                .sort((a, b) =>
-                    b - a);
+                .map(layerRecord => mapLayerStack.indexOf(layerRecord.config.id))
+                .sort((a, b) => b - a);
 
             // layers are now iterated using their UI order and moved into the positions or slots found in the previous step
             //
@@ -598,8 +601,7 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
     function getBoundingBoxRecord(id) {
         const boundingBoxRecords = configService.getSync.map.boundingBoxRecords;
 
-        return boundingBoxRecords.find(boundingBoxRecord =>
-            boundingBoxRecord.id === id);
+        return boundingBoxRecords.find(boundingBoxRecord => boundingBoxRecord.id === id);
     }
 
     /**
@@ -617,7 +619,10 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
         let boundingBoxRecord = getBoundingBoxRecord(id);
         if (!boundingBoxRecord) {
             boundingBoxRecord = gapiService.gapi.layer.bbox.makeBoundingBox(
-                id, bbExtent, mapBody.extent.spatialReference);
+                id,
+                bbExtent,
+                mapBody.extent.spatialReference
+            );
 
             boundingBoxRecords.push(boundingBoxRecord);
             mapBody.addLayer(boundingBoxRecord);
@@ -657,7 +662,10 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
     function _setHoverTips(layerRecord) {
         // TODO: layerRecord returns a promise on layerType to be consistent with dynamic children which don't know their type upfront
         // to not wait on promise, check the layerRecord config
-        if (layerRecord.config.layerType !== Geo.Layer.Types.ESRI_FEATURE && layerRecord.config.layerType !== Geo.Layer.Types.OGC_WFS) {
+        if (
+            layerRecord.config.layerType !== Geo.Layer.Types.ESRI_FEATURE &&
+            layerRecord.config.layerType !== Geo.Layer.Types.OGC_WFS
+        ) {
             return;
         }
 
@@ -826,16 +834,15 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
      * @returns {Array}     list of rcs layers' ids
      */
     function getRcsLayerIDs() {
-
         // FIXME need to handle a layer that has been deleted
         //       but the undo timer has yet to remove it from
         //       the map. In this case, it exists in the map
         //       but not in the legend. Determine best way
         //       to detect this.
         return configService.getSync.map.layers
-            .filter(lyr => (lyr.origin === 'rcs'))    // only take rcs layers
-            .filter(lyr => (getLayerRecord(lyr.id)))  // only take layers still in the map
-            .map(lyr => lyr.id.split('.')[1]);        // extract rcs key from layer id
+            .filter(lyr => lyr.origin === 'rcs') // only take rcs layers
+            .filter(lyr => getLayerRecord(lyr.id)) // only take layers still in the map
+            .map(lyr => lyr.id.split('.')[1]); // extract rcs key from layer id
     }
 
     return service;
@@ -859,9 +866,9 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
             const childIndices = _simpleWalk(layerRecord.getChildTree());
             childIndices.forEach(idx => {
                 let configLayer;
-                configLayer = mapApi.layers.allLayers.find(layer =>
-                    layer.id === layerRecord.layerId &&
-                    layer.layerIndex === idx);
+                configLayer = mapApi.layers.allLayers.find(
+                    layer => layer.id === layerRecord.layerId && layer.layerIndex === idx
+                );
 
                 if (configLayer) {
                     configLayer._initLayerSettings(layerRecord, idx);
@@ -885,7 +892,8 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
                     createdLayers.push(apiLayer);
                 }
             });
-        } else {    // for non-dynamic layers, it will correctly create one ConfigLayer for the layer
+        } else {
+            // for non-dynamic layers, it will correctly create one ConfigLayer for the layer
             let configLayer;
             configLayer = mapApi.layers.allLayers.find(layer => layer.id === layerRecord.layerId);
 
@@ -947,13 +955,16 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
 
     function _simpleWalk(treeChildren) {
         // roll in the results into a flat array
-        return [].concat.apply([], treeChildren.map((treeChild, index) => {
-            if (treeChild.childs) {
-                return [].concat(_simpleWalk(treeChild.childs));
-            } else {
-                return treeChild.entryIndex;
-            }
-        }));
+        return [].concat.apply(
+            [],
+            treeChildren.map((treeChild, index) => {
+                if (treeChild.childs) {
+                    return [].concat(_simpleWalk(treeChild.childs));
+                } else {
+                    return treeChild.entryIndex;
+                }
+            })
+        );
     }
 
     /**
@@ -969,7 +980,9 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
     function _onLayerAttribDownload(layerRecord, idx, attribs) {
         let configLayer;
         if (layerRecord.layerType === Geo.Layer.Types.ESRI_DYNAMIC) {
-            configLayer = mapApi.layers.allLayers.find(l => l.id === layerRecord.layerId && l.layerIndex === parseInt(idx));
+            configLayer = mapApi.layers.allLayers.find(
+                l => l.id === layerRecord.layerId && l.layerIndex === parseInt(idx)
+            );
         } else {
             configLayer = mapApi.layers.getLayersById(layerRecord.layerId)[0];
         }
@@ -993,7 +1006,9 @@ function layerRegistryFactory($rootScope, $filter, $translate, shellService, err
         if (layerRecord.layerType === Geo.Layer.Types.ESRI_DYNAMIC && layerRecord.state === Geo.Layer.States.LOADED) {
             const childIndices = _simpleWalk(layerRecord.getChildTree());
             childIndices.forEach(idx => {
-                index = mapApi.layers.allLayers.findIndex(layer => layer.id === layerRecord.layerId && layer.layerIndex === idx);
+                index = mapApi.layers.allLayers.findIndex(
+                    layer => layer.id === layerRecord.layerId && layer.layerIndex === idx
+                );
                 if (index !== -1) {
                     const apiLayer = mapApi.layers.allLayers[index];
 

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -510,6 +510,7 @@ function LegendBlockFactory(
         set controlled(value) {
             this._controlled = value;
         }
+
         /**
          * @returns {Boolean} returns true if the LegendBlock is directly controlled by a parent LegendBlock and has no visible UI
          */

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -7,13 +7,20 @@
  * This service also scrapes layer symbology.
  *
  */
-angular
-    .module('app.geo')
-    .factory('legendService', legendServiceFactory);
+angular.module('app.geo').factory('legendService', legendServiceFactory);
 
-function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stateManager, LegendBlock, LayerBlueprint,
-    layerRegistry, common, events) {
-
+function legendServiceFactory(
+    $rootScope,
+    Geo,
+    ConfigObject,
+    configService,
+    stateManager,
+    LegendBlock,
+    LayerBlueprint,
+    layerRegistry,
+    common,
+    events
+) {
     const service = {
         constructLegend,
         importLayerBlueprint,
@@ -32,8 +39,7 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
         configService.getSync.map.instance.addConfigLayer = layerJSON => {
             const layerRecords = configService.getSync.map.layerRecords;
 
-            const index = layerRecords.find(layerRecord =>
-                layerRecord.layerId === layerJSON.id);
+            const index = layerRecords.find(layerRecord => layerRecord.layerId === layerJSON.id);
 
             if (!index) {
                 let addToLegend = false;
@@ -54,16 +60,14 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
         };
 
         configService.getSync.map.instance.setLegendConfig = legendStructure => {
-            stateManager.setActive({ tableFulldata: false } , { sideMetadata: false }, { sideSettings: false });
+            stateManager.setActive({ tableFulldata: false }, { sideMetadata: false }, { sideSettings: false });
 
             const apiLayers = mApi.layers.allLayers
                 // filter on the existence of a viewerLayer config, this will strip out 'simpleLayer's
                 .filter(l => l._viewerLayer.config)
                 .map(l => l._viewerLayer.config.source);
             const viewerLayers = configService.getSync.map.layers;
-            const layers = apiLayers.concat(
-                viewerLayers.filter(layer => apiLayers.indexOf(layer) < 0)
-            );
+            const layers = apiLayers.concat(viewerLayers.filter(layer => apiLayers.indexOf(layer) < 0));
             const newLegend = new ConfigObject.legend.Legend(legendStructure, layers);
             service.constructLegend(layers, newLegend);
             configService.getSync.map._legend = newLegend;
@@ -92,12 +96,14 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
         const newDefinitions = [];
 
         layerDefinitions.forEach(ld => {
-            let index = layerBlueprintsCollection.findIndex(blueprint =>
-                blueprint.config.id === ld.id);
+            let index = layerBlueprintsCollection.findIndex(blueprint => blueprint.config.id === ld.id);
             const legendItem = legendStructure.root
-                .walk(entry =>
-                    entry.layerId === ld.id || (entry.controlledIds && entry.controlledIds.indexOf(ld.id) > -1) ?
-                    entry : null)
+                .walk(
+                    entry =>
+                        entry.layerId === ld.id || (entry.controlledIds && entry.controlledIds.indexOf(ld.id) > -1)
+                            ? entry
+                            : null
+                )
                 .filter(a => a)[0];
 
             // if the layer is being readded to the legend, regenerate the layer record to have up-to-date settings
@@ -125,8 +131,7 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
         // wait for all promises to resolve then show info
         Promise.all(blueprintPromises).then(() => {
             // create mapping for all layer blueprints
-            mapConfig.layerBlueprints.forEach(lb =>
-                (legendMappings[lb.config.id] = []));
+            mapConfig.layerBlueprints.forEach(lb => (legendMappings[lb.config.id] = []));
 
             const legendBlocks = _makeLegendBlock(legendStructure.root, layerBlueprintsCollection);
             mapConfig.legendBlocks = legendBlocks;
@@ -188,9 +193,10 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
         // TODO: this can potentially move to blueprint code
         const entryConfigObject = {
             layerId: layerBlueprint.config.id,
-            symbologyRenderStyle: layerBlueprint.config.layerType === Geo.Layer.Types.OGC_WMS ?
-                ConfigObject.legend.Entry.IMAGES :
-                ConfigObject.legend.Entry.ICONS
+            symbologyRenderStyle:
+                layerBlueprint.config.layerType === Geo.Layer.Types.OGC_WMS
+                    ? ConfigObject.legend.Entry.IMAGES
+                    : ConfigObject.legend.Entry.ICONS
         };
 
         const sortGroups = Geo.Layer.SORT_GROUPS_;
@@ -204,13 +210,15 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
 
         let position = 0;
         // find an appropriate spot in a auto legend;
-        if (pos) {   // If the order from bookmark exists
+        if (pos) {
+            // If the order from bookmark exists
             position = pos;
         } else if (configService.getSync.map.legend.type === ConfigObject.TYPES.legend.AUTOPOPULATE) {
             const layerType = importedLegendBlock.layerType;
-            const sortGroup = layerType ? sortGroups[layerType] : 1;    // layerType doesn't exist, legend block is a group
-            position = legendBlocks.entries.findIndex(block =>
-                !block.layerType || sortGroups[block.layerType] >= sortGroup);
+            const sortGroup = layerType ? sortGroups[layerType] : 1; // layerType doesn't exist, legend block is a group
+            position = legendBlocks.entries.findIndex(
+                block => !block.layerType || sortGroups[block.layerType] >= sortGroup
+            );
 
             // if the sort group for this layer doesn't exist, insert at the bottom of the legend
             position = position === -1 ? legendBlocks.entries.length : position;
@@ -250,41 +258,47 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
             // need to find the actual legend block mapped to the legendBlock being reloaded and its parent container legendGroup
             const legendBlocks = configService.getSync.map.legendBlocks;
             const { legendBlock, legendBlockParent } = legendBlocks
-                .walk((entry, index, parentEntry) =>
-                    entry.id === legendBlockId ? {
-                        legendBlock: entry,
-                        legendBlockParent: parentEntry
-                    } : null)
+                .walk(
+                    (entry, index, parentEntry) =>
+                        entry.id === legendBlockId
+                            ? {
+                                  legendBlock: entry,
+                                  legendBlockParent: parentEntry
+                              }
+                            : null
+                )
                 .filter(a => a !== null)[0];
 
             // need to find the block config the legend block was made from and create a new one
             const legend = configService.getSync.map.legend;
             const legendBlockConfig = legend.root
-                .walk(child =>
-                    child.id === legendBlockConfigId ? child : null)
+                .walk(child => (child.id === legendBlockConfigId ? child : null))
                 .filter(a => a !== null)[0];
 
             // all controlled layer records __must__ be reloaded before the legend block is made
             // if this were to be done after, the state settings of the controlling legend block will not be applied correctly
             // (`regenerateLayerRecord` will remove the layer from the map, but it's the logic inside `_makeLegendBlock` that adds the layer back to the map)
-            legendBlockConfig.controlledIds.forEach(controlledId =>
-                reloadBoundLegendBlocks(controlledId));
+            legendBlockConfig.controlledIds.forEach(controlledId => reloadBoundLegendBlocks(controlledId));
 
             const reloadedLegendBlock = _makeLegendBlock(legendBlockConfig, layerBlueprintsCollection);
             const index = legendBlockParent.removeEntry(legendBlock);
             const layerRecordPromise = layerRegistry.getLayerRecordPromise(legendBlockConfig.layerId);
 
-            if (promise) { // ensure only one promise is created
+            if (promise) {
+                // ensure only one promise is created
                 return;
             }
+
+            _boundingBoxRemoval(legendBlock);
+            legendBlockParent.addEntry(reloadedLegendBlock, index);
 
             promise = layerRecordPromise.then(_handleLayerStateChange);
 
             /**
              * A helper function to watch the layer record loading state.
              *
-             * @param {*} layerRecord
-             * @returns {Promise<LegendBlock>}
+             * @param {LayerRecord} layerRecord a layerRecord to watch for state
+             * @returns {Promise<LegendBlock|string>} returns a promise resolving with a legendBlock if layer loads successfully or layer name if the layer fails to load
              */
             function _handleLayerStateChange(layerRecord) {
                 // need time to reload children for Dynamic layers
@@ -295,10 +309,6 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
                         // add back entry
                         if (state === 'rv-loaded' || state === 'rv-error') {
                             layerRecord.removeStateListener(_onLayerRecordLoad);
-
-                            _boundingBoxRemoval(legendBlock);
-
-                            legendBlockParent.addEntry(reloadedLegendBlock, index);
                         }
 
                         if (state === 'rv-loaded') {
@@ -337,8 +347,7 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
 
         const legendBlocks = configService.getSync.map.legendBlocks;
         const legendBlockParent = legendBlocks
-            .walk((entry, index, parentEntry) =>
-                entry === legendBlock ? parentEntry : null)
+            .walk((entry, index, parentEntry) => (entry === legendBlock ? parentEntry : null))
             .filter(a => a !== null)[0];
 
         // TODO: instead of removing the legend block form the selector, just hide it with some css
@@ -362,15 +371,15 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
             // legendBlock.layerRecordId can be undefined if we recursively call 'removeLayer()' in tocService because we are
             // removing a groups parent. in that case we need to find the correct layerRecordId of the initial layer that was being removed
             if (layerRecordId === null) {
-                layerRecordId = legendBlock.walk(l => l.layerRecordId !== null ? l.layerRecordId : null).filter(a => a)[0];
+                layerRecordId = legendBlock
+                    .walk(l => (l.layerRecordId !== null ? l.layerRecordId : null))
+                    .filter(a => a)[0];
             }
 
             // check if any other blocks reference this layer record
             // if none found, it's safe to remove the layer record
-            const isSafeToRemove = legendBlocks
-                .walk(entry => entry.layerRecordId === layerRecordId)
-                .filter(a => a)
-                .length === 0;
+            const isSafeToRemove =
+                legendBlocks.walk(entry => entry.layerRecordId === layerRecordId).filter(a => a).length === 0;
 
             if (isSafeToRemove) {
                 layerRegistry.removeLayerRecord(layerRecordId);
@@ -434,8 +443,7 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
                 // real blueprints are only available on Legend.NODEs
                 const nodeBlueprints = {
                     main: _getLayerBlueprint(blockConfig.layerId),
-                    controlled: blockConfig.controlledIds.map(id =>
-                        _getLayerBlueprint(id))
+                    controlled: blockConfig.controlledIds.map(id => _getLayerBlueprint(id))
                 };
 
                 // dynamic layers render as LegendGroup blocks; all other layers are rendered as LegendNode blocks;
@@ -504,12 +512,11 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
 
             // wait for the dynamic layer record to load to get its children
             const layerRecordPromise = layerRegistry.getLayerRecordPromise(blockConfig.layerId);
-            layerRecordPromise.then(_waitOnLayerLoad).then(layerRecord => {
+            _waitOnLayerLoad(layerRecordPromise).then(layerRecord => {
                 // on loaded, create child LegendBlocks for the dynamic layer and
                 // add them to the created LegendBlock.GROUP to be displayed in the UI (following any hierarchy provided)
                 const tree = _createDynamicChildTree(layerRecord, layerConfig);
-                tree.forEach(item =>
-                    _addChildBlock(item, legendBlockGroup));
+                tree.forEach(item => _addChildBlock(item, legendBlockGroup));
 
                 legendBlockGroup.synchronizeControlledEntries();
             });
@@ -519,7 +526,6 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
             // and add to the main dynamic group
             blueprints.controlled.forEach(blueprint =>
                 _getControlledLegendBlockProxy(blueprint).then(proxyWrappers => {
-
                     proxyWrappers.forEach(proxyWrapper => {
                         const entryConfig = new ConfigObject.legend.Entry({});
                         const legendBlock = new LegendBlock.Node(proxyWrapper, entryConfig);
@@ -527,16 +533,16 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
                         legendBlock.layerRecordId = layerConfig.id;
 
                         legendBlockGroup.addEntry(legendBlock);
-                    })
+                    });
 
                     // apply group settings to the newly added controlled entries so any settings modified by the user
                     // while the controlled layers were loading would apply on top as well
                     legendBlockGroup.synchronizeControlledEntries();
-                }));
+                })
+            );
 
-            const meetsCollapseCondition = layerConfig.layerEntries
-                .filter(layerEntry => !layerEntry.stateOnly)
-                .length === 1;
+            const meetsCollapseCondition =
+                layerConfig.layerEntries.filter(layerEntry => !layerEntry.stateOnly).length === 1;
 
             if (layerConfig.singleEntryCollapse && meetsCollapseCondition) {
                 legendBlockGroup.collapsed = true;
@@ -563,16 +569,16 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
                     legendBlock = new LegendBlock.Group(groupConfig, rootProxyWrapper);
                     legendBlock.layerRecordId = layerConfig.id; // map all dynamic children to the block config and layer record of their root parent
 
-                    item.childs.forEach(child =>
-                        _addChildBlock(child, legendBlock));
-
+                    item.childs.forEach(child => _addChildBlock(child, legendBlock));
                 } else {
                     const entryConfig = new ConfigObject.legend.Entry(item);
                     legendBlock = new LegendBlock.Node(item.proxyWrapper, entryConfig);
                     legendBlock.layerRecordId = layerConfig.id; // map all dynamic children to the block config and layer record of their root parent
 
                     // show filter flag if there is a filter query being applied
-                    legendBlock.filter = item.proxyWrapper.layerConfig.initialFilteredQuery && item.proxyWrapper.layerConfig.initialFilteredQuery !== "";
+                    legendBlock.filter =
+                        item.proxyWrapper.layerConfig.initialFilteredQuery &&
+                        item.proxyWrapper.layerConfig.initialFilteredQuery !== '';
                 }
 
                 parentLegendGroup.addEntry(legendBlock);
@@ -591,14 +597,14 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
          */
         function _createDynamicChildTree(layerRecord, layerConfig) {
             const dynamicLayerChildDefaults = angular.copy(
-                ConfigObject.DEFAULTS.layer[Geo.Layer.Types.ESRI_DYNAMIC].child);
+                ConfigObject.DEFAULTS.layer[Geo.Layer.Types.ESRI_DYNAMIC].child
+            );
 
             const groupDefaults = ConfigObject.DEFAULTS.legend[ConfigObject.TYPES.legend.GROUP];
 
             layerRecord.derivedChildConfigs = [];
             const tree = layerRecord.getChildTree();
-            tree.forEach(treeChild =>
-                _createDynamicChildLegendBlock(treeChild, layerConfig.source));
+            tree.forEach(treeChild => _createDynamicChildLegendBlock(treeChild, layerConfig.source));
 
             layerConfig.isResolved = true;
 
@@ -621,41 +627,34 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
 
                 // process as a group
                 if (treeChild.childs) {
-
                     const originalSource = angular.merge({}, derivedLayerEntryConfig.source);
 
                     if (!layerConfig.isResolved) {
                         // converting a child source config into a group source config;
                         // for that we need to filter out `controls` array, add `name` and empty `children` array
-                        const derivedChildGroupSource = angular.extend({},
-                            originalSource,
-                            {
-                                children: [],
-                                controls: common.intersect(
-                                    originalSource.controls,
-                                    groupDefaults.controls
-                                ),
-                                disabledControls: common.intersect(
-                                    originalSource.disabledControls,
-                                    groupDefaults.controls),
-                                userDisabledControls: common.intersect(
-                                    originalSource.userDisabledControls,
-                                    groupDefaults.controls
-                                ),
-                                name: treeChild.name
-                            });
+                        const derivedChildGroupSource = angular.extend({}, originalSource, {
+                            children: [],
+                            controls: common.intersect(originalSource.controls, groupDefaults.controls),
+                            disabledControls: common.intersect(originalSource.disabledControls, groupDefaults.controls),
+                            userDisabledControls: common.intersect(
+                                originalSource.userDisabledControls,
+                                groupDefaults.controls
+                            ),
+                            name: treeChild.name
+                        });
 
                         // convert and store at this point; pass derivedGroupSource as source for LegendGroup
                         derivedLayerEntryConfig = new ConfigObject.layers.DynamicLayerEntryNode(
-                            derivedChildGroupSource, true);
+                            derivedChildGroupSource,
+                            true
+                        );
                     }
 
                     treeChild.groupSource = derivedLayerEntryConfig.source;
 
                     treeChild.childs.forEach(subTreeChild =>
-                        _createDynamicChildLegendBlock(subTreeChild, originalSource));
-
-
+                        _createDynamicChildLegendBlock(subTreeChild, originalSource)
+                    );
                 } else {
                     // layerRecord is generated by this point, it's not a promise
                     const mainProxy = common.$q.resolve(layerRecord.getChildProxy(treeChild.entryIndex));
@@ -679,8 +678,7 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
                  * @param {DynamicLayerEntryNode} layerEntryConfig fully defaulted dynamic child layer entry config
                  */
                 function _saveLayerEntryConfig(layerEntryConfig) {
-                    let index = layerConfig.layerEntries.findIndex(entry =>
-                        entry.index === layerEntryConfig.index);
+                    let index = layerConfig.layerEntries.findIndex(entry => entry.index === layerEntryConfig.index);
 
                     index = index === -1 ? layerConfig.layerEntries.length : index;
 
@@ -706,8 +704,9 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
                         }
                     };
 
-                    const layerEntryConfig = layerConfig.layerEntries.find(entry =>
-                        entry.index === treeChild.entryIndex) || defaultLayerEntryConfig;
+                    const layerEntryConfig =
+                        layerConfig.layerEntries.find(entry => entry.index === treeChild.entryIndex) ||
+                        defaultLayerEntryConfig;
 
                     if (layerConfig.isResolved) {
                         return layerEntryConfig;
@@ -718,21 +717,27 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
                     const derivedChildLayerConfigSource = ConfigObject.applyLayerNodeDefaults(
                         layerEntryConfig.source,
                         dynamicLayerChildDefaults,
-                        parentLayerConfigSource);
+                        parentLayerConfigSource
+                    );
 
                     // dynamic children might not support opacity if the layer is not a true dynamic layer
                     // in such cases the opacity control is user disabled for all children and opacity of the whole layer should be changed at the root
                     // in single entry collapse cases, the root is hidden, and opacity control is left user enabled at the top single entry; all subsequent children are user disabled as usual
-                    if (!layerRecord.isTrueDynamic &&
-                        !(layerConfig.singleEntryCollapse &&
-                        derivedChildLayerConfigSource.index === layerConfig.layerEntries[0].index)) {
-
+                    if (
+                        !layerRecord.isTrueDynamic &&
+                        !(
+                            layerConfig.singleEntryCollapse &&
+                            derivedChildLayerConfigSource.index === layerConfig.layerEntries[0].index
+                        )
+                    ) {
                         derivedChildLayerConfigSource.userDisabledControls.push('opacity');
                         derivedChildLayerConfigSource.userDisabledControls.push('interval');
                     }
 
                     const derviedChildLayerConfig = new ConfigObject.layers.DynamicLayerEntryNode(
-                        derivedChildLayerConfigSource, true);
+                        derivedChildLayerConfigSource,
+                        true
+                    );
 
                     return derviedChildLayerConfig;
                 }
@@ -779,7 +784,7 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
             if (layerConfig.layerType === Geo.Layer.Types.OGC_WMS) {
                 blockConfig.symbologyRenderStyle = ConfigObject.legend.Entry.IMAGES;
 
-                layerConfig.layerEntries.forEach(entry => (entry.cachedStyle = entry.currentStyle))
+                layerConfig.layerEntries.forEach(entry => (entry.cachedStyle = entry.currentStyle));
             }
 
             layerConfig.cachedRefreshInterval = layerConfig.refreshInterval;
@@ -791,7 +796,7 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
             node.layerRecordId = layerConfig.id;
 
             // show filter flag if there is a filter query being applied
-            node.filter = layerConfig.initialFilteredQuery && layerConfig.initialFilteredQuery !== "";
+            node.filter = layerConfig.initialFilteredQuery && layerConfig.initialFilteredQuery !== '';
 
             legendMappings[layerConfig.id].push({
                 legendBlockId: node.id,
@@ -807,7 +812,8 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
                         // reapply state setting to the node so any settings changed by the user will apply to the newly added controlled proxy (this is possible if the controlled is a dynamic layer and there is a lag when fetching its child proxies)
                         node.synchronizeControlledProxyWrappers();
                     })
-                ));
+                )
+            );
 
             return node;
         }
@@ -873,8 +879,7 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
             });
 
             // controlled layers can't have enabled bounding boxes or query states (even if specified in the config file)
-            disabledOptions.state.forEach(stateName =>
-                (layerConfig.state[stateName] = false));
+            disabledOptions.state.forEach(stateName => (layerConfig.state[stateName] = false));
 
             // controlled layers are not supposed to have hovertips
             layerConfig.hovertipEnabled = false;
@@ -882,17 +887,15 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
             let proxyWrapperPromise;
 
             if (blueprint.config.layerType === Geo.Layer.Types.ESRI_DYNAMIC) {
-                // wait for the layer record to finishi generating, then set listener to wait until the record is fully loaded
-                proxyWrapperPromise = layerRecordPromise.then(_waitOnLayerLoad).then(layerRecord => {
+                // wait for the layer record to finish generating, then set listener to wait until the record is fully loaded
+                proxyWrapperPromise = _waitOnLayerLoad(layerRecordPromise).then(layerRecord => {
                     // tree consists of objects with entryIndex and its proxy wrapper,
                     // for controlledLayers only proxyWrappers are needed
                     const tree = _createDynamicChildTree(layerRecord, layerConfig);
-                    const flatTree = _flattenTree(tree).map(item =>
-                        item.proxyWrapper);
+                    const flatTree = _flattenTree(tree).map(item => item.proxyWrapper);
 
                     return flatTree;
                 });
-
             } else {
                 const proxyPromise = layerRecordPromise.then(layerRecord => layerRecord.getProxy());
                 const proxyWrapper = new LegendBlock.ProxyWrapper(proxyPromise, layerConfig);
@@ -909,14 +912,17 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
              * @returns
              */
             function _flattenTree(tree) {
-                const result = [].concat.apply([], tree.map(item => {
-                    if (item.childs) {
-                        // when flattening the tree, the groups are discarded as they will not be used
-                        return _flattenTree(item.childs);
-                    } else {
-                        return item;
-                    }
-                }));
+                const result = [].concat.apply(
+                    [],
+                    tree.map(item => {
+                        if (item.childs) {
+                            // when flattening the tree, the groups are discarded as they will not be used
+                            return _flattenTree(item.childs);
+                        } else {
+                            return item;
+                        }
+                    })
+                );
 
                 return result;
             }
@@ -964,8 +970,7 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
          * @return {LayerBlueprint|undefined} retuns a LayerBlueprint with a corresponding id or undefined if not found
          */
         function _getLayerBlueprint(id) {
-            const blueprint = layerBlueprints.find(blueprint =>
-                blueprint.config.id === id);
+            const blueprint = layerBlueprints.find(blueprint => blueprint.config.id === id);
 
             // TODO: this should return something meaningful for info sections and maybe sets?
             return blueprint;
@@ -974,23 +979,25 @@ function legendServiceFactory($rootScope, Geo, ConfigObject, configService, stat
         /**
          * A helper function to wait on the layer load.
          *
-         * @param {*} layerRecord
+         * @param {Promise<LayerRecord>} layerRecordPromise a layer record promise from the layer registry
          * @returns {Promise<LayerRecord>} a promise of a layer record which resolve when the record is fully loaded
          */
-        function _waitOnLayerLoad(layerRecord) {
-            const promise = common.$q(resolve => {
-                // TODO: there is a potential for race condition if a listener is set too late
-                layerRecord.addStateListener(_onLayerRecordLoad);
+        function _waitOnLayerLoad(layerRecordPromise) {
+            const promise = common.$q(resolve =>
+                layerRecordPromise.then(layerRecord => {
+                    // TODO: there is a potential for race condition if a listener is set too late
+                    layerRecord.addStateListener(_onLayerRecordLoad);
 
-                function _onLayerRecordLoad(state) {
-                    if (state !== 'rv-loaded') {
-                        return;
+                    function _onLayerRecordLoad(state) {
+                        if (state !== 'rv-loaded') {
+                            return;
+                        }
+
+                        layerRecord.removeStateListener(_onLayerRecordLoad);
+                        resolve(layerRecord);
                     }
-
-                    layerRecord.removeStateListener(_onLayerRecordLoad);
-                    resolve(layerRecord);
-                }
-            })
+                })
+            );
 
             return promise;
         }


### PR DESCRIPTION
## Description
This is related to #2859. This comment specifically: #2859 (comment).

This is another refactor update leading up to hopefully fixing layer loading process.
The generation of `LayerRecord`s is now treated as an async call. `LayerBlueprint`s return promises resolving with `LayerRecord`s (although the blueprint loading process is not fixed yet - that's the next part). A `LayerRecord` can now exist in a sort of limbo, not added to the map yet, but in the process of being made. As such, it will be excluded from the `map.layerRecords` array. There is a new function in the `layerRegistry` to get a promise of `LayerRecord` even if it's still loading. 

There are now two major cases:
### All layers except WFS and config-loaded file-based layers
`LayerRecord`s are made "instantaneously"; their `proxy` objects are also created synchronously. The corresponding `LayerBlocks` wait for the proxy's state to change to `rv-loaded` to render the proper legend. (In case of user-loaded files, the `LayerRecord` is made sync __because__ you already have the data before a `LegendBlock` needs to be made. Config-loaded file-based layers are not supported yet.)

### WFS and config-loaded file-based layers
`LayerRecord`s are made asynchronously because we need to get the data __before__ making a `LayerRecord`. So, `LayerRecord` generation is async loading of data and sync creating the record. Now, with legend rendering decoupled from `LayerRecord` creation, we can display `LegendBlocks` for such layers __while__ the data is loading without resorting to hacks with swapping layer guts inside `LayerRecord`s. 

Take a bee candy if you've read this far.

The next step is to fix blueprint generation of `LayerRecord`s and shoehorn WFS loading into this new paradigm.

There should be no changes in the app behaviour. If you see any, it's a bug.

P.S.: I prettified the legend-block file as well.

## Testing
:horse: 

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- ~~[ ] Release notes have been updated~~
- [x] PR targets the correct release version
- ~~[ ] Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2928)
<!-- Reviewable:end -->
