### PR TITLE
fix(geosearch): clear filters has proper label on hover

### DIFF
--- a/src/app/ui/geosearch/geosearch-top-filters.html
+++ b/src/app/ui/geosearch/geosearch-top-filters.html
@@ -24,10 +24,10 @@
 
     <md-button
         ng-disabled="!self.selectedType && !self.selectedProvince"
-        aria-label="{{ 'appbar.aria.geosearchclose' | translate }}"
+        aria-label="{{ 'appbar.aria.geosearchfilters' | translate }}"
         class="md-icon-button rv-icon-20 rv-button-24 black"
         ng-click="self.clear()">
-        <md-tooltip>{{ 'appbar.aria.geosearchclose' | translate }}</md-tooltip>
+        <md-tooltip>{{ 'appbar.aria.geosearchfilters' | translate }}</md-tooltip>
         <md-icon md-svg-src="community:filter-remove"></md-icon>
     </md-button>
 </div>

--- a/src/locales/translations.csv
+++ b/src/locales/translations.csv
@@ -15,7 +15,8 @@ Appbar tooltip for tools icon,appbar.tooltip.tools,Tools,1,Outils,1
 Appbar aria label for layers icon,appbar.aria.layers,Sets,1,Séries,1
 Appbar aria label for layers icon,appbar.aria.geoApiError,Geolocation search is unavailable,1,La recherche géolocalisée n'est pas disponible,1
 Appbar aria label for point info icon,appbar.aria.pointInfo,Feature details,1,Détails sur l'élément,1
-Appbar aria label for menu  icon,appbar.aria.menu,Open Sidenav,1,Ouvrir le menu de navigation,1
+Appbar aria label for menu icon,appbar.aria.menu,Open Sidenav,1,Ouvrir le menu de navigation,1
+Appbar aria label for geosearch filter icon,appbar.aria.geosearchfilters,Clear filters,1,Effacer les filtres,1
 Appbar aria for geosearch close icon,appbar.aria.geosearchclose,Close Geolocation Search,1,Fermer la recherche géolocalisée,1
 ,appbar.aria.geosearch,Geo Search,1,Recherche géo,1
 Appbar aria label for geosearch icon,appbar.aria.geosearch,Geolocation Search,1,Recherche géolocalisée,1


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3068

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Test on any sample, close button should have original text, erasing filter should have new text.

French translations are official (copied from datatable) and should work.

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
n/a

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~[ ] Help files and documentation have been updated~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3070)
<!-- Reviewable:end -->
