### PR TITLE
Fix pan & zoom on Chrome 68+ for touch/pen events

### DIFF
--- a/src/app/startup.ts
+++ b/src/app/startup.ts
@@ -6,6 +6,21 @@ const customAttrs = ['config', 'langs', 'service-endpoint', 'restore-bookmark', 
 const nIdList: Array<string> = RV._nodeIdList = [];
 const nodeList: Array<Node> = [];
 
+// Adds support for document.createTouch (deprecated and dropped on chrome 68+) where the browser supports window.Touch. 
+// ESRI has a createTouch dependency which has caused pan & zoom to stop working on touch and pen events.
+if (!document.createTouch && (<any>window).Touch) {
+    document.createTouch = function(view, target, identifier, pageX, pageY, screenX, screenY) {
+            return new Touch({
+                target: target,
+                identifier: identifier,
+                pageX: pageX,
+                pageY: pageY,
+                screenX: screenX,
+                screenY: screenY
+            });
+        };
+}
+
 // Google tag manager loading
 (<any>window).dataLayer = (<any>window).dataLayer ? (<any>window).dataLayer : [];
 const gtmScript = document.createElement("script");


### PR DESCRIPTION
## Description
Adds support for `document.createTouch` (deprecated and dropped on chrome 68+) where the browser supports `window.Touch`. 

Closes #2962

## Testing
Pan & zoom working on pixel chrome 68 for CCCS.

## Documentation
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2963)
<!-- Reviewable:end -->
