### PR TITLE
fix(ui): fix icons covering description

### DIFF
--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -408,12 +408,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             if (self.description !== '') {
                 totalHeight -= symbologyListMargin / 2;
 
-                // briefly show the description node to grab it's height, and hide it again
-                ref.descriptionItem.show();
-                let width = getTextWidth(canvas, ref.descriptionItem.text(), ref.descriptionItem.css('font'));
-                let height = Math.ceil(width / ref.descriptionItem.width()) * parseInt(ref.descriptionItem.css('line-height').slice(0, -2));
-                const descriptionHeight = ref.descriptionItem.height() >= 0 ? ref.descriptionItem.height() : height;
-                ref.descriptionItem.hide();
+                const descriptionHeight = ref.descriptionItem.height();
 
                 // move the node into position unhiding it (it's still invisible beacuse opacity is 0)
                 timeline.set(ref.descriptionItem, {

--- a/src/content/samples/config/config-sample-77.json
+++ b/src/content/samples/config/config-sample-77.json
@@ -322,14 +322,16 @@
             },
             {
               "infoType": "title",
-              "content": "Will stay"
+              "content": "Title 1 - will stay in export legend"
             },
             {
-              "layerId": "3"
+              "layerId": "3",
+              "description":"This is a description. These are some more words to make the description take up multiple lines. Words are fun.",
+              "symbologyRenderStyle": "icons"
             },
             {
               "infoType": "title",
-              "content": "Will stay"
+              "content": "Title 2 - will stay in export legend"
             },
             {
               "layerId": "4"
@@ -339,11 +341,11 @@
             },
             {
               "infoType": "title",
-              "content": "will disappear"
+              "content": "Title 3 - will disappear from export legend"
             },
             {
               "infoType": "title",
-              "content": "will disappear"
+              "content": "Title 4 - will disappear from export legend"
             }
           ]
         }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
#2975 

It was the `ref.descriptionItem.show()` breaking things. Removed the rest of it as I couldn't find a case where `.height()` didn't work. I assume the other logic was an attempt at patching the `.show()` error.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Sample 77, second layer has multi-line description and icon symbology.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
removed misleading comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2976)
<!-- Reviewable:end -->
