### PR TITLE
fix(ui): don't expand images in small layout

### DIFF
--- a/src/app/ui/common/expand-image.directive.js
+++ b/src/app/ui/common/expand-image.directive.js
@@ -13,7 +13,7 @@ angular
     .module('app.ui')
     .directive('rvExpandImage', rvExpandImage);
 
-function rvExpandImage($mdDialog, referenceService, $compile, $templateCache) {
+function rvExpandImage($mdDialog, referenceService, $compile, $templateCache, layoutService) {
     const directive = {
         restrict: 'A',
         link
@@ -28,6 +28,10 @@ function rvExpandImage($mdDialog, referenceService, $compile, $templateCache) {
         let width = 0;
         let height = 0;
         self.canEnlarge = false;
+
+        if (layoutService.currentLayout() === 'small') {
+            return;
+        }
 
         // get the url of the image from the tag's ngSrc or src
         // if the tag has a special format for src (eg. <rv-svg>) then specify an additional attribute


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Expanding images when the legend takes up the entire app width doesn't make much sense, on small layouts we now force there to be no zoom button.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
sample 67; Button appears normally at large size, reducing the screen width to small and refreshing will remove the zoom button on the images.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3032)
<!-- Reviewable:end -->
