### PR TITLE
fix(ui): toggle stack and layer behaviour in sync

### DIFF
--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -1,3 +1,5 @@
+import { Observable, Subject, BehaviorSubject } from 'rxjs';
+
 /**
  *
  * @module LegendBlock
@@ -658,6 +660,7 @@ function LegendBlockFactory(
             this.isControlDisabled = ref.isControlDisabled.bind(this);
             this.isControlSystemDisabled = ref.isControlSystemDisabled.bind(this);
             this.isControlUserDisabled = ref.isControlUserDisabled.bind(this);
+            this._selectedChanged = new Subject();
         }
 
         get isInteractive() {
@@ -673,6 +676,11 @@ function LegendBlockFactory(
         }
         set isSelected(value) {
             this._isSelected = value;
+            this._selectedChanged.next(value);
+        }
+
+        get selectedChanged(){
+            return this._selectedChanged.asObservable();
         }
 
         /**
@@ -711,6 +719,7 @@ function LegendBlockFactory(
             this._controlledProxyWrappers = [];
 
             this._aggregateStates = ref.aggregateStates;
+            this._visibilityChanged = new Subject();
 
             this._symbologyStack = new SymbologyStack(
                 this.proxyWrapper.proxyPromise,
@@ -741,6 +750,11 @@ function LegendBlockFactory(
                     deregisterWatch();
                 }
             );
+
+            // applies visibility settings to grid
+            if (!this.visibility) {
+                this.symbDefinitionQuery = '1=2';
+            }
         }
 
         get proxyWrapper() {
@@ -865,6 +879,10 @@ function LegendBlockFactory(
             return this.proxyWrapper.visibility;
         }
         set visibility(value) {
+            if (value === this.visibility) {
+                return;
+            }
+
             if (this.isControlSystemDisabled('visibility')) {
                 return;
             }
@@ -875,6 +893,12 @@ function LegendBlockFactory(
             if (!value) {
                 this.boundingBox = false;
             }
+
+            this._visibilityChanged.next(value);
+        }
+
+        get visibilityChanged() {
+            return this._visibilityChanged.asObservable();
         }
 
         get opacity() {
@@ -1532,6 +1556,7 @@ function LegendBlockFactory(
 
             return this._selectedEntry === null ? false : this._selectedEntry.visibility;
         }
+
         set visibility(value) {
             if (!value) {
                 this._activeEntries.forEach(entry => (entry.visibility = value));


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2456

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
`keys=NPRI_CO, CESI_Other, JOSM`, `sample 46`, other samples with symbology stacks. 

**Test six cases:**
- Toggle off each item in stack, does top level layer toggle off automatically?
- Now toggle on an item in the stack, does top level layer toggle on automatically?
- Toggle off top level in the stack, do all items in the stack toggle off automatically?
- Toggle on top level in the stack, do all items in the stack toggle on automatically?
- Toggle off visibility of non-symbology stack layer, is the datatable empty?
- Toggle on visibility of non-symbology stack layer, is the datatable formatted properly?

Pay attention to correct entries showing up on datatable, and correct symbologies showing up on map.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
inline comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~[ ] Help files and documentation have been updated~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3051)
<!-- Reviewable:end -->
