### PR TITLE
fix(core): fix wrong return in init

### DIFF
--- a/src/app/geo/init-map.directive.js
+++ b/src/app/geo/init-map.directive.js
@@ -63,16 +63,15 @@ function rvInitMap(
             // GTM application load time
             if (window.performance) {
                 const timeSincePageLoad = Math.round(performance.now());
-                if (!api.gtmDL) {
-                    return;
+                if (api.gtmDL) {
+                    api.gtmDL.push({
+                        event: 'fieldTiming',
+                        timingCategory: 'performance',
+                        timingVariable: 'load',
+                        timingLabel: 'mapLoaded',
+                        timingValue: timeSincePageLoad
+                    });
                 }
-                api.gtmDL.push({
-                    event: 'fieldTiming',
-                    timingCategory: 'performance',
-                    timingVariable: 'load',
-                    timingLabel: 'mapLoaded',
-                    timingValue: timeSincePageLoad
-                });
             }
 
             // reduce map animation time which in turn makes panning less jittery


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->

GTM fix returned accidentally in init-map, api events were getting skipped and breaking things (but only on api maps)

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers
