### PR TITLE
fix(focusManager): Slider selector corrected

### DIFF
--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -18,7 +18,7 @@ const focusSelector = [
     'md-select:not([disabled])',
     'md-checkbox:not([disabled])',
     'md-switch:not([disabled])',
-    'md-slider:not([disabled])',
+    'md-slider:not([disabled]) > div',
     'textarea:not([disabled])',
     'button:not([disabled]):not([nofocus])',
     '.rv-esri-map',


### PR DESCRIPTION
## Description
Fixes an issue where the focus manager would appear to be stuck before a slider element. It had an incorrect focus target selector which resulted in a falling back to the original position. 

Closes #3094

## Testing
👁 

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3101)
<!-- Reviewable:end -->
