### PR TITLE
fix(identify): indentify properly filters out symbology stacks

### DIFF
--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -149,6 +149,10 @@ function rvSymbologyStack($q, Geo, animationService, layerRegistry, stateManager
 
             // apply to block so changes reflect on map
             self.block.definitionQuery = fullDef;
+
+            // save `definitionClause` on layerRecord (do not delete important for accurate identify results)
+            layerRecord.definitionClause = defClause;
+
             // trigger event which table uses to update
             events.$broadcast(events.rvSymbDefinitionQueryChanged);
         };


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Code essential for identify (geoAPI side) got deleted here https://github.com/fgpv-vpgf/fgpv-vpgf/pull/3050.  Reversed this fix: https://github.com/fgpv-vpgf/fgpv-vpgf/pull/3036. This PR adds it back.


## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Tested with `JOSM`, `NPRI_CO`, `CESI_Other`, `sample 46`

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- ~[ ] Release notes have been updated~ (Fix linked above already updated in release notes)
- [x] PR targets the correct release version
- ~[ ] Help files and documentation have been updated~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3064)
<!-- Reviewable:end -->
