### PR TITLE
fix(https): display error when importing non https service over https

### DIFF
--- a/src/app/ui/loader/loader-service.directive.js
+++ b/src/app/ui/loader/loader-service.directive.js
@@ -168,6 +168,12 @@ function Controller($q, $timeout, stateManager, Geo, Stepper, $rootElement, keyN
     function connectOnContinue() {
         const connect = self.connect;
 
+        // maps served over https can only accept https enabled services to avoid mixed content issues.
+        if (location.protocol === 'https:' && connect.serviceUrl.match(/http:/)) {
+            toggleErrorMessage(connect.form, 'serviceUrl', 'https', false);
+            return;
+        }
+
         const layerBlueprintPromise = layerSource
             .fetchServiceInfo(connect.serviceUrl)
             .then(({ options: layerBlueprintOptions, preselectedIndex }) => {
@@ -221,6 +227,7 @@ function Controller($q, $timeout, stateManager, Geo, Stepper, $rootElement, keyN
     function serviceUrlResetValidation() {
         // reset broken endpoint error message when user modifies service url
         toggleErrorMessage(self.connect.form, 'serviceUrl', 'broken', true);
+        toggleErrorMessage(self.connect.form, 'serviceUrl', 'https', true);
     }
 
     /**

--- a/src/app/ui/loader/loader-service.directive.js
+++ b/src/app/ui/loader/loader-service.directive.js
@@ -32,6 +32,7 @@ function Controller($q, $timeout, stateManager, Geo, Stepper, $rootElement, keyN
 
     self.closeLoaderService = closeLoaderService;
     self.isWMSLayerWithMultipleStyles = isWMSLayerWithMultipleStyles;
+    self.isHTTPS = location.protocol === 'https:';
 
     self.serviceTypes = [
         Geo.Service.Types.FeatureLayer,
@@ -168,14 +169,9 @@ function Controller($q, $timeout, stateManager, Geo, Stepper, $rootElement, keyN
     function connectOnContinue() {
         const connect = self.connect;
 
-        // maps served over https can only accept https enabled services to avoid mixed content issues.
-        if (location.protocol === 'https:' && connect.serviceUrl.match(/http:/)) {
-            toggleErrorMessage(connect.form, 'serviceUrl', 'https', false);
-            return;
-        }
-
         const layerBlueprintPromise = layerSource
-            .fetchServiceInfo(connect.serviceUrl)
+            // maps served over https can only accept https enabled services to avoid mixed content issues.
+            .fetchServiceInfo(self.isHTTPS ? connect.serviceUrl.replace('http:', 'https:') : connect.serviceUrl)
             .then(({ options: layerBlueprintOptions, preselectedIndex }) => {
                 self.layerBlueprintOptions = layerBlueprintOptions;
                 self.layerBlueprint = layerBlueprintOptions[preselectedIndex];
@@ -227,7 +223,6 @@ function Controller($q, $timeout, stateManager, Geo, Stepper, $rootElement, keyN
     function serviceUrlResetValidation() {
         // reset broken endpoint error message when user modifies service url
         toggleErrorMessage(self.connect.form, 'serviceUrl', 'broken', true);
-        toggleErrorMessage(self.connect.form, 'serviceUrl', 'https', true);
     }
 
     /**

--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -22,8 +22,9 @@
                 <div ng-messages="self.connect.form.serviceUrl.$error">
                     <div ng-message="url">{{ 'import.service.connect.invalidurl' | translate }}</div>
                     <div ng-message="broken">{{ 'import.service.connect.broken' | translate }}</div>
-                    <div ng-message="https">{{ 'import.service.connect.https' | translate }}</div>
                 </div>
+
+                <div class="rv-hint" ng-if="self.isHTTPS">{{ 'import.service.connect.httpshint' | translate }}</div>
             </md-input-container>
         </rv-stepper-item>
 

--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -22,6 +22,7 @@
                 <div ng-messages="self.connect.form.serviceUrl.$error">
                     <div ng-message="url">{{ 'import.service.connect.invalidurl' | translate }}</div>
                     <div ng-message="broken">{{ 'import.service.connect.broken' | translate }}</div>
+                    <div ng-message="https">{{ 'import.service.connect.https' | translate }}</div>
                 </div>
             </md-input-container>
         </rv-stepper-item>

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -328,6 +328,7 @@ Geometry types,geometry.type.imagery,imagery,1,imagerie,1
 ,import.service.connect.serviceurl,Service layer URL,1,Adresse URL du service,1
 ,import.service.connect.invalidurl,This is not a valid URL,1,Cette adresse URL n'est pas valide,1
 ,import.service.connect.broken,Service does not respond,1,Le service ne répond pas,1
+,import.service.connect.https,"Service url must start with https://",1,"L'URL de service doit commencer par https://",0
 ,import.service.select.title,Select Service type,1,Sélectionner le type de service,1
 ,import.service.select.servicetype,Service Type,1,Type de service,1
 ,import.service.select.wrong,Service can not be imported using this type,1,Le service ne peut être importé en utilisant ce type,1

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -323,12 +323,12 @@ Geometry types,geometry.type.imagery,imagery,1,imagerie,1
 ,import.file.type.csv,CSV,1,CSV,1
 ,import.file.type.shapefile,zipped Shapefile,1,Shapefile zippé,1
 ,import.file.type.geojson,GeoJSON,1,GeoJSON,1
+,import.service.connect.httpshint,Requests will be made using HTTPS,1,Les demandes seront faites en utilisant HTTPS,0
 ,import.service.title,Import Service,1,Importer un service,1
 ,import.service.connect.title,Connect service,1,Connecter au service,1
 ,import.service.connect.serviceurl,Service layer URL,1,Adresse URL du service,1
 ,import.service.connect.invalidurl,This is not a valid URL,1,Cette adresse URL n'est pas valide,1
 ,import.service.connect.broken,Service does not respond,1,Le service ne répond pas,1
-,import.service.connect.https,"Service url must start with https://",1,"L'URL de service doit commencer par https://",0
 ,import.service.select.title,Select Service type,1,Sélectionner le type de service,1
 ,import.service.select.servicetype,Service Type,1,Type de service,1
 ,import.service.select.wrong,Service can not be imported using this type,1,Le service ne peut être importé en utilisant ce type,1


### PR DESCRIPTION
## Description

Displays an error when attempting to load an http service over an https connection.

![https-import](https://user-images.githubusercontent.com/10187181/46212518-2bfbae00-c304-11e8-98c9-72d574343548.gif)

Closes #3031

## Testing
Tested over localhost https mode. 

## Documentation
inline

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3048)
<!-- Reviewable:end -->
