### PR TITLE
Clear legend api blueprint tracker on map destroy

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -26,12 +26,13 @@ function legendServiceFactory(
         importLayerBlueprint,
         reloadBoundLegendBlocks,
         addLayerDefinition,
-        removeLegendBlock
+        removeLegendBlock,
+        resetApiBlueprints
     };
 
     let mApi = null;
-    const apiBlueprints = []; // blueprint promises from nonstandard sources. enables us to block legend on them as well
-    const apiBlueprintsIds = [];
+    let apiBlueprints = []; // blueprint promises from nonstandard sources. enables us to block legend on them as well
+    let apiBlueprintsIds = [];
     events.$on(events.rvApiMapAdded, (_, api) => (mApi = api));
 
     // wire in a hook to any map for adding a layer through a JSON snippet. this makes it available on the API
@@ -1007,5 +1008,15 @@ function legendServiceFactory(
 
             return promise;
         }
+    }
+
+    /**
+     * Clears our trackers of api blueprints.
+     *
+     * @function resetApiBlueprints
+     */
+    function resetApiBlueprints() {
+        apiBlueprints = [];
+        apiBlueprintsIds = [];
     }
 }

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -19,7 +19,8 @@ function mapServiceFactory(
     events,
     $translate,
     errorService,
-    $http
+    $http,
+    legendService
 ) {
     const service = {
         destroyMap,
@@ -146,6 +147,7 @@ function mapServiceFactory(
 
         mapConfig.instance._map.destroy();
         mapConfig.reset();
+        legendService.resetApiBlueprints();
 
         referenceService.mapNode.empty();
 


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3118

Need to clear out legend's internal tracker of layer blueprints added via API when map gets destroyed (e.g. projection change).  See above issue comments for the why.

Would imagine how this solution is implemented needs adjustment (e.g. making the map service reference the legend service is likely bad)

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Minimal, needs more when I'm back.  

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3124)
<!-- Reviewable:end -->
