### PR TITLE
fix(symbology): layer toggles properly when table not open

### DIFF
--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -308,8 +308,13 @@ function LegendBlockFactory(
             if (!this._proxyCheck(() => (this.setDefinitionQuery = value))) {
                 return;
             }
-
-            this._proxy.setDefinitionQuery(value);
+            //only setDefinitionQuery once this._proxy has loaded
+            const proxyLoaded = $rootScope.$watch(() => this._proxy.state, (state, oldState) => {
+                if (state === 'rv-loaded') {
+                    this._proxy.setDefinitionQuery(value);
+                    proxyLoaded();
+                }
+            });
         }
 
         /**


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Fixes a bug which was missed in this PR: https://github.com/fgpv-vpgf/fgpv-vpgf/pull/3051
Also closes: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3110

https://webservices.maps.canada.ca/arcgis/rest/services/PHAC/fluwatchers_en/MapServer/0

Add above service [current develop](http://fgpv.cloudapp.net/demo/develop/dev/samples/index-fgp-en.html). 
- Uncheck each symbology individually WITHOUT OPENING TABLE
- Now check top level --> you will notice that boxes are checked but points on map are gone

This PR fixes that issue. 

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Repeat the steps described above, in any demo sample, it should work.
Please test multiple cases especially where layers are under groups or sets if you can. 

The bug was caused because of a piece of code that was added to avoid race conditions with groups or sets ( as a result when their table was open, weird flickering would happen). I'm pretty sure this PR doesn't retrigger that, but extra :eyes: are appreciated)

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~~[ ] Help files and documentation have been updated~~

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3109)
<!-- Reviewable:end -->
