### PR TITLE
fix(config): add defaults to legend export config

### DIFF
--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1890,9 +1890,19 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
         constructor (source) {
             super(source);
 
-            this._showInfoSymbology = source.showInfoSymbology || false;
-            this._showControlledSymbology = source.showControlledSymbology || false;
-            this._columnWidth = source.columnWidth || 350;
+            // apply legend export component defaults
+            source = {
+                ...{
+                    showInfoSymbology: false,
+                    showControlledSymbology: false,
+                    columnWidth: 350
+                },
+                ...source
+            };
+
+            this._showInfoSymbology = source.showInfoSymbology;
+            this._showControlledSymbology = source.showControlledSymbology;
+            this._columnWidth = source.columnWidth;
         }
 
         get showInfoSymbology () {      return this._showInfoSymbology; }
@@ -2220,7 +2230,7 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
             // we run the above loop regardless to ensure any bookmark data gets tacked on the raw config items.
             if (this.legend.type === TYPES.legend.AUTOPOPULATE) {
                 this._layers = filteredConfigLayers;
-            } 
+            }
 
             // re-create the legend structure
             // - in auto legend, this will generate the legend using the order of the layers array (in cases where it was modified by the bookmark)

--- a/src/content/samples/config/config-sample-80.json
+++ b/src/content/samples/config/config-sample-80.json
@@ -38,7 +38,6 @@
       },
       "map": {},
       "mapElements": {},
-      "legend": {},
       "footnote": {
         "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
       }


### PR DESCRIPTION
Sets default values for the legend export config component. Without the defaults, the config tries to read values of `undefined` and fails.

### To test
- open config 80
- if the map loads, everything is okay
- generate export image and config there is no legend in the image
- eat a fizzy boom

Closes #3146

## Description
<!-- Link to an issue or include a description -->

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE
- [x] works with projection change
- [x] works with language change
- [x] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [x] works in auto-legend
- [x] works in structured legend
- [ ] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] orignal issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3148)
<!-- Reviewable:end -->
