### PR TITLE
enhance export legend 

### DIFF
--- a/api/src/schema.d.ts
+++ b/api/src/schema.d.ts
@@ -311,6 +311,10 @@ export interface FgpvConfigSchema {
          * Indicates whether symbology from controlled layers should be included in export legend
          */
         showControlledSymbology?: boolean;
+        /**
+         * Value in pixels to be used as the column width for the export legend.
+         */
+        columnWidth?: number;
       };
       /**
        * Foot notice to add to exported map

--- a/schema.json
+++ b/schema.json
@@ -181,6 +181,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Indicates whether symbology from controlled layers should be included in export legend"
+                },
+                "columnWidth": {
+                    "type": "integer",
+                    "default": false,
+                    "description": "Value in pixels to be used as the column width for the export legend."
                 }
             },
             "description": "This is the initial configuration for a legend export component.",

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1886,6 +1886,7 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
 
             this._showInfoSymbology = source.showInfoSymbology || false;
             this._showControlledSymbology = source.showControlledSymbology || false;
+            this._columnWidth = source.columnWidth || null;
         }
 
         get showInfoSymbology () {      return this._showInfoSymbology; }
@@ -1894,10 +1895,13 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
         get showControlledSymbology () {      return this._showControlledSymbology; }
         set showControlledSymbology (value) { this._showControlledSymbology = value; }
 
+        get columnWidth () { return this._columnWidth }
+
         get JSON() {
             return angular.merge(super.JSON, {
                 showInfoSymbology: this.showInfoSymbology,
-                showControlledSymbology: this.showControlledSymbology
+                showControlledSymbology: this.showControlledSymbology,
+                columnWidth: this.columnWidth
             });
         }
     }

--- a/src/app/ui/export/export-generators.service.js
+++ b/src/app/ui/export/export-generators.service.js
@@ -217,7 +217,12 @@ function exportGenerators($q, $filter, $translate, configService, graphicsServic
      */
     function legendGenerator(exportSize) {
         // update `exportLegendService.generate` function to take ExportSize object as the first parameter
-        const legendPromise = exportLegendService.generate(exportSize.height, exportSize.width, 350);
+        let columnWidth;
+        if (configService.getSync.services.export && configService.getSync.services.export.legend) {
+            columnWidth = configService.getSync.services.export.legend.columnWidth;
+        }
+
+        const legendPromise = exportLegendService.generate(exportSize.height, exportSize.width, columnWidth || 350);
 
         return wrapOutput(legendPromise);
     }

--- a/src/app/ui/export/export-legend.service.js
+++ b/src/app/ui/export/export-legend.service.js
@@ -26,9 +26,7 @@ const SYMBOL_SIZE = 32;
  * The `exportLegendService` service generates svg image of the legend breaking into into columns.
  *
  */
-angular
-    .module('app.ui')
-    .service('exportLegendService', exportLegendService);
+angular.module('app.ui').service('exportLegendService', exportLegendService);
 
 function exportLegendService($q, $rootElement, geoService, LegendBlock, configService, gapiService, graphicsService) {
     const service = {
@@ -48,7 +46,6 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
      * @return {Promise} promise with resolves with a canvas containing the legend
      */
     function generate(availableHeight = 500, availableWidth = 1500, preferredSectionWidth = 500) {
-
         // I think this todo is done.
         // TODO: break item names when they overflow even if there are no spaces in the name
 
@@ -89,10 +86,11 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
 
             // optimize; get back the number of sections used
             // if only one column available, ignore optimization
-            sectionsUsed = sectionInfo.count === 1 ?
-                1 :
-                gapiService.gapi.legend.makeLegend(legendDataCopy, sectionInfo.count, availableHeight)
-                    .sectionsUsed;
+            sectionsUsed =
+                sectionInfo.count === 1
+                    ? 1
+                    : gapiService.gapi.legend.makeLegend(legendDataCopy, sectionInfo.count, availableHeight)
+                          .sectionsUsed;
         }
 
         wraplegend(svgLegend, sectionInfo);
@@ -100,9 +98,7 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
         const totalLegendHeight = sectionInfo.height + LEGEND_MARGIN.t + LEGEND_MARGIN.b;
 
         // set the height of the legend based on the height of its sections
-        legend
-            .height(totalLegendHeight)
-            .viewbox(0, 0, availableWidth, totalLegendHeight);
+        legend.height(totalLegendHeight).viewbox(0, 0, availableWidth, totalLegendHeight);
 
         hiddenNode.remove();
 
@@ -111,8 +107,7 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
             canvg(localCanvas, legend.node.outerHTML, {
                 ignoreAnimation: true,
                 ignoreMouse: true,
-                renderCallback: () =>
-                    resolve(localCanvas)
+                renderCallback: () => resolve(localCanvas)
             });
         });
 
@@ -125,9 +120,10 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
          * @return {Number} returns the section width
          */
         function getSectionWidth() {
-            return (availableWidth -
-                (LEGEND_MARGIN.l + LEGEND_MARGIN.r + (sectionInfo.count - 1) * SECTION_SPACING)) /
-            sectionInfo.count;
+            return (
+                (availableWidth - (LEGEND_MARGIN.l + LEGEND_MARGIN.r + (sectionInfo.count - 1) * SECTION_SPACING)) /
+                sectionInfo.count
+            );
         }
     }
 
@@ -142,7 +138,6 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
      *                 {Number} sectionCount number of sections to break the legend into
      */
     function wraplegend(svgLegend, sectionInfo) {
-
         // create wrap legend sections
         const sections = Array.from(Array(sectionInfo.count)).map(() => svgLegend.container.set());
 
@@ -153,13 +148,11 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
         const lineStoreSet = svgLegend.lines; // use a group line set from svgLegend
 
         // moves legend items from an array to a set
-        svgLegend.items.forEach(svg =>
-            itemStoreSet.add(svg));
+        svgLegend.items.forEach(svg => itemStoreSet.add(svg));
 
         svgLegend.items.forEach(svg => {
             // wrap the legend at elements previously marked
             if (svg.remember('self').splitBefore) {
-
                 const svgY = svg.y();
 
                 // cut the group lines at the wrapping point
@@ -176,15 +169,14 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                     // if the line starts above and ends below the wrapping element
                     if (lineY + lineHeight > svgY) {
                         // split the line in two parts: above and below the wrap
-                        const up = svgLegend.container.line(lineX, lineY, lineX, Math.min(svgY, sectionInfo.height))
+                        const up = svgLegend.container
+                            .line(lineX, lineY, lineX, Math.min(svgY, sectionInfo.height))
                             .stroke('black');
-                        const down = svgLegend.container.line(lineX, svgY, lineX, lineY + lineHeight)
-                            .stroke('black');
+                        const down = svgLegend.container.line(lineX, svgY, lineX, lineY + lineHeight).stroke('black');
 
                         line.remove(); // remove original line
                         currentSection.add(up); // store the above part in the  current section
                         lineStoreSet.add(down); // add the below part to the list store for future wrapping (a single line can wrap and be cut multiple time)
-
                     } else {
                         currentSection.add(line); // if the line fits in the current section, add it there
                     }
@@ -332,27 +324,26 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                 anchor: 'start'
             };
 
-            const imageItem = legendItem.group().svg(svgcode).first();
+            const imageItem = legendItem
+                .group()
+                .svg(svgcode)
+                .first();
             const imageItemViewbox = imageItem.viewbox();
 
             /// Use the narrower width as the bound for the image
-            if (imageItemViewbox.width > sectionWidth){
+            if (imageItemViewbox.width > sectionWidth) {
                 const imgLookFactor = 0.9; // So it'd have space on left and right for the visual look
-                imageItemViewbox.height *= ((sectionWidth / imageItemViewbox.width) * imgLookFactor);
+                imageItemViewbox.height *= (sectionWidth / imageItemViewbox.width) * imgLookFactor;
                 imageItemViewbox.width = sectionWidth * imgLookFactor;
             }
 
             if (imageItemViewbox.height > SYMBOL_SIZE || imageItemViewbox.width > SYMBOL_SIZE) {
-
                 flow = legendItem
                     .textflow(name, sectionWidth - runningIndent * indentD)
                     .attr(flowAttributes)
                     .dy(-4);
 
-                imageItem
-                    .size(imageItemViewbox.width, imageItemViewbox.height)
-                    .dy(flow.bbox().height + IMAGE_GUTTER);
-
+                imageItem.size(imageItemViewbox.width, imageItemViewbox.height).dy(flow.bbox().height + IMAGE_GUTTER);
             } else {
                 flow = legendItem
                     .textflow(name, sectionWidth - SYMBOL_SIZE - IMAGE_GUTTER - runningIndent * indentD)
@@ -366,7 +357,8 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
             }
 
             legendItem.move(runningIndent * indentD, runningHeight);
-            const heightToAppend = (legendItem.rbox().height > imageItemViewbox.height) ? legendItem.rbox().height : imageItemViewbox.height;
+            const heightToAppend =
+                legendItem.rbox().height > imageItemViewbox.height ? legendItem.rbox().height : imageItemViewbox.height;
             runningHeight += heightToAppend + ITEM_GUTTER;
 
             item.height = legendItem.rbox().height;
@@ -417,18 +409,15 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
      * @return {Array} a flat array of layers and their symbology items
      */
     function extractLegendTree(legendBlock) {
-
         const TYPE_TO_SYMBOLOGY = {
-            [LegendBlock.TYPES.NODE]: entry =>
-                ({
-                    name: entry.name,
-                    items: entry.symbologyStack.stack
-                }),
-            [LegendBlock.TYPES.GROUP]: entry =>
-                ({
-                    name: entry.name,
-                    items: extractLegendTree(entry)
-                }),
+            [LegendBlock.TYPES.NODE]: entry => ({
+                name: entry.name,
+                items: entry.symbologyStack.stack
+            }),
+            [LegendBlock.TYPES.GROUP]: entry => ({
+                name: entry.name,
+                items: extractLegendTree(entry)
+            }),
             [LegendBlock.TYPES.SET]: () => null,
             [LegendBlock.TYPES.INFO]: entry => {
                 if (entry.infoType === 'image') {
@@ -436,8 +425,9 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                     return {
                         name: '',
                         items: [{ name: '', svgcode: svgCode }],
-                        blockType: LegendBlock.TYPES.INFO
-                    }
+                        blockType: LegendBlock.TYPES.INFO,
+                        infoType: entry.infoType
+                    };
                 } else {
                     const content = entry.layerName || entry.content;
 
@@ -446,8 +436,9 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                         return {
                             name: removeMd(content),
                             items: entry.symbologyStack.stack || [],
-                            blockType: LegendBlock.TYPES.INFO
-                        }
+                            blockType: LegendBlock.TYPES.INFO,
+                            infoType: entry.infoType
+                        };
                     }
 
                     const contentToHtml = marked(content);
@@ -457,8 +448,9 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                         return {
                             name: entry.layerName || entry.content,
                             items: entry.symbologyStack.stack || [],
-                            blockType: LegendBlock.TYPES.INFO
-                        }
+                            blockType: LegendBlock.TYPES.INFO,
+                            infoType: entry.infoType
+                        };
                     }
 
                     const canvas = service.canvas || (service.canvas = document.createElement('canvas'));
@@ -482,34 +474,61 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
 
                     const DOMURL = window.URL || window.webkitURL || window;
                     const img = new Image();
-                    const svg = new Blob([data], {type: 'image/svg+xml'});
+                    const svg = new Blob([data], { type: 'image/svg+xml' });
                     const url = DOMURL.createObjectURL(svg);
 
                     img.onload = function() {
-                      ctx.drawImage(this, 0, 0);
-                      DOMURL.revokeObjectURL(url);
-                    }
+                        ctx.drawImage(this, 0, 0);
+                        DOMURL.revokeObjectURL(url);
+                    };
 
                     img.src = url;
 
                     // we now have a local image and URL that we can wrap in a legend generator supported svg element
                     return {
                         name: '',
-                        items: [{ name: '', svgcode: `<svg xmlns:xlink="http://www.w3.org/1999/xlink" height="${approxHeight}" width="${correctedWidth}"><image height="${approxHeight}" width="${correctedWidth}" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="${url}"></image></svg>` }].concat(entry.symbologyStack.stack || []),
-                        blockType: LegendBlock.TYPES.INFO
-                    }
+                        items: [
+                            {
+                                name: '',
+                                svgcode: `<svg xmlns:xlink="http://www.w3.org/1999/xlink" height="${approxHeight}" width="${correctedWidth}"><image height="${approxHeight}" width="${correctedWidth}" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="${url}"></image></svg>`
+                            }
+                        ].concat(entry.symbologyStack.stack || []),
+                        blockType: LegendBlock.TYPES.INFO,
+                        infoType: entry.infoType
+                    };
                 }
             }
