### PR TITLE
Fix symbology stack overlapping issue

### DIFF
--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -573,7 +573,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                 lineHeight = parseInt(symbolItem.label.css('line-height').slice(0, -2));
                 padding = parseInt(symbolItem.label.css('padding-bottom').slice(0, -2)) + parseInt(symbolItem.label.css('padding-top').slice(0, -2));
                 const sidePadding = parseInt(symbolItem.label.css('padding-left').slice(0, -2)) + parseInt(symbolItem.label.css('padding-right').slice(0, -2));
-                labelHeight = Math.max(Math.ceil(textWidth / (itemWidth - sidePadding)) * lineHeight + padding, lineHeight + padding);
+                labelHeight = Math.floor(textWidth / (ref.maxItemWidth - sidePadding) + 1) * lineHeight + padding;
             }
 
             // animate symbology container's size
@@ -609,7 +609,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                 RV_DURATION / 3 * 2,
                 {
                     width: itemWidth,
-                    height: itemHeight + labelHeight - lineHeight - padding,
+                    height: itemHeight,
                     padding: 0, // removes padding from expanded wms legend images making them clearer; TODO: revisit when all symbology is svg items
                     ease: RV_SWIFT_IN_OUT_EASE
                 },

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -355,9 +355,11 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                 Math.max(
                     ...ref.symbolItems.map(symbolItem => {
                         const svgImage = symbolItem.image.find('svg')[0];
+                        const texLRPadding = (parseInt(symbolItem.label.css('padding-left').slice(0, -2))
+                                                + parseInt(symbolItem.label.css('padding-right').slice(0, -2)));
                         return Math.max(
                             svgImage ? svgImage.viewBox.baseVal.width : 0,
-                            getTextWidth(canvas, symbolItem.label.text(), 'normal 14px Roboto')
+                            getTextWidth(canvas, symbolItem.label.text(), 'normal 14px Roboto') + texLRPadding
                         );
                     }
 
@@ -564,12 +566,14 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             // extremely convoluted math to calculate an aproximation of the label's height
             // can't just get outerHeight() since it returns strange values when the symbology stack isn't expanded
             let labelHeight = 0;
+            let lineHeight = 0;
+            let padding = 0;
             const textWidth = getTextWidth(canvas, symbolItem.label[0].innerText, symbolItem.label.css('font'));
             if (textWidth > 0) {
-                const lineHeight = parseInt(symbolItem.label.css('line-height').slice(0, -2));
-                const padding = parseInt(symbolItem.label.css('padding-bottom').slice(0, -2)) + parseInt(symbolItem.label.css('padding-top').slice(0, -2));
+                lineHeight = parseInt(symbolItem.label.css('line-height').slice(0, -2));
+                padding = parseInt(symbolItem.label.css('padding-bottom').slice(0, -2)) + parseInt(symbolItem.label.css('padding-top').slice(0, -2));
                 const sidePadding = parseInt(symbolItem.label.css('padding-left').slice(0, -2)) + parseInt(symbolItem.label.css('padding-right').slice(0, -2));
-                labelHeight = Math.ceil(textWidth / (itemWidth - sidePadding)) * lineHeight + padding;
+                labelHeight = Math.max(Math.ceil(textWidth / (itemWidth - sidePadding)) * lineHeight + padding, lineHeight + padding);
             }
 
             // animate symbology container's size
@@ -605,7 +609,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                 RV_DURATION / 3 * 2,
                 {
                     width: itemWidth,
-                    height: itemHeight,
+                    height: itemHeight + labelHeight - lineHeight - padding,
                     padding: 0, // removes padding from expanded wms legend images making them clearer; TODO: revisit when all symbology is svg items
                     ease: RV_SWIFT_IN_OUT_EASE
                 },

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -573,7 +573,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                 lineHeight = parseInt(symbolItem.label.css('line-height').slice(0, -2));
                 padding = parseInt(symbolItem.label.css('padding-bottom').slice(0, -2)) + parseInt(symbolItem.label.css('padding-top').slice(0, -2));
                 const sidePadding = parseInt(symbolItem.label.css('padding-left').slice(0, -2)) + parseInt(symbolItem.label.css('padding-right').slice(0, -2));
-                labelHeight = Math.floor(textWidth / (ref.maxItemWidth - sidePadding) + 1) * lineHeight + padding;
+                labelHeight = Math.floor(textWidth / (0.9 * (ref.maxItemWidth - sidePadding)) + 1) * lineHeight + padding;  // divide by 0.9 due to display rounding
             }
 
             // animate symbology container's size


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2935 

Prevent symbology stack overlapping and fix the issue with description of the symbol not fully shown.
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
1. Add service: http://maps.geogratis.gc.ca/wms/railway_en
2. Add `Railway Subdivision Name` (the image is not working) and add any other layer(s)
3. Open the symbology stack.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2943)
<!-- Reviewable:end -->
