### PR TITLE
fix(ui): symbology toggle not aligned with parent

### DIFF
--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -78,7 +78,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
     return directive;
 
     /*********/
-
+    // eslint-disable-next-line max-statements
     function link(scope, element) {
         const self = scope.self;
 
@@ -89,6 +89,8 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
 
         self.expandSymbology = expandSymbology;
         self.fanOutSymbology = fanOutSymbology;
+
+        self.symbologyWidth = 32;
 
         const canvas = document.createElement('canvas');
 
@@ -163,9 +165,17 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             trigger: null, // expand self.trigger node
 
             // TODO: container width will depend on app mode: desktop or mobile; need a way to determine this
-            containerWidth: 343,
+            containerWidth: 350,
             maxItemWidth: 350
         };
+
+        scope.$watch(() => (element.parent().width()), value => {
+            if (value) {
+                ref.containerWidth = value;
+                updateContainerWidth(value);
+            }
+            scope.$applyAsync();
+        });
 
         scope.$watch('self.showSymbologyToggle', value => {
             if (value) {
@@ -214,8 +224,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                                 self.toggleList[s.name] = new ToggleSymbol(s);
                             }
                         });
-
-                        self.buttonOffset = `${parseInt(element.closest('rv-legend-block').css('padding-left')) - 35.4}px`;
+                        updateContainerWidth(ref.containerWidth);
                     });
                 }
             }
@@ -262,6 +271,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                     ref.fanOutTimeline.reverse();
                 } else {
                     // collapse symbology items and forward play wiggle
+                    self.symbologyWidth = 32;
                     ref.expandTimeline.reverse();
                     self.showSymbologyToggle = false;
                     ref.fanOutTimeline.play();
@@ -729,6 +739,19 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
             // measure text width on the canvas: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/measureText
             const metrics = context.measureText(text);
             return metrics.width;
+        }
+
+        /**
+         * Updates container width to allign the symbology checkboxes
+         * @function updateContainerWidth
+         * @param {number} value
+         */
+        function updateContainerWidth(value) {
+            if ((self.isExpanded && Object.keys(self.toggleList).length > 0 && ref.expandTimeline && !ref.expandTimeline.isActive()) ||
+                (!self.isExpanded && ref.expandTimeline && ref.expandTimeline.isActive())) {
+                self.symbologyWidth = value;
+                scope.$applyAsync();
+            }
         }
     }
 }

--- a/src/app/ui/toc/templates/symbology-stack.html
+++ b/src/app/ui/toc/templates/symbology-stack.html
@@ -9,7 +9,7 @@
         <rv-svg class="rv-symbol-graphic" src="self.symbology.coverIcon.svgcode"></rv-svg>
     </div>
 
-    <div class="rv-symbol" ng-repeat="symbol in self.symbology.stack" ng-style="{'z-index': 100 + self.symbology.stack.length - $index }">
+    <div class="rv-symbol" ng-repeat="symbol in self.symbology.stack" ng-style="{'z-index': 100 + self.symbology.stack.length - $index, 'width': self.symbologyWidth}">
         <rv-svg ng-if="symbol.image" rv-expand-image class="rv-symbol-graphic" source="{{ symbol.image }}" src="symbol.svgcode"></rv-svg>
         <rv-svg ng-if="!symbol.image" class="rv-symbol-graphic" src="symbol.svgcode"></rv-svg>
 
@@ -19,8 +19,7 @@
         </div>
 
         <md-button
-            class="md-icon-button rv-icon-20"
-            ng-style="{'right': self.buttonOffset, 'position': 'absolute'}"
+            class="md-icon-button rv-icon-20 toggle-button"
             ng-click="self.onToggleClick(symbol.name)"
             ng-if="self.toggleList[symbol.name]"
             aria-pressed = "{{ self.toggleList[symbol.name].isSelected }}"

--- a/src/content/styles/modules/_symbology.scss
+++ b/src/content/styles/modules/_symbology.scss
@@ -43,6 +43,10 @@
                 &.show {
                     opacity: 1;
                 }
+
+                &.toggle-button {
+                    margin-right: 6px;
+                }
             }
 
             .rv-symbol-graphic {


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Fix in #3011 wasn't working in all situations. Should now properly align the symbology whether or not there's a scroll bar. 

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
:eyes:
Sample 46
http://fgpv.cloudapp.net/demo/users/dane-thomas/symbology-toggle-offset/dev/samples/index-fgp-en.html?keys=CESI_Other,JOSM
Any layers with toggle symbology 

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
in-line comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3034)
<!-- Reviewable:end -->
