### PR TITLE
fix(ui): symbology toggle bug with scroll bar

### DIFF
--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -224,7 +224,6 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                                 self.toggleList[s.name] = new ToggleSymbol(s);
                             }
                         });
-                        updateContainerWidth(ref.containerWidth);
                     });
                 }
             }
@@ -271,7 +270,6 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                     ref.fanOutTimeline.reverse();
                 } else {
                     // collapse symbology items and forward play wiggle
-                    self.symbologyWidth = 32;
                     ref.expandTimeline.reverse();
                     self.showSymbologyToggle = false;
                     ref.fanOutTimeline.play();
@@ -385,10 +383,12 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
                 },
                 onComplete: () => {
                     self.showSymbologyToggle = true;
+                    updateContainerWidth(ref.containerWidth);
                     scope.$digest();
                 },
                 onReverseComplete: () => {
                     self.isExpanded = false;
+                    self.symbologyWidth = 32;
                     scope.$digest();
                 }
             });
@@ -747,8 +747,7 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
          * @param {number} value
          */
         function updateContainerWidth(value) {
-            if ((self.isExpanded && Object.keys(self.toggleList).length > 0 && ref.expandTimeline && !ref.expandTimeline.isActive()) ||
-                (!self.isExpanded && ref.expandTimeline && ref.expandTimeline.isActive())) {
+            if (self.isExpanded && Object.keys(self.toggleList).length > 0 && ref.expandTimeline && !ref.expandTimeline.isActive()) {
                 self.symbologyWidth = value;
                 scope.$applyAsync();
             }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Fix in #3034 wasn't working in all situations. Should now properly align the symbology whether or not there's a scroll bar. 

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
:eyes:
Sample 46
http://fgpv.cloudapp.net/demo/users/dane-thomas/symbology-toggle-offset2/dev/samples/index-fgp-en.html?keys=CESI_Other,JOSM
Any layers with toggle symbology 

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
in-line comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3035)
<!-- Reviewable:end -->
