### PR TITLE
fix(export): use native toBlob in Edge

### DIFF
--- a/src/app/ui/export/export.service.js
+++ b/src/app/ui/export/export.service.js
@@ -243,6 +243,7 @@ function exportService($mdDialog, $mdToast, referenceService, configService, eve
          * @function saveImage
          * @private
          */
+        // eslint-disable-next-line max-statements
         function saveImage() {
             // get generated graphics from the export components
             const exportGraphics = self.exportComponents.items
@@ -311,10 +312,18 @@ function exportService($mdDialog, $mdToast, referenceService, configService, eve
                 return;
             }
 
+
             try {
-                canvas.toBlob(blob => {
-                    FileSaver.saveAs(blob, `${fileName}.${self.fileType}`);
-                });
+                // https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3184
+                // IE 10+ and Edge have their own `toBlob` implmenetation called `msToblob` ...
+                if (canvas.msToBlob) {
+                    // ... and it's synchronous!
+                    FileSaver.saveAs(canvas.msToBlob(), `${fileName}.${self.fileType}`);
+                } else {
+                    canvas.toBlob(blob => {
+                        FileSaver.saveAs(blob, `${fileName}.${self.fileType}`);
+                    });
+                }
             } catch (error) {
                 console.error(error);
                 // something else happened

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -179,8 +179,7 @@ module.exports = function (env) {
             return new HtmlWebpackPlugin({
                 inject: false,
                 filename: `${filePath.join('/')}/${fileName.replace(/\.[^/.]+$/, '.html')}`,
-                template: `src/content/${file}`,
-                excludeChunks: ['ie-polyfills']
+                template: `src/content/${file}`
             });
         }
         }).filter(x => x)


### PR DESCRIPTION
Fixes downloading of the exported image in Edge. See the issue for more details.

Closes #3184 

## Description
<!-- Link to an issue or include a description -->

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Load sample 75 and try to download the export image in Edge. It should work. (It also should still work in all other browsers).

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE and Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
Inline comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3189)
<!-- Reviewable:end -->
