### PR TITLE
fix(epsgLookup): file wizard loads GeoJson with custom projection

### DIFF
--- a/src/app/geo/layer-blueprint.class.ts
+++ b/src/app/geo/layer-blueprint.class.ts
@@ -30,7 +30,7 @@ function mixins<A, B, C, D, E>(
     CtorE: Constructor<E>
 ): Constructor<A & B & C & D & E>;
 function mixins<T>(...Ctors: Constructor<T>[]): Constructor<T> {
-    class Class {}
+    class Class { }
 
     Ctors.forEach(Ctor => {
         Object.getOwnPropertyNames(Ctor.prototype).forEach(name => {
@@ -73,6 +73,7 @@ angular.module('app.geo').factory('LayerBlueprint', LayerBlueprint);
 LayerBlueprint.$inject = ['$http', 'Geo', 'gapiService', 'ConfigObject', 'appInfo', 'configService'];
 
 function LayerBlueprint($http: any, Geo: any, gapiService: any, ConfigObject: any, appInfo: any, configService: any) {
+
     /**
      * The base class for the mixins. This just declares what base properties are available across mixins.
      *
@@ -197,6 +198,7 @@ function LayerBlueprint($http: any, Geo: any, gapiService: any, ConfigObject: an
 
             // clone data because the makeSomethingLayer functions mangle the config data
             const clonedFormattedData = angular.copy(this._formattedData);
+
             const [error, layer] = await to(this.layerFactory(clonedFormattedData, this.config));
 
             if (!layer) {
@@ -247,7 +249,10 @@ function LayerBlueprint($http: any, Geo: any, gapiService: any, ConfigObject: an
          * @memberof BlueprintBase
          */
         _setConfig(rawConfig: any, ConfigClass: new (config: any) => void): void {
+
+            const epsg = appInfo.plugins.find((x: any) => x.intention === 'epsg');
             this.config = new ConfigClass(rawConfig);
+            this.config.epsgLookup = epsg.lookup;
 
             // hack fix for broken cors support
             if (this.config.url) {
@@ -295,9 +300,7 @@ function LayerBlueprint($http: any, Geo: any, gapiService: any, ConfigObject: an
                 return Promise.resolve(this._layerRecord);
             }
 
-            // TODO: move epsg lookup
-            const epsg = appInfo.plugins.find((x: any) => x.intention === 'epsg');
-            this._layerRecord = this.layerRecordFactory(this.config, esriLayer, epsg.lookup);
+            this._layerRecord = this.layerRecordFactory(this.config, esriLayer, this.config.epsgLookup);
 
             return Promise.resolve(this._layerRecord);
         }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3022

File wizard now loads GeoJSON with custom projections.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

save the following in a file (eg: `example.json`):

```js
{
  "type": "FeatureCollection",
  "crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::3174"}},
  "features": [
    {
      "type": "Feature",
      "properties": {"name":"4905 Duffers"},
      "geometry": {
        "type": "Point",
        "coordinates": [
          1400729.1329429878,
          813466.9383310359
        ]
      }
    }
  ]
}
```

Try importing through file wizard, if it doesn't error and something like the follow shows up, the fix works.

![capture](https://user-images.githubusercontent.com/25359812/45770509-9334a680-bc10-11e8-8ca2-5c581db91315.PNG)


## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~[ ] Help files and documentation have been updated~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3030)
<!-- Reviewable:end -->
