### PR TITLE
fix(export): export image working in chrome when legend is included

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -186,7 +186,7 @@
       }
     },
     "@claviska/jquery-minicolors": {
-      "version": "github:claviska/jquery-minicolors#0bca978062312ed622eb481af35f7d71171390d5"
+      "version": "github:claviska/jquery-minicolors#a4ad885ebc392836b295c6ef7e8bb653f2ff8a8f"
     },
     "@flowjs/ng-flow": {
       "version": "2.7.8",
@@ -4391,9 +4391,6 @@
         "buffer-indexof": "1.1.1"
       }
     },
-    "docdash": {
-      "version": "git+https://github.com/alyec/docdash.git#0ac9d0dd482a9b65aa0885d5279fafc566a91f9b"
-    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -6384,10 +6381,29 @@
         "text-encoding": "0.6.4"
       },
       "dependencies": {
+        "docdash": {
+          "version": "git+https://github.com/alyec/docdash.git#0ac9d0dd482a9b65aa0885d5279fafc566a91f9b"
+        },
         "jquery": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
           "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
+        },
+        "shpjs": {
+          "version": "git+https://github.com/fgpv-vpgf/shapefile-js.git#dd6b31899dee1d70f106b3725430f2eb5f0b350c",
+          "requires": {
+            "jszip": "2.6.1",
+            "lie": "3.3.0",
+            "lru-cache": "2.7.3",
+            "parsedbf": "1.0.0",
+            "proj4": "2.4.4"
+          }
+        },
+        "terraformer-proj4js": {
+          "version": "git+https://github.com/RAMP-PCAR/terraformer-proj4js.git#b2bac5f00e95cf37dd53d5c18821cfa429b9eaf4",
+          "requires": {
+            "terraformer": "1.0.9"
+          }
         }
       }
     },
@@ -13231,16 +13247,6 @@
         "rechoir": "0.6.2"
       }
     },
-    "shpjs": {
-      "version": "git+https://github.com/fgpv-vpgf/shapefile-js.git#dd6b31899dee1d70f106b3725430f2eb5f0b350c",
-      "requires": {
-        "jszip": "2.6.1",
-        "lie": "3.3.0",
-        "lru-cache": "2.7.3",
-        "parsedbf": "1.0.0",
-        "proj4": "2.5.0"
-      }
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -14053,12 +14059,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/terraformer-arcgis-parser/-/terraformer-arcgis-parser-1.0.5.tgz",
       "integrity": "sha1-sdRrJG7SzoJLtrdEzVHAj3S5ZAQ=",
-      "requires": {
-        "terraformer": "1.0.9"
-      }
-    },
-    "terraformer-proj4js": {
-      "version": "git+https://github.com/RAMP-PCAR/terraformer-proj4js.git#b2bac5f00e95cf37dd53d5c18821cfa429b9eaf4",
       "requires": {
         "terraformer": "1.0.9"
       }

--- a/src/app/core/graphics.service.js
+++ b/src/app/core/graphics.service.js
@@ -41,6 +41,7 @@ function graphicsService($q) {
             const options = angular.extend(
                 defaultOptions,
                 optionOverrides,
+                {useCORS: false},
                 { renderCallback: () => resolve(canvas) }
             );
 

--- a/src/app/ui/export/export-legend.service.js
+++ b/src/app/ui/export/export-legend.service.js
@@ -472,17 +472,20 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                         </svg>
                     `;
 
-                    const DOMURL = window.URL || window.webkitURL || window;
                     const img = new Image();
-                    const svg = new Blob([data], { type: 'image/svg+xml' });
-                    const url = DOMURL.createObjectURL(svg);
+                    const svg = new Blob([data], {type: 'image/svg+xml'});
+
+                    // workaround for known chrome issue https://bugs.chromium.org/p/chromium/issues/detail?id=294129
+                    const reader = new FileReader();
+                    reader.readAsDataURL(svg);
+
+                    reader.onload = function(e) {
+                        img.src = e.target.result;
+                    }
 
                     img.onload = function() {
-                        ctx.drawImage(this, 0, 0);
-                        DOMURL.revokeObjectURL(url);
-                    };
-
-                    img.src = url;
+                      ctx.drawImage(this, 0, 0);
+                    }
 
                     // we now have a local image and URL that we can wrap in a legend generator supported svg element
                     return {
@@ -490,7 +493,7 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                         items: [
                             {
                                 name: '',
-                                svgcode: `<svg xmlns:xlink="http://www.w3.org/1999/xlink" height="${approxHeight}" width="${correctedWidth}"><image height="${approxHeight}" width="${correctedWidth}" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="${url}"></image></svg>`
+                                svgcode: `<svg xmlns:xlink="http://www.w3.org/1999/xlink" height="${approxHeight}" width="${correctedWidth}"><image height="${approxHeight}" width="${correctedWidth}" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="${img.src}"></image></svg>`
                             }
                         ].concat(entry.symbologyStack.stack || []),
                         blockType: LegendBlock.TYPES.INFO,


### PR DESCRIPTION
## Description
Fixes CCCS bug 43540: Cannot download map if Legend selected in chrome

## Testing
Chrome, FF, IE

## Documentation
inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2952)
<!-- Reviewable:end -->
