### PR TITLE
fix(dynamicRecord): identify results show with undefined clauses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6490,7 +6490,7 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#v2.5.0-22",
+      "version": "github:fgpv-vpgf/geoApi#v2.5.0-24",
       "requires": {
         "babel-cli": "6.26.0",
         "babel-preset-env": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "datatables.net-select": "1.2.5",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "1.3.8",
-    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-22",
+    "geoApi": "github:fgpv-vpgf/geoApi#v2.5.0-24",
     "imports-loader": "0.8.0",
     "linkifyjs": "2.1.6",
     "marked": "0.4.0",


### PR DESCRIPTION
## Description
<!-- Link to an issue (use #nnn for easy linking) or include a description -->
As per CGCC chat: identify did not work for child 0 of this layer: https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/CGCC/MapServer/0

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Test with child 0 of this layer:  https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/CGCC/MapServer/0

Also try identifying with other Dynamic layer symbology stacks (eg: `keys=NPRI_CO`, sample 46, etc)

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
inline comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~[ ] Help files and documentation have been updated~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers
