### PR TITLE
Fix bookmark encoding with non Latin1 characters 

### DIFF
--- a/src/app/core/bookmark.service.js
+++ b/src/app/core/bookmark.service.js
@@ -602,7 +602,7 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
      * @returns {String}        The encoded string
      */
     function encode64(string) {
-        return btoa(string).replace(/\=/g, '').replace(/\//g, '_').replace(/\+/g, '-');
+        return btoa(encodeURIComponent(string)).replace(/\=/g, '').replace(/\//g, '_').replace(/\+/g, '-');
     }
 
     /**
@@ -614,6 +614,6 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
      * @returns {String}        The decoded string
      */
     function decode64(string) {
-        return atob(string.replace(/_/g, '/').replace(/-/g, '+'));
+        return decodeURIComponent(atob(string.replace(/_/g, '/').replace(/-/g, '+')));
     }
 }

--- a/src/content/samples/bookmark-decode.html
+++ b/src/content/samples/bookmark-decode.html
@@ -20,7 +20,7 @@
     <div class="row"><div class="form-group col-md-12">
     </div></div>
 
-    <!-- Outputs -->    
+    <!-- Outputs -->
     <div class="row">
         <div class="form-group col-md-4">
             <label>Version</label>
@@ -280,7 +280,7 @@
 
             // Generate text for all layers
             layers.forEach(function (layer, i) {
-                layer = decode64(layer);
+                layer = decodeURIComponent(decode64(layer));
 
                 // strip out hex char that defines the layer type
                 var layerCode = parseInt(layer.substr(0, 1));
@@ -339,7 +339,7 @@
                     nextAnd = bookmark.length;
                 }
                 bookmark = bookmark.substring(keyStart + 3, nextAnd);
-            } 
+            }
 
             var version = bookmark.match(/^([^,]+)/)[0];
 
@@ -368,7 +368,7 @@
                     nextAnd = bookmark.length;
                 }
                 bookmark = bookmark.substring(keyStart + 3, nextAnd);
-            } 
+            }
 
             var rawOut = bookmark.split(',').map(function(nugget, idx) {
                 if (idx === 0) {

--- a/src/content/samples/config/config-sample-26.json
+++ b/src/content/samples/config/config-sample-26.json
@@ -79,13 +79,13 @@
     },
     "layers": [
       {
-        "id": "powerplant100mw-electric",
-        "name": "Electric Transmission Line",
+        "id": "Hydro energy resource potential – reservoir hydro",
+        "name": "Hydro energy resource potential – reservoir hydro***99015304",
         "layerType": "esriFeature",
         "disabledControls": [
           "remove"
         ],
-        "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/1"
+        "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/20"
       }
     ],
     "extentSets": [


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2944 

Fix issue where bookmark was not able to encode non Latin1 characters by convert them to URI components.
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
1. http://fgpv.cloudapp.net/demo/users/barryytm/2944/dev/samples/index-samples.html?sample=26
2. Go to Menu
3. Click SHARE
4. Copy the link and decode it in http://fgpv.cloudapp.net/demo/users/barryytm/2944/dev/samples/bookmark-decode.html

**Note:** The en dash `–` is not a Latin1 character.  

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
NA
## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] ~~Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2951)
<!-- Reviewable:end -->
