### PR TITLE
fix(legendAPI): fix parent not found before trying to access children

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -1245,12 +1245,13 @@ function legendServiceFactory(
     function _updateApiReloadedBlock(reloadedBlock) {
         // Only run when the parent is ready on the reloadedBlock
         const watchParent = $rootScope.$watch(() => reloadedBlock.parent, (parent, nullParent) => {
-            const index = parent.entries.indexOf(reloadedBlock);
-            const parentElement = parent.name === "I'm root" ? // not sure if there's a better way to check for root
-                { children: mApi.ui.configLegend.children } :
+            parent = parent.collapsed ? parent.parent : parent;
+            const index = parent.entries.filter(entry => !entry.hidden).indexOf(reloadedBlock);
+            const parentElement = parent.blockConfig === configService.getSync.map.legend.root ?
+                mApi.ui.configLegend :
                 _findParentElement(parent);
 
-            if (index > -1) {
+            if (index > -1 && parentElement) {
                 parentElement.children[index]._initSettings(reloadedBlock);
             }
 
@@ -1262,12 +1263,13 @@ function legendServiceFactory(
             for (let element of list) {
                 if (element._legendBlock === parentBlock) {
                     return element;
-                }
-                else if (element.children) {
-                    return _findParentElement(parentBlock, element.children);
+                } else if (element.children) {
+                    const pElement = _findParentElement(parentBlock, element.children);
+                    if (pElement) {
+                        return pElement;
+                    }
                 }
             }
-
         }
     }
 }


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Fix issue with parent element not being found before accessing children

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
:eyes:
Reload layer through api or otherwise. Should no longer see an error in console stating parent wasn't found. 

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3046)
<!-- Reviewable:end -->