-        }
+        };
 
         // TODO: decide if symbology from the duplicated layer should be included in the export image
-        const legendTreeData = legendBlock
-            .walk(entry => _showBlock(entry) ?
-                    TYPE_TO_SYMBOLOGY[entry.blockType](entry) : null,
-                entry => entry.blockType === LegendBlock.TYPES.GROUP ? false : true)      // don't walk entry's children if it's a group
-            .filter(a =>
-                a !== null);
-        return legendTreeData.filter(entry => entry.blockType === LegendBlock.TYPES.INFO || entry.items.length > 0);
+        let legendTreeData = legendBlock
+            .walk(
+                entry => (_showBlock(entry) ? TYPE_TO_SYMBOLOGY[entry.blockType](entry) : null),
+                entry => (entry.blockType === LegendBlock.TYPES.GROUP ? false : true)
+            ) // don't walk entry's children if it's a group
+            .filter(a => a !== null);
+
+        let titleBefore = false;
+        legendTreeData = legendTreeData
+            // filter out non-info blocks with no symbology
+            .filter(entry => entry.blockType === LegendBlock.TYPES.INFO || entry.items.length > 0)
+            // clear out titles where everything below it (or in between another title) has been removed
+            // The two reverses let us filter backwards, making detection of bad titles easier.
+            .reverse()
+            .filter((entry, index) => {
+                if (entry.infoType && entry.infoType === 'title') {
+                    if (index === 0 || titleBefore) {
+                        titleBefore = true;
+                        return false;
+                    }
+                    titleBefore = true;
+                } else {
+                    titleBefore = false;
+                }
+                return true;
+            })
+            .reverse();
+        return legendTreeData;
     }
 
     /**
@@ -551,7 +570,7 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
         let svgimg = document.createElementNS('http://www.w3.org/2000/svg', 'image');
         svgimg.setAttribute('height', img.naturalHeight);
         svgimg.setAttribute('width', img.naturalWidth);
-        svgimg.setAttributeNS('http://www.w3.org/1999/xlink','href', link);
+        svgimg.setAttributeNS('http://www.w3.org/1999/xlink', 'href', link);
 
         svg.appendChild(svgimg);
 

--- a/src/content/samples/config/config-sample-77.json
+++ b/src/content/samples/config/config-sample-77.json
@@ -1,0 +1,544 @@
+{
+    "ui": {
+      "navBar": {
+        "zoom": "buttons",
+        "extra": [
+          "fullscreen",
+          "geoLocator",
+          "home",
+          "help"
+        ]
+      },
+      "sideMenu": {
+        "logo": true
+      },
+      "legend": {
+        "isOpen": {
+          "large": true,
+          "medium": true,
+          "small": false
+        },
+        "reorderable": false
+      }
+    },
+    "version": "2.0",
+    "language": "en",
+    "services": {
+      "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+      "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+      "export": {
+        "title": {
+          "value": "Title"
+        },
+        "map": {},
+        "mapElements": {},
+        "legend": {
+          "columnWidth": 1000,
+          "showInfoSymbology": true
+        },
+        "footnote": {
+          "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+        }
+      },
+      "search": {
+        "serviceUrls": {
+          "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
+          "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
+          "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+          "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
+          "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+        }
+      }
+    },
+    "map": {
+      "initialBasemapId": "baseNrCan",
+      "components": {
+        "geoSearch": {
+          "enabled": true,
+          "showGraphic": true,
+          "showInfo": true
+        },
+        "mouseInfo": {
+          "enabled": true,
+          "spatialReference": {
+            "wkid": 102100
+          }
+        },
+        "northArrow": {
+          "enabled": true
+        },
+        "basemap": {
+          "enabled": true
+        },
+        "overviewMap": {
+          "enabled": true,
+          "layerType": "imagery"
+        },
+        "scaleBar": {
+          "enabled": true
+        }
+      },
+      "extentSets": [
+        {
+          "id": "EXT_NRCAN_Lambert_3978",
+          "default": {
+            "xmax": 3549492,
+            "xmin": -2681457,
+            "ymax": 3482193,
+            "ymin": -883440
+          },
+          "spatialReference": {
+            "wkid": 3978
+          }
+        },
+        {
+          "id": "EXT_ESRI_World_AuxMerc_3857",
+          "default": {
+            "xmax": -5007771.626060756,
+            "xmin": -16632697.354854,
+            "ymax": 10015875.184845109,
+            "ymin": 5022907.964742964
+          },
+          "spatialReference": {
+            "wkid": 102100,
+            "latestWkid": 3857
+          }
+        }
+      ],
+      "lodSets": [
+        {
+          "id": "LOD_NRCAN_Lambert_3978",
+          "lods": [
+            {
+              "level": 0,
+              "resolution": 38364.660062653464,
+              "scale": 145000000
+            },
+            {
+              "level": 1,
+              "resolution": 22489.62831258996,
+              "scale": 85000000
+            },
+            {
+              "level": 2,
+              "resolution": 13229.193125052918,
+              "scale": 50000000
+            },
+            {
+              "level": 3,
+              "resolution": 7937.5158750317505,
+              "scale": 30000000
+            },
+            {
+              "level": 4,
+              "resolution": 4630.2175937685215,
+              "scale": 17500000
+            },
+            {
+              "level": 5,
+              "resolution": 2645.8386250105837,
+              "scale": 10000000
+            },
+            {
+              "level": 6,
+              "resolution": 1587.5031750063501,
+              "scale": 6000000
+            },
+            {
+              "level": 7,
+              "resolution": 926.0435187537042,
+              "scale": 3500000
+            },
+            {
+              "level": 8,
+              "resolution": 529.1677250021168,
+              "scale": 2000000
+            },
+            {
+              "level": 9,
+              "resolution": 317.50063500127004,
+              "scale": 1200000
+            },
+            {
+              "level": 10,
+              "resolution": 185.20870375074085,
+              "scale": 700000
+            },
+            {
+              "level": 11,
+              "resolution": 111.12522225044451,
+              "scale": 420000
+            },
+            {
+              "level": 12,
+              "resolution": 66.1459656252646,
+              "scale": 250000
+            },
+            {
+              "level": 13,
+              "resolution": 38.36466006265346,
+              "scale": 145000
+            },
+            {
+              "level": 14,
+              "resolution": 22.48962831258996,
+              "scale": 85000
+            },
+            {
+              "level": 15,
+              "resolution": 13.229193125052918,
+              "scale": 50000
+            },
+            {
+              "level": 16,
+              "resolution": 7.9375158750317505,
+              "scale": 30000
+            },
+            {
+              "level": 17,
+              "resolution": 4.6302175937685215,
+              "scale": 17500
+            }
+          ]
+        },
+        {
+          "id": "LOD_ESRI_World_AuxMerc_3857",
+          "lods": [
+            {
+              "level": 0,
+              "resolution": 19567.87924099992,
+              "scale": 73957190.948944
+            },
+            {
+              "level": 1,
+              "resolution": 9783.93962049996,
+              "scale": 36978595.474472
+            },
+            {
+              "level": 2,
+              "resolution": 4891.96981024998,
+              "scale": 18489297.737236
+            },
+            {
+              "level": 3,
+              "resolution": 2445.98490512499,
+              "scale": 9244648.868618
+            },
+            {
+              "level": 4,
+              "resolution": 1222.992452562495,
+              "scale": 4622324.434309
+            },
+            {
+              "level": 5,
+              "resolution": 611.4962262813797,
+              "scale": 2311162.217155
+            },
+            {
+              "level": 6,
+              "resolution": 305.74811314055756,
+              "scale": 1155581.108577
+            },
+            {
+              "level": 7,
+              "resolution": 152.87405657041106,
+              "scale": 577790.554289
+            },
+            {
+              "level": 8,
+              "resolution": 76.43702828507324,
+              "scale": 288895.277144
+            },
+            {
+              "level": 9,
+              "resolution": 38.21851414253662,
+              "scale": 144447.638572
+            },
+            {
+              "level": 10,
+              "resolution": 19.10925707126831,
+              "scale": 72223.819286
+            },
+            {
+              "level": 11,
+              "resolution": 9.554628535634155,
+              "scale": 36111.909643
+            },
+            {
+              "level": 12,
+              "resolution": 4.77731426794937,
+              "scale": 18055.954822
+            },
+            {
+              "level": 13,
+              "resolution": 2.388657133974685,
+              "scale": 9027.977411
+            },
+            {
+              "level": 14,
+              "resolution": 1.1943285668550503,
+              "scale": 4513.988705
+            },
+            {
+              "level": 15,
+              "resolution": 0.5971642835598172,
+              "scale": 2256.994353
+            },
+            {
+              "level": 16,
+              "resolution": 0.29858214164761665,
+              "scale": 1128.497176
+            },
+            {
+              "level": 17,
+              "resolution": 0.14929107082380833,
+              "scale": 564.248588
+            },
+            {
+              "level": 18,
+              "resolution": 0.07464553541190416,
+              "scale": 282.124294
+            },
+            {
+              "level": 19,
+              "resolution": 0.03732276770595208,
+              "scale": 141.062147
+            },
+            {
+              "level": 20,
+              "resolution": 0.01866138385297604,
+              "scale": 70.5310735
+            }
+          ]
+        }
+      ],
+      "legend": {
+        "type": "structured",
+        "root": {
+          "name": "root",
+          "children": [
+            {
+              "layerId": "1"
+            },
+            {
+              "infoType": "title",
+              "content": "Will stay"
+            },
+            {
+              "layerId": "3"
+            },
+            {
+              "infoType": "title",
+              "content": "Will stay"
+            },
+            {
+              "layerId": "4"
+            },
+            {
+              "layerId": "6"
+            },
+            {
+              "infoType": "title",
+              "content": "will disappear"
+            },
+            {
+              "infoType": "title",
+              "content": "will disappear"
+            }
+          ]
+        }
+      },
+      "layers": [
+        {
+          "id": "1",
+          "name": "Energy infrastructure 2",
+          "layerType": "esriFeature",
+          "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
+        },
+        {
+          "id": "3",
+          "name": "Energy infrastructure 4",
+          "layerType": "esriFeature",
+          "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/4"
+        },
+        {
+          "id": "4",
+          "name": "No initial filter",
+          "layerType": "esriFeature",
+          "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/5"
+        },
+        {
+          "id": "6",
+          "name": "Dynamic Layer",
+          "layerType": "esriDynamic",
+          "layerEntries": [
+            {
+              "index": 14
+            },
+            {
+              "index": 15
+            }
+          ],
+          "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer"
+        }
+      ],
+      "tileSchemas": [
+        {
+          "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+          "name": "Lambert Maps",
+          "extentSetId": "EXT_NRCAN_Lambert_3978",
+          "lodSetId": "LOD_NRCAN_Lambert_3978",
+          "hasNorthPole": true
+        },
+        {
+          "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+          "name": "Web Mercator Maps",
+          "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+          "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+        }
+      ],
+      "baseMaps": [
+        {
+          "id": "baseNrCan",
+          "name": "Canada Base Map - Transportation (CBMT)",
+          "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+          "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+          "layers": [
+            {
+              "id": "CBMT",
+              "layerType": "esriFeature",
+              "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseSimple",
+          "name": "Canada Base Map - Simple",
+          "description": "Canada Base Map - Simple",
+          "altText": "altText - Canada base map - Simple",
+          "layers": [
+            {
+              "id": "SMR",
+              "layerType": "esriFeature",
+              "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseCBME_CBCE_HS_RO_3978",
+          "name": "Canada Base Map - Elevation (CBME)",
+          "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+          "altText": "altText - Canada Base Map - Elevation (CBME)",
+          "layers": [
+            {
+              "id": "CBME_CBCE_HS_RO_3978",
+              "layerType": "esriFeature",
+              "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseCBMT_CBCT_GEOM_3978",
+          "name": "Canada Base Map - Transportation (CBMT)",
+          "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+          "altText": "altText - Canada Base Map - Transportation (CBMT)",
+          "layers": [
+            {
+              "id": "CBMT_CBCT_GEOM_3978",
+              "layerType": "esriFeature",
+              "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseEsriWorld",
+          "name": "World Imagery",
+          "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+          "altText": "altText - World Imagery",
+          "layers": [
+            {
+              "id": "World_Imagery",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriPhysical",
+          "name": "World Physical Map",
+          "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+          "altText": "altText - World Physical Map",
+          "layers": [
+            {
+              "id": "World_Physical_Map",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriRelief",
+          "name": "World Shaded Relief",
+          "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+          "altText": "altText - World Shaded Relief",
+          "layers": [
+            {
+              "id": "World_Shaded_Relief",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriStreet",
+          "name": "World Street Map",
+          "description": "This worldwide street map presents highway-level data for the world.",
+          "altText": "altText - ESWorld Street Map",
+          "layers": [
+            {
+              "id": "World_Street_Map",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriTerrain",
+          "name": "World Terrain Base",
+          "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+          "altText": "altText - World Terrain Base",
+          "layers": [
+            {
+              "id": "World_Terrain_Base",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriTopo",
+          "name": "World Topographic Map",
+          "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+          "altText": "altText - World Topographic Map",
+          "layers": [
+            {
+              "id": "World_Topo_Map",
+              "layerType": "esriFeature",
+              "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+            }
+          ],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        }
+      ]
+    }
+  }
+  

--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -226,7 +226,7 @@
 
     <script>
         var SAMPLE_KEY = 'sample';
-        var URL = new URL(window.location.href);
+        var currentUrl = new URL(window.location.href);
         document.getElementById('selectConfig').addEventListener("change", changeConfig);
         document.getElementById('loadButton').addEventListener("click", loadBookmark);
         document.getElementById('clearButton').addEventListener("click", clearBookmark);
@@ -307,7 +307,7 @@
 
         // Find and load the sample specified in the key `sample`.  If `sample` is not provided, defaults to first sample.
         function loadSample() {
-            var params = new URLSearchParams(URL.search);
+            var params = new URLSearchParams(currentUrl.search);
             var sampleIndex =  params.get(SAMPLE_KEY) - 1;
             var selectElem = document.getElementById('selectConfig');
             var sameplMapElem = document.getElementById('sample-map');
@@ -328,7 +328,7 @@
                     var sampleIndex = 0;
                     params.set('sample', sampleIndex + 1);
                     sessionStorage.setItem('sample', newSample);
-                    var newUrl = URL.origin + URL.pathname + '?' + params.toString();
+                    var newUrl = currentUrl.origin + currentUrl.pathname + '?' + params.toString();
                     window.location.href = newUrl;
                 }
             }
@@ -338,9 +338,9 @@
         function changeConfig() {
             var currentSample = document.getElementById('selectConfig').value; // load existing config
             sessionStorage.setItem('sample', currentSample); // store new config
-            var params = new URLSearchParams(URL.search);
+            var params = new URLSearchParams(currentUrl.search);
             params.set('sample', document.getElementById('selectConfig').selectedIndex + 1);
-            var newUrl = URL.origin + URL.pathname + '?' + params.toString();
+            var newUrl = currentUrl.origin + currentUrl.pathname + '?' + params.toString();
             window.location.href = newUrl;
         }
     </script>

--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -171,6 +171,7 @@
                 <option value="config/config-sample-76.json">74. Custom layer renderer on client</option>
                 <option value="config/config-sample-80.json">75. All layer types</option>
                 <option value="config/config-sample-81.json">76. WFS with system co-ords in attributes</option>
+                <option value="config/config-sample-77.json">77. Legend with titles that are removed in export and custom legend width</option>
             </select>
         </div>
 


### PR DESCRIPTION
Adds a config attr for custom legend column width.
Removes structured legend titles with nothing under them.

## Description
<!-- Link to an issue or include a description -->

Fixes issues with export legend structure, removes extra titles that no longer have entries between them and another title (or the end of the legend).
Also adds a config attribute `columnWidth` on export.legend that specifies the column width for the export legend image.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Sample 77: titles will do as their names imply, legend should be rendered as one column in default export.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2949)
<!-- Reviewable:end -->
