### PR TITLE
fix(search): add error when search query rejects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17897,7 +17897,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "2.1.1",

--- a/src/app/ui/geosearch/geosearch.html
+++ b/src/app/ui/geosearch/geosearch.html
@@ -1,12 +1,13 @@
 <div class="rv-geosearch-content rv-whiteframe-z2" ng-show="self.service.searchValue && self.service.isResultsVisible" rv-trap-focus>
 
-    <rv-geosearch-top-filters on-update="self.onTopFiltersUpdate"></rv-geosearch-top-filters>
+    <rv-geosearch-top-filters on-update="self.onTopFiltersUpdate" ng-if="!self.service.serviceError"></rv-geosearch-top-filters>
 
-    <md-divider class="rv-geosearch-divider"></md-divider>
+    <md-divider class="rv-geosearch-divider" ng-if="!self.service.serviceError"></md-divider>
 
     <div class="rv-geosearch-results">
 
         <span class="rv-no-results" ng-if="self.service.noResultsSearchValue">{{ 'geosearch.nomatches.label' | translate:self.service }}</span>
+        <span class="rv-no-results" ng-if="self.service.serviceError"><md-icon md-svg-src="alert:warning"></md-icon> {{ 'geosearch.serviceerror.label' | translate:self.service }}</span>
 
         <ul class="rv-results-list">
 
@@ -49,8 +50,8 @@
 
     </div>
 
-    <md-divider class="rv-geosearch-divider"></md-divider>
+    <md-divider class="rv-geosearch-divider" ng-if="!self.service.serviceError"></md-divider>
 
-    <rv-geosearch-bottom-filters on-update="self.onBottomFiltersUpdate"></rv-geosearch-bottom-filters>
+    <rv-geosearch-bottom-filters on-update="self.onBottomFiltersUpdate" ng-if="!self.service.serviceError"></rv-geosearch-bottom-filters>
 
 </div>

--- a/src/app/ui/geosearch/geosearch.html
+++ b/src/app/ui/geosearch/geosearch.html
@@ -7,7 +7,7 @@
     <div class="rv-geosearch-results">
 
         <span class="rv-no-results" ng-if="self.service.noResultsSearchValue">{{ 'geosearch.nomatches.label' | translate:self.service }}</span>
-        <span class="rv-no-results" ng-if="self.service.serviceError"><md-icon md-svg-src="alert:warning"></md-icon> {{ 'geosearch.serviceerror.label' | translate:self.service }}</span>
+        <span class="rv-no-results" ng-if="self.service.serviceError"><md-icon md-svg-src="alert:warning"></md-icon> <div>{{ 'geosearch.serviceerror.label' | translate:self.service }}</div></span>
 
         <ul class="rv-results-list">
 

--- a/src/app/ui/geosearch/geosearch.html
+++ b/src/app/ui/geosearch/geosearch.html
@@ -7,7 +7,7 @@
     <div class="rv-geosearch-results">
 
         <span class="rv-no-results" ng-if="self.service.noResultsSearchValue">{{ 'geosearch.nomatches.label' | translate:self.service }}</span>
-        <span class="rv-no-results" ng-if="self.service.serviceError"><md-icon md-svg-src="alert:warning"></md-icon> <div>{{ 'geosearch.serviceerror.label' | translate:self.service }}</div></span>
+        <span class="rv-no-results" ng-if="self.service.serviceError"><md-icon md-svg-src="alert:warning"></md-icon> <span>{{ 'geosearch.serviceerror.label' | translate:self.service }}</span></span>
 
         <ul class="rv-results-list">
 

--- a/src/app/ui/geosearch/geosearch.service.js
+++ b/src/app/ui/geosearch/geosearch.service.js
@@ -16,6 +16,7 @@ function geosearchService($q, $rootScope, stateManager, referenceService, geoSea
         isLoading: false, // waiting for results
         isResultsVisible: false, // showing results when we get some
         noResultsSearchValue: '', // the (previous) search term which returned no results
+        serviceError: false,
 
         searchValue: '', // current search term
         searchValuePerm: '', // searchValue is cleared on esc, keep a reference
@@ -129,6 +130,7 @@ function geosearchService($q, $rootScope, stateManager, referenceService, geoSea
             // hide loading indicator
             service.isLoading = false;
             service.isResultsVisible = true;
+            service.serviceError = false;
 
             // discard any old results
             if (requestCount === ref.runningRequestCount) {
@@ -139,6 +141,11 @@ function geosearchService($q, $rootScope, stateManager, referenceService, geoSea
 
             // return data for optional processing further down the promise chain
             return data;
+        }, _ => {
+            service.searchResults = [];
+            service.isLoading = false;
+            service.isResultsVisible = true;
+            service.serviceError = true;
         });
     }
 

--- a/src/content/styles/modules/_geosearch.scss
+++ b/src/content/styles/modules/_geosearch.scss
@@ -97,6 +97,17 @@ $result-item-height-touch: rem(4.8);
                 .rv-no-results {
                     display: block;
                     text-align: center;
+
+                    md-icon {
+                        margin: 0 8px;
+                        width: unset;
+                        vertical-align: super;
+                    }
+
+                    div {
+                        max-width: 80%;
+                        display: inline-block;
+                    }
                 }
 
                 .rv-results-list {

--- a/src/content/styles/modules/_geosearch.scss
+++ b/src/content/styles/modules/_geosearch.scss
@@ -95,18 +95,21 @@ $result-item-height-touch: rem(4.8);
                 padding: rem(1.0) 0;
 
                 .rv-no-results {
-                    display: block;
-                    text-align: center;
+                    display: flex;
+                    margin: 0 10px;
+                    align-items: center;
 
                     md-icon {
-                        margin: 0 8px;
-                        width: unset;
-                        vertical-align: super;
+                       margin: 0 8px;
+                           flex-shrink: 0;
                     }
 
-                    div {
-                        max-width: 80%;
-                        display: inline-block;
+                    span {
+                        text-align: left;
+                            white-space: nowrap;
+                            margin-left: 2px;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
                     }
                 }
 

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -104,6 +104,7 @@ Geosearch lat/long type,geosearch.type.latlong,Latitude/Longitude,1,Latitude/Lon
 Geosearch FSA type,geosearch.type.fsa,Postal code,1,Code postal,1
 Geosearch National Topographic System type,geosearch.type.nts,NTS,1,SNRC,1
 ,geosearch.nomatches.label,No matches found for ""{{ noResultsSearchValue }}"",1,Aucun résultat correspondant à ""{{ noResultsSearchValue }}"".,1
+Geosearch FSA type,geosearch.serviceerror.label,A service error is preventing results from being shown.,1,Une erreur de service empêche l'affichage des résultats.,0
 ,geosearch.loadingfilters.label,Loading filters,1,Chargement des filtres,1
 Basemap refresh required,basemap.refresh.req,Map refresh required,1,Actualiser la carte,1
 Basemap blank title,basemap.blank.title,Blank map,1,Carte vide,1

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -104,7 +104,7 @@ Geosearch lat/long type,geosearch.type.latlong,Latitude/Longitude,1,Latitude/Lon
 Geosearch FSA type,geosearch.type.fsa,Postal code,1,Code postal,1
 Geosearch National Topographic System type,geosearch.type.nts,NTS,1,SNRC,1
 ,geosearch.nomatches.label,No matches found for ""{{ noResultsSearchValue }}"",1,Aucun résultat correspondant à ""{{ noResultsSearchValue }}"".,1
-Geosearch FSA type,geosearch.serviceerror.label,A service error is preventing results from being shown.,1,Une erreur de service empêche l'affichage des résultats.,0
+Geosearch FSA type,geosearch.serviceerror.label,"Service error, results cannot be shown at this time.",1,"Erreur de service, les résultats ne peuvent pas être affichés pour le moment.",0
 ,geosearch.loadingfilters.label,Loading filters,1,Chargement des filtres,1
 Basemap refresh required,basemap.refresh.req,Map refresh required,1,Actualiser la carte,1
 Basemap blank title,basemap.blank.title,Blank map,1,Carte vide,1


### PR DESCRIPTION
## Description
Displays an error when the search query is rejected.

![geo-search-error](https://user-images.githubusercontent.com/10187181/45362785-be315180-b5a3-11e8-9eb3-779c1586ef53.png)

## Testing
Block requests to `geogratis.gc.ca` in dev tools after the map has finished loading, then perform a search.

## Documentation
❌ 

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3001)
<!-- Reviewable:end -->
