### PR TITLE
Fit extent to map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6490,7 +6490,7 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#v2.5.0-24",
+      "version": "github:fgpv-vpgf/geoApi#v2.5.0-25",
       "requires": {
         "babel-cli": "6.26.0",
         "babel-preset-env": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "datatables.net-select": "1.2.5",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.8",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-24",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-25",
     "imports-loader": "0.8.0",
     "linkifyjs": "2.1.6",
     "marked": "0.4.0",

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -261,7 +261,7 @@ function apiBlock($rootScope, globalRegistry, geoService, configService, events,
      * @param {Array}  extent                   The extent to set
      */
     function setExtent(extent) {
-        configService.getSync.map.instance.setExtent(configService.getSync.map.instance.enhanceConfigExtent(extent));
+        configService.getSync.map.instance.setExtent(configService.getSync.map.instance.enhanceConfigExtent(extent), true);
     }
 
     /**

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -96,7 +96,7 @@ function geoService($rootScope, $rootElement, events, mapService, layerRegistry,
         setFullExtent() {
             // TODO: check if this is true:
             // basemap extent should have the same projection as the map, so there is no need to reproject it and pass through `enhanceConfigExtent`
-            this.map.setExtent(this.map.enhanceConfigExtent(configService.getSync.map.selectedBasemap.full));
+            this.setExtent(this.map.enhanceConfigExtent(configService.getSync.map.selectedBasemap.full));
         }
 
         /**


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3023

Links in geoApi patch and fixes a few other instances where the map extent set was not respecting the map size.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
`index-fgp-en.html` is the best test for my monitor.  Basically, find any map that, on load, cuts off southern Ontario (you can resize your browser until it happens).  Then with same size, load this build and see that the map starts at a zoom level that shows all of Canada.


## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3033)
<!-- Reviewable:end -->
