### PR TITLE
fix(plugin): Remove geomag service when in https because only avialab…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4237,9 +4237,9 @@
       "dev": true
     },
     "dependency-graph": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.7.1.tgz",
-      "integrity": "sha512-2s2uojwu7aq0K94DwrnJwo/mTkGiPqy2cU7z5BVXmhb564WgITZR3ruZMUIJ8Ymb5ruew244odZCR23/lZoxXg=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.7.2.tgz",
+      "integrity": "sha512-KqtH4/EZdtdfWX0p6MGP9jljvxSY6msy/pRUD4jgNwVpv3v1QmNLlsB3LDSSUg79BRVSn7jI1QPRtArGABovAQ=="
     },
     "des.js": {
       "version": "1.0.0",
@@ -4283,7 +4283,7 @@
       "integrity": "sha512-In8huU+6W+Rd7MdfzhQoRbntF4AsJgtbwRUTyfPgvhaC3RGJX/YOEkMnn7vLLk3zaCrEkIQGW6eADoudpnBceg==",
       "requires": {
         "canonical-path": "0.0.2",
-        "dependency-graph": "0.7.1",
+        "dependency-graph": "0.7.2",
         "di": "0.0.1",
         "lodash": "4.17.10",
         "objectdiff": "1.1.0",
@@ -6358,7 +6358,7 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#89981d18256d0538fd0cd5c7c8224b4435611ef9",
+      "version": "github:fgpv-vpgf/geoApi#125821cdb1edc202bc1b8a48917affd80c4cba51",
       "requires": {
         "babel-cli": "6.26.0",
         "babel-preset-env": "1.6.1",
@@ -17541,7 +17541,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "datatables.net-select": "1.2.5",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.8",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-17",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-19",
     "imports-loader": "0.8.0",
     "linkifyjs": "2.1.6",
     "marked": "0.4.0",

--- a/src/content/samples/config/config-sample-79.json
+++ b/src/content/samples/config/config-sample-79.json
@@ -1,0 +1,359 @@
+{
+    "ui": {
+        "title": "Custom Title",
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
+        },
+        "sideMenu": {
+            "logo": true
+        },
+        "help": {
+            "folderName": "default"
+        },
+        "legend": {
+            "isOpen": {
+                "large": true,
+                "medium": true,
+                "small": false
+            }
+        }
+    },
+    "version": "2.0",
+    "language": "en",
+    "services": {
+        "corsEverywhere": true,
+        "proxyUrl": "https://maps.canada.ca/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "geometryUrl": "https://webservices.maps.canada.ca/arcgis/rest/services/Utilities/Geometry/GeometryServer",
+        "exportMapUrl": "https://webservices.maps.canada.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Title"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "footnote": {
+                "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+            }
+        },
+        "search": {
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 102100
+                }
+            },
+            "northArrow": {
+                "enabled": true
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery",
+                "initiallyExpanded": false
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "legend": {
+            "type": "autopopulate"
+        },
+        "layers": [
+        ],
+        "extentSets": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmax": 3549492,
+                    "xmin": -2681457,
+                    "ymax": 3482193,
+                    "ymin": -883440
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.62831258996,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.0435187537042,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.1677250021168,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.36466006265346,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.48962831258996,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.87924099992,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.992452562495,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.4962262813797,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.43702828507324,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.554628535634155,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.388657133974685,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.5971642835598172,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.07464553541190416,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.03732276770595208,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.01866138385297604,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT",
+                        "layerType": "esriFeature",
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "attribution": {
+                    "text": {
+                        "enabled": true,
+                        "value": "Custom Attribution"
+                    },
+                    "logo": {
+                        "enabled": true
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -173,6 +173,7 @@
                 <option value="config/config-sample-81.json">76. WFS with system co-ords in attributes</option>
                 <option value="config/config-sample-77.json">77. Legend with titles that are removed in export and custom legend width</option>
                 <option value="config/config-sample-78.json">78. Tile layer with some tiles missing</option>
+                <option value="config/config-sample-79.json">79. Use https for Get Coord Info plugin</option>
             </select>
         </div>
 


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Remove the call to geomag service when in https. If not, it breaks the whole plugin.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
To test, run in https mode (add --https to webpack-dev-server command inside package.json)

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/2994)
<!-- Reviewable:end -->
