### PR TITLE
Fix icons overlapping description (properly this time)

### DIFF
--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -408,7 +408,12 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             if (self.description !== '') {
                 totalHeight -= symbologyListMargin / 2;
 
-                const descriptionHeight = ref.descriptionItem.height();
+                // briefly show the description node to grab it's height, and hide it again
+                ref.descriptionItem.show();
+                let width = getTextWidth(canvas, ref.descriptionItem.text(), ref.descriptionItem.css('font'));
+                let height = Math.ceil(width / ref.descriptionItem.width()) * parseInt(ref.descriptionItem.css('line-height').slice(0, -2));
+                const descriptionHeight = ref.descriptionItem.height() > 0 ? ref.descriptionItem.height() : height;
+                ref.descriptionItem.hide();
 
                 // move the node into position unhiding it (it's still invisible beacuse opacity is 0)
                 timeline.set(ref.descriptionItem, {


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
#2975 

Properly see if `.height()` is returning the height of the description. Before it was taking `0` as a proper height when it should've fallen back to the calculation.

Last attempt was #2976 . Always worked on ramp because icons were inline SVG, CCCS race condition decided to take a break for a bit that day.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Sample 77 + tested in cccs

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Reinstated old comment

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3000)
<!-- Reviewable:end -->
