### PR TITLE
fix(geo): metadata shouldn't be available if undefined in config

### DIFF
--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -439,6 +439,10 @@ function LegendBlockFactory(
         get metadataUrl() {
             return this._layerConfig.metadataUrl;
         }
+        set metadataUrl(url) {
+            this._layerConfig.metadataUrl = url;
+        }
+
         get catalogueUrl() {
             return this._layerConfig.catalogueUrl;
         }

--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -487,6 +487,8 @@ function legendServiceFactory(
             const legendBlockGroup = new LegendBlock.Group(derivedEntryGroupConfig, rootProxyWrapper, true);
             // map this legend block to the layerRecord
             legendBlockGroup.layerRecordId = layerConfig.id;
+            // store the provided metadataUrl on the parent group block
+            legendBlockGroup.metadataUrl = blueprints.main.config.metadataUrl;
 
             legendMappings[layerConfig.id].push({
                 legendBlockId: legendBlockGroup.id,
@@ -554,10 +556,12 @@ function legendServiceFactory(
                     const groupConfig = new ConfigObject.legend.EntryGroup(item.groupSource);
                     legendBlock = new LegendBlock.Group(groupConfig, rootProxyWrapper);
                     legendBlock.layerRecordId = layerConfig.id; // map all dynamic children to the block config and layer record of their root parent
+                    legendBlock.metadataUrl = parentLegendGroup.metadataUrl; // store the provided metadataUrl on the parent group block
 
                     item.childs.forEach(child => _addChildBlock(child, legendBlock));
                 } else {
                     const entryConfig = new ConfigObject.legend.Entry(item);
+                    item.proxyWrapper.metadataUrl = parentLegendGroup.metadataUrl; // store the provided metadataUrl on the proxy wrapper
                     legendBlock = new LegendBlock.Node(item.proxyWrapper, entryConfig);
                     legendBlock.layerRecordId = layerConfig.id; // map all dynamic children to the block config and layer record of their root parent
 
@@ -567,6 +571,9 @@ function legendServiceFactory(
                         item.proxyWrapper.layerConfig.initialFilteredQuery !== '';
                 }
 
+                if (legendBlock.metadataUrl === undefined) {
+                    legendBlock.disabledControls.push('metadata');
+                }
                 parentLegendGroup.addEntry(legendBlock);
             }
         }

--- a/src/content/samples/config/config-sample-06.json
+++ b/src/content/samples/config/config-sample-06.json
@@ -96,6 +96,7 @@
         "id": "powerplant-nuclear",
         "name": "Power Plants, nuclear",
         "layerType": "esriDynamic",
+        "metadataUrl": "http://donnees-data.intranet.ec.gc.ca:80/geonetwork/srv/eng/xml.metadata.get?uuid=917b8854-64a5-41d6-ad7f-d0a3c0c3cb29",
         "layerEntries": [
           {
             "index": 22,


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes #3113

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
:eyes: on sample 6
Added a metadata url for `Nuclear` layer

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] orignal issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3163)
<!-- Reviewable:end -->
