### PR TITLE
Fix export map and full screen clash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4290,7 +4290,7 @@
         "optimist": "0.6.1",
         "q": "1.5.1",
         "validate.js": "0.12.0",
-        "winston": "2.4.3"
+        "winston": "2.4.4"
       },
       "dependencies": {
         "q": {
@@ -6358,7 +6358,7 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#b2e7d664f741e4dd8d09620c5d6afc21db1147de",
+      "version": "github:fgpv-vpgf/geoApi#74034426bea588409b6bcd0acb712c6961abd2f9",
       "requires": {
         "babel-cli": "6.26.0",
         "babel-preset-env": "1.6.1",
@@ -6373,7 +6373,7 @@
         "jquery": "2.2.4",
         "jsdoc": "3.5.5",
         "lodash": "4.17.10",
-        "proj4": "2.4.4",
+        "proj4": "2.5.0",
         "rcolor": "1.0.1",
         "rgbcolor": "1.0.1",
         "shpjs": "git+https://github.com/fgpv-vpgf/shapefile-js.git#dd6b31899dee1d70f106b3725430f2eb5f0b350c",
@@ -11824,9 +11824,9 @@
       "dev": true
     },
     "proj4": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.4.4.tgz",
-      "integrity": "sha512-yo6qTpBQXnxhcPopKJeVwwOBRzUpEa3vzSFlr38f5mF4Jnfb6NOL/ePIomefWiZmPgkUblHpcwnWVMB8FS3GKw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.5.0.tgz",
+      "integrity": "sha512-XZTRT7OPdLzgvtTqL8DG2cEj8lYdovztOwiwpwRSYayOty5Ipf3H68dh/fiL+HKDEyetmQSMhkkMGiJoyziz3w==",
       "requires": {
         "mgrs": "1.0.0",
         "wkt-parser": "1.2.2"
@@ -13238,7 +13238,7 @@
         "lie": "3.3.0",
         "lru-cache": "2.7.3",
         "parsedbf": "1.0.0",
-        "proj4": "2.4.4"
+        "proj4": "2.5.0"
       }
     },
     "signal-exit": {
@@ -17384,9 +17384,9 @@
       "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "winston": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.3.tgz",
-      "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "datatables.net-select": "1.2.5",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.8",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-16",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-17",
     "imports-loader": "0.8.0",
     "linkifyjs": "2.1.6",
     "marked": "0.4.0",


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Print map was modifying layer SVGs and causing them to be offset when the map resized.
Most prominent was print map -> fullscreen pushing features away from their proper locations.

https://github.com/fgpv-vpgf/geoApi/pull/322

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
index-samples 76 and 75

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
in-line

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2960)
<!-- Reviewable:end -->
