### PR TITLE
fix(export): limit export title to 128 chars

### DIFF
--- a/src/app/ui/export/export.html
+++ b/src/app/ui/export/export.html
@@ -78,6 +78,7 @@
                         ng-if="self.titleComponent.isSelected && !self.isGenerateError">
                         <md-input-container md-no-float class="md-headline" ng-disabled="self.isError">
                             <input ng-model="self.titleComponent.value"
+                                maxlength='128'
                                 ng-change="self.updateTitleComponent()"
                                 ng-model-options="{ updateOn: 'default blur', debounce: { default: 300, blur: 0 } }"
                                 placeholder="{{ 'export.title' | translate }}">


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2978

Title length is limited to 128 chars, and as a direct result filename is also limited thanks to this bit of code in `export.service.js`:

```js
            // file name is either the `app id + title` provided by the user or `app id + timestamp`
            if (self.titleComponent && self.titleComponent.value !== '') {
                fileName += ` - ${self.titleComponent.value}`;
            } else {
                const timestampComponent = self.exportComponents.get('timestamp');
                if (timestampComponent) {
                    fileName += ` - ${timestampComponent.value}`;
                }
            }
```

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

copy/paste this into export map
> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

It'll cut off at the 128  character mark.


### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE
- [x] works with projection change
- [x] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [x] works via RCS
- [x] works via bookmark load
- [x] works in auto-legend
- [x] works in structured legend
- [ ] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
none

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~[ ] Help files and documentation have been updated~
- [x] orignal issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3171)
<!-- Reviewable:end -->
