### PR TITLE
fix(bookmark): WFS layer bookmarks properly encoded and decoded

### DIFF
--- a/src/app/core/bookmark.service.js
+++ b/src/app/core/bookmark.service.js
@@ -208,7 +208,8 @@ function bookmarkService($q, configService, gapiService, bookmarkVersions, Geo, 
             [types.OGC_WMS]: '1',
             [types.ESRI_TILE]: '2',
             [types.ESRI_DYNAMIC]: '3',
-            [types.ESRI_IMAGE]: '4'
+            [types.ESRI_IMAGE]: '4',
+            [types.OGC_WFS]: '5'
         };
         const layerCode = typeToCode[layerDefinition.layerType];
 

--- a/src/content/samples/bookmark-decode.html
+++ b/src/content/samples/bookmark-decode.html
@@ -252,7 +252,8 @@
             ['Wms', ['opacity', 'visibility', 'boundingBox', 'query']],
             ['Tile', ['opacity', 'visibility', 'boundingBox']],
             ['Dynamic', ['opacity', 'visibility', 'boundingBox', 'query', 'childCount']],
-            ['Image', ['opacity', 'visibility', 'boundingBox']]
+            ['Image', ['opacity', 'visibility', 'boundingBox']],
+            ['WFS', ['opacity', 'visibility', 'boundingBox', 'snapshot', 'query']]
         ];
 
         var info = bookmark.match(pattern);


### PR DESCRIPTION
## Description
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3071

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Test sample 76, sample 75. 

WFS layers should be preserved upon switching from Lambert/Mercator and English/French.
**Use the [UPDATED BOOKMARK DECODER](http://fgpv.cloudapp.net/demo/users/ShrutiVellanki/fix-mercator-french/dev/samples/bookmark-decode.html) to test if the WFS layer is properly encoded/decoded.**

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~[ ] Help files and documentation have been updated~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3072)
<!-- Reviewable:end -->
