### PR TITLE
fix(ui): `symbologyExpanded` not working for dynamic layers

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -519,7 +519,10 @@ function legendServiceFactory(
                 // on loaded, create child LegendBlocks for the dynamic layer and
                 // add them to the created LegendBlock.GROUP to be displayed in the UI (following any hierarchy provided)
                 const tree = _createDynamicChildTree(layerRecord, layerConfig);
-                tree.forEach(item => _addChildBlock(item, legendBlockGroup));
+                tree.forEach(item => {
+                    item.symbologyExpanded = blockConfig.symbologyExpanded;
+                    _addChildBlock(item, legendBlockGroup);
+                });
 
                 legendBlockGroup.synchronizeControlledEntries();
             });

--- a/src/content/samples/config/config-sample-07-structured-legend-one-group-proper-subset.json
+++ b/src/content/samples/config/config-sample-07-structured-legend-one-group-proper-subset.json
@@ -80,7 +80,12 @@
         "name": "root",
         "children": [
           {
-            "layerId": "somepowerplants"
+            "layerId": "somepowerplants",
+            "symbologyExpanded": true
+          },
+          {
+            "layerId": "onepowerplant",
+            "symbologyExpanded": true
           }
         ]
       }
@@ -101,6 +106,18 @@
             "index": 21
           }
         ],
+        "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer"
+      },
+      {
+        "id": "onepowerplant",
+        "name": "Power Plant",
+        "layerType": "esriDynamic",
+        "layerEntries": [
+          {
+            "index": 20
+          }
+        ],
+        "singleEntryCollapse": true,
         "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer"
       }
     ],

--- a/src/content/samples/config/config-sample-08-structured-legend-one-layer-muti-legends.json
+++ b/src/content/samples/config/config-sample-08-structured-legend-one-layer-muti-legends.json
@@ -80,7 +80,8 @@
         "name": "root",
         "children": [
           {
-            "layerId": "somepowerplants"
+            "layerId": "somepowerplants",
+            "symbologyExpanded": true
           },
           {
             "layerId": "somepowerplants"


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #2987 

Dynamic layers with `symbologyExpanded` set in the config will expand the symbology of all its child layers.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
:eyes:
index-samples 7 & 8

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3005)
<!-- Reviewable:end -->
