### PR TITLE
fix(export): make export legend svg generation sync

### DIFF
--- a/src/app/ui/export/export-legend.service.js
+++ b/src/app/ui/export/export-legend.service.js
@@ -473,19 +473,9 @@ function exportLegendService($q, $rootElement, geoService, LegendBlock, configSe
                     `;
 
                     const img = new Image();
-                    const svg = new Blob([data], {type: 'image/svg+xml'});
 
-                    // workaround for known chrome issue https://bugs.chromium.org/p/chromium/issues/detail?id=294129
-                    const reader = new FileReader();
-                    reader.readAsDataURL(svg);
-
-                    reader.onload = function(e) {
-                        img.src = e.target.result;
-                    }
-
-                    img.onload = function() {
-                      ctx.drawImage(this, 0, 0);
-                    }
+                    // https://bugs.chromium.org/p/chromium/issues/detail?id=294129#c26
+                    img.src = 'data:image/svg+xml; charset=utf8, ' + encodeURIComponent(data);
 
                     // we now have a local image and URL that we can wrap in a legend generator supported svg element
                     return {


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Info sections were failing to appear in export legend.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Sample 77
Click export, you should see the legend properly generate with headers and the image should be downloadable.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
in-line

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2973)
<!-- Reviewable:end -->
