### PR TITLE
fix(esri): Polyfill createTouch with Touch

### DIFF
--- a/src/app/startup.ts
+++ b/src/app/startup.ts
@@ -10,7 +10,7 @@ const nodeList: Array<Node> = [];
 // ESRI has a createTouch dependency which has caused pan & zoom to stop working on touch and pen events.
 if (!document.createTouch && (<any>window).Touch) {
     document.createTouch = function(view, target, identifier, pageX, pageY, screenX, screenY) {
-            return new Touch({
+            return new (<any>window).Touch({
                 target: target,
                 identifier: identifier,
                 pageX: pageX,


### PR DESCRIPTION
Fixes TS error on [v2.8.3](https://github.com/Microsoft/TypeScript/blob/v2.8.3/lib/lib.dom.d.ts#L13308) where `Touch` constructor has no parameter causing prod build to error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2974)
<!-- Reviewable:end -->
