### PR TITLE
fix(ui): invalid legend img url results in repeated requests

### DIFF
--- a/src/app/ui/common/expand-image-button.html
+++ b/src/app/ui/common/expand-image-button.html
@@ -1,4 +1,4 @@
-<md-button ng-if="self.canEnlarge()" class="md-icon-button rv-icon-20 rv-image-expand" ng-click="self.open()"
+<md-button ng-if="self.canEnlarge" class="md-icon-button rv-icon-20 rv-image-expand" ng-click="self.open()"
     aria-label="{{ 'toc.tooltip.fullsizeImage' | translate }}">
     <md-icon md-svg-src="action:zoom_in"></md-icon>
     <md-tooltip md-direction="top">{{ 'toc.tooltip.fullsizeImage' | translate }}</md-tooltip>

--- a/src/app/ui/common/expand-image.directive.js
+++ b/src/app/ui/common/expand-image.directive.js
@@ -25,8 +25,9 @@ function rvExpandImage($mdDialog, referenceService, $compile, $templateCache) {
         const self = scope.self;
 
         const shellNode = referenceService.panels.shell;
-        let width;
-        let height;
+        let width = 0;
+        let height = 0;
+        self.canEnlarge = false;
 
         // get the url of the image from the tag's ngSrc or src
         // if the tag has a special format for src (eg. <rv-svg>) then specify an additional attribute
@@ -35,15 +36,13 @@ function rvExpandImage($mdDialog, referenceService, $compile, $templateCache) {
 
         // set canEnlarge true if natural width of the image is larger than the width of the toc panel
         // also get the natural width and height of the image
-        self.canEnlarge = () => {
-            const img = new Image();
-            img.onload = function() {
-                width = Math.min(this.width + 50, shellNode.width() * 0.8);
-                height = Math.min(this.height, shellNode.height() * 0.8);
-            }
-            img.src = imageUrl;
-            return width > element.parents(".rv-toc").width();
-        };
+        const img = new Image();
+        img.onload = function() {
+            width = Math.min(this.width + 50, shellNode.width() * 0.8);
+            height = Math.min(this.height, shellNode.height() * 0.8);
+            self.canEnlarge = width > element.parents(".rv-toc").width();
+        }
+        img.src = imageUrl;
 
         const template = $templateCache.get(buttonTemplateUrl);
         element.after($compile(template)(scope));

--- a/src/content/samples/config/config-sample-67.json
+++ b/src/content/samples/config/config-sample-67.json
@@ -111,6 +111,10 @@
           {
             "infoType": "image",
             "content": "http://fgpv.cloudapp.net/demo/__assets__/solazy.gif"
+          },
+          {
+            "infoType": "image",
+            "content": "http://broken.link.gif"
           }
         ]
       }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #3003

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
[Sample 67](http://fgpv.cloudapp.net/demo/users/dane-thomas/repeat-image-req/dev/samples/index-samples.html?sample=67)
Now has an image with a bad link. Should see the `GET` error once in the console on initial failed load and none after. Big images should still have working expand buttons.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3015)
<!-- Reviewable:end -->
