### PR TITLE
fix(dynamicRecord): identify filters out invisible symbologies in stack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6355,7 +6355,7 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#98329bbe931cc4cd7df8dfcabe753dd960cffa9f",
+      "version": "github:fgpv-vpgf/geoApi#v2.5.0-22",
       "requires": {
         "babel-cli": "6.26.0",
         "babel-preset-env": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "datatables.net-select": "1.2.5",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.8",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-21",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-22",
     "imports-loader": "0.8.0",
     "linkifyjs": "2.1.6",
     "marked": "0.4.0",


### PR DESCRIPTION
## Description
Closes: fgpv-vpgf/fgpv-vpgf#2981

When Dynamic Layers in symbology stacks were identified, all symbologies in close proximity were identified (regardless if they were toggled on/off). Now only the symbologies that are toggled visible  are identified.

## Testing
Test sample 46, also `keys=NPRI_CO`

http://fgpv.cloudapp.net/demo/users/ShrutiVellanki/fix-dynamic-identify/dev/samples/index-samples.html

## Documentation
inline comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~[ ] Help files and documentation have been updated~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3017)
<!-- Reviewable:end -->
