### PR TITLE
perf(symbology): align toggle stacks without potential infinite loop

### DIFF
--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -215,19 +215,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                             }
                         });
 
-                        // Manually correct symbology boxes so they align with all other layer visibility boxes
-                        const symbolButtonOffset =
-                            parseInt(element.closest('rv-legend-block').css('padding-left')) - 35.4;
-
-                        // angular is not rendering the nestled buttons fast enough so keep checking until they're ready
-                        const stopSymbolInterval = $interval(() => {
-                            const symbolButtons = element.find('.md-icon-button').not('.rv-symbol-trigger');
-                            if (symbolButtons.length > 0) {
-                                symbolButtons.css('position', 'absolute');
-                                symbolButtons.css('right', `${symbolButtonOffset}px`);
-                                $interval.cancel(stopSymbolInterval);
-                            }
-                        }, 100);
+                        self.buttonOffset = (parseInt(element.closest('rv-legend-block').css('padding-left')) - 35.4).toString() + "px";
                     });
                 }
             }

--- a/src/app/ui/toc/templates/symbology-stack.html
+++ b/src/app/ui/toc/templates/symbology-stack.html
@@ -20,6 +20,7 @@
 
         <md-button
             class="md-icon-button rv-icon-20"
+            ng-style="{'right': self.buttonOffset}"
             ng-click="self.onToggleClick(symbol.name)"
             ng-if="self.toggleList[symbol.name]"
             aria-pressed = "{{ self.toggleList[symbol.name].isSelected }}"


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
As @AleksueiR brought up, this interval can potentially not stop at all if there are no buttons found: https://github.com/fgpv-vpgf/fgpv-vpgf/blob/develop/src/app/ui/toc/symbology-stack.directive.js#L224 

Note: for some reason setting `margin: auto` seems to screw things up more, works fine without it

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Toggle symbology stacks on sample 46 and 75 (check if they line up properly)

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
none

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~[ ] Help files and documentation have been updated~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers
