### PR TITLE
Improve handling of layer loading errors and Gracefully Handle No-Feature WFS

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "datatables.net-select": "1.2.5",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.8",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-20",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-21",
     "imports-loader": "0.8.0",
     "linkifyjs": "2.1.6",
     "marked": "0.4.0",

--- a/src/app/ui/loader/layer-source.service.js
+++ b/src/app/ui/loader/layer-source.service.js
@@ -220,8 +220,6 @@ function layerSource($q, gapiService, Geo, LayerBlueprint, ConfigObject, configS
 
             const targetWkid = configService.getSync.map.instance.spatialReference.wkid;
             const layerInfo = new LayerBlueprint.WFSServiceSource(layerRawConfig);
-            // TODO: add wkid to setRawdata
-            // layerInfo.setRawData(data.rawData);
 
             return layerInfo;
         }

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -70,7 +70,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             container: '=?'
         },
         link: link,
-        controller: () => { },
+        controller: () => {},
         controllerAs: 'self',
         bindToController: true
     };
@@ -209,7 +209,8 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                     $q.all(drawPromises).then(() => {
                         // create a ToggleSymbol instance for each symbol
                         self.symbology.stack.forEach(s => {
-                            if (s.definitionClause) { // If the symbol doesn't have a query it shouldn't be a toggle symbol
+                            if (s.definitionClause) {
+                                // If the symbol doesn't have a query it shouldn't be a toggle symbol
                                 self.toggleList[s.name] = new ToggleSymbol(s);
                             }
                         });
@@ -279,7 +280,6 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                 }
                 self.symbology.expanded = value;
             }
-
         }
 
         /**
@@ -316,7 +316,6 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
 
                 self.symbology.fannedOut = value;
             }
-
         }
 
         // find and store references to relevant nodes
@@ -355,15 +354,14 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                 Math.max(
                     ...ref.symbolItems.map(symbolItem => {
                         const svgImage = symbolItem.image.find('svg')[0];
-                        const texLRPadding = (parseInt(symbolItem.label.css('padding-left').slice(0, -2))
-                                                + parseInt(symbolItem.label.css('padding-right').slice(0, -2)));
+                        const texLRPadding =
+                            parseInt(symbolItem.label.css('padding-left').slice(0, -2)) +
+                            parseInt(symbolItem.label.css('padding-right').slice(0, -2));
                         return Math.max(
                             svgImage ? svgImage.viewBox.baseVal.width : 0,
                             getTextWidth(canvas, symbolItem.label.text(), 'normal 14px Roboto') + texLRPadding
                         );
-                    }
-
-                    )
+                    })
                 ),
                 ref.containerWidth
             );
@@ -419,7 +417,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                 // show and animate description node
                 timeline.to(
                     ref.descriptionItem,
-                    RV_DURATION / 3 * 2,
+                    (RV_DURATION / 3) * 2,
                     {
                         opacity: 1,
                         top: totalHeight,
@@ -549,14 +547,13 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
          * @return {Number}                height of this symbology item plus its bottom margin is applicable
          */
         function imageLegendItem(timeline, symbolItem, totalHeight, isLast) {
-
             const symbologyListItemMargin = 16;
             const imageWidth = symbolItem.image.find('svg')[0].viewBox.baseVal.width;
             const imageHeight = symbolItem.image.find('svg')[0].viewBox.baseVal.height;
 
             // calculate symbology item's dimensions based on max width
             const itemWidth = Math.min(ref.maxItemWidth, imageWidth);
-            const itemHeight = imageWidth !== 0 ? itemWidth / imageWidth * imageHeight : 0; // in cases when image urls are broken its size is 0
+            const itemHeight = imageWidth !== 0 ? (itemWidth / imageWidth) * imageHeight : 0; // in cases when image urls are broken its size is 0
 
             // extremely convoluted math to calculate an aproximation of the label's height
             // can't just get outerHeight() since it returns strange values when the symbology stack isn't expanded
@@ -566,9 +563,14 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             const textWidth = getTextWidth(canvas, symbolItem.label[0].innerText, symbolItem.label.css('font'));
             if (textWidth > 0) {
                 lineHeight = parseInt(symbolItem.label.css('line-height').slice(0, -2));
-                padding = parseInt(symbolItem.label.css('padding-bottom').slice(0, -2)) + parseInt(symbolItem.label.css('padding-top').slice(0, -2));
-                const sidePadding = parseInt(symbolItem.label.css('padding-left').slice(0, -2)) + parseInt(symbolItem.label.css('padding-right').slice(0, -2));
-                labelHeight = Math.floor(textWidth / (0.9 * (ref.maxItemWidth - sidePadding)) + 1) * lineHeight + padding;  // divide by 0.9 due to display rounding
+                padding =
+                    parseInt(symbolItem.label.css('padding-bottom').slice(0, -2)) +
+                    parseInt(symbolItem.label.css('padding-top').slice(0, -2));
+                const sidePadding =
+                    parseInt(symbolItem.label.css('padding-left').slice(0, -2)) +
+                    parseInt(symbolItem.label.css('padding-right').slice(0, -2));
+                labelHeight =
+                    Math.floor(textWidth / (0.9 * (ref.maxItemWidth - sidePadding)) + 1) * lineHeight + padding; // divide by 0.9 due to display rounding
             }
 
             // animate symbology container's size
@@ -576,7 +578,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             // so they don't overlay legend entry
             timeline.to(
                 symbolItem.container,
-                RV_DURATION / 3 * 2,
+                (RV_DURATION / 3) * 2,
                 {
                     width: ref.maxItemWidth,
                     height: itemHeight + labelHeight,
@@ -601,7 +603,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             // animate image width to the calculated width
             timeline.to(
                 symbolItem.image,
-                RV_DURATION / 3 * 2,
+                (RV_DURATION / 3) * 2,
                 {
                     width: itemWidth,
                     height: itemHeight,
@@ -629,7 +631,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                     opacity: 1,
                     ease: RV_SWIFT_IN_OUT_EASE
                 },
-                RV_DURATION / 3 * 2
+                (RV_DURATION / 3) * 2
             );
 
             return itemHeight + labelHeight + (isLast ? 0 : symbologyListItemMargin);
@@ -652,7 +654,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             // expand symbology container width and align it to the left (first and last items are fanned out)
             timeline.to(
                 symbolItem.container,
-                RV_DURATION / 3 * 2,
+                (RV_DURATION / 3) * 2,
                 {
                     width: ref.containerWidth,
                     left: 0,
@@ -687,7 +689,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             // animate image width to the calculated width
             timeline.to(
                 symbolItem.image,
-                RV_DURATION / 3 * 2,
+                (RV_DURATION / 3) * 2,
                 {
                     width: itemSize,
                     height: itemSize,
@@ -708,7 +710,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             // animate symbology label into view
             timeline.to(
                 symbolItem.label,
-                RV_DURATION / 3 * 2,
+                (RV_DURATION / 3) * 2,
                 {
                     opacity: 1,
                     ease: RV_SWIFT_IN_OUT_EASE
@@ -761,7 +763,9 @@ function symbologyStack($q, ConfigObject, gapiService) {
         ) {
             // resolve proxy promise and store the proxy object itself
             if (proxy) {
-                $q.resolve(proxy).then(proxy => (this._proxy = proxy));
+                $q.resolve(proxy)
+                    .then(proxy => (this._proxy = proxy))
+                    .catch(() => {}); // ignore proxyPromise error; if that happens, symbology will not be shown anyway
             }
 
             this._renderStyle = renderStyle;

--- a/src/app/ui/toc/toc.service.js
+++ b/src/app/ui/toc/toc.service.js
@@ -96,8 +96,10 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, comm
      */
     function reloadLayer(legendBlock) {
         // get table configuration and check if static field were used. If so, table can't be remove and flag need to stay
-        const tableConfig = configService.getSync.map.layerRecords.find(item =>
-            item.config.id === legendBlock.layerRecordId).initialConfig.table;
+        const layerRecord = configService.getSync.map.layerRecords.find(item =>
+            item.config.id === legendBlock.layerRecordId);
+
+        const tableConfig = layerRecord ? layerRecord.initialConfig.tableConfig : null;
 
         // update filter flag
         if (tableConfig) {


### PR DESCRIPTION
## Description
Now errors in layer loading (like loading WFS data and other errors) are correctly piped to the UI. Some errors still do cause the legend UI to stay in the perpetual loading state, but these errors are not handled correctly by geoApi yet.

Closes #2899, #2995

## Testing
👀 

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- ~~[ ] Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers
