### PR TITLE
fix(LegendAPI): keep viewer and api legend children synced

### DIFF
--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -21,6 +21,7 @@ const THROTTLE_TIMEOUT = 3000;
  */
 angular.module('app.geo').factory('layerRegistry', layerRegistryFactory);
 
+// eslint-disable-next-line max-statements
 function layerRegistryFactory(
     $rootScope,
     $filter,
@@ -48,6 +49,7 @@ function layerRegistryFactory(
         removeBoundingBoxRecord,
 
         synchronizeLayerOrder,
+        syncApiElementOrder,
         getRcsLayerIDs
     };
 
@@ -562,6 +564,8 @@ function layerRegistryFactory(
             mapBody.reorderLayer(highlightLayer, featureStackLastIndex);
         }
 
+        syncApiElementOrder();
+
         /**
          * A helper function which synchronizes a single sort group of layers between the layer selector and internal layer stack.
          *
@@ -608,6 +612,27 @@ function layerRegistryFactory(
         }
     }
 
+    /**
+     * A helper function which synchronizes the order of the api elements
+     *
+     * @function syncApiElementOrder
+     * @private
+     */
+    function syncApiElementOrder() {
+        const legendEntries = configService.getSync.map.legendBlocks.entries.filter(entry => !entry.hidden);
+        const legendElements = mapApi.ui.configLegend.children;
+        let reorderedElements = [];
+        legendEntries.forEach((entry, index) => {
+            entry = entry.collapsed ? entry.entries[0] : entry;
+            if (entry !== legendElements[index]._legendBlock) {
+                const element = legendElements.find(legendElement => entry === legendElement._legendBlock) || reorderedElements.find(legendElement => entry === legendElement._legendBlock);
+                if (element) {
+                    reorderedElements.push(legendElements[index]);
+                    legendElements[index] = element;
+                }
+            }
+        });
+    }
     /**
      * // TODO: make a wrapper for the bounding box layer
      *


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
The order not being correct on the API side prevented certain lookups  from working properly. Should now keep track of reorders and orders of layers added through the wizard.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
:eyes:
Try adding services, reordering legends

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3074)
<!-- Reviewable:end -->
