### PR TITLE
Symbology stack checkboxes aligned with parent

### DIFF
--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -216,12 +216,13 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
 
                         // Manually correct symbology boxes so they align with all other layer visibility boxes
                         const symbolButtonOffset =
-                            parseInt(element.closest('rv-legend-block').css('padding-left')) - 30;
+                            parseInt(element.closest('rv-legend-block').css('padding-left')) - 35.4;
 
                         // angular is not rendering the nestled buttons fast enough so keep checking until they're ready
                         const stopSymbolInterval = $interval(() => {
                             const symbolButtons = element.find('.md-icon-button').not('.rv-symbol-trigger');
                             if (symbolButtons.length > 0) {
+                                symbolButtons.css('position', 'absolute');
                                 symbolButtons.css('right', `${symbolButtonOffset}px`);
                                 $interval.cancel(stopSymbolInterval);
                             }


### PR DESCRIPTION
## Description
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2888.

- Symbology toggle checkboxes are now aligned with parent layer checkboxes
- Achieved by adjusting padding slightly

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Pixel alignment tested using [Greenshot](http://getgreenshot.org/)

1. http://fgpv.cloudapp.net/demo/users/ShrutiVellanki/symbology-checkboxes/dev/samples/index-samples.html?keys=JOSM,CESI_Other,NPRI_CO

2. Sample 46, look at these layers: 

![capture](https://user-images.githubusercontent.com/25359812/44267459-49653480-a1fc-11e8-8eeb-287092bf91ad.PNG)
![capture2](https://user-images.githubusercontent.com/25359812/44267463-4ec27f00-a1fc-11e8-964a-e498dbc18be3.PNG)





## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
none

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2939)
<!-- Reviewable:end -->
