### PR TITLE
fix(polyfill): NodeList.forEach no longer ie11 specific + more

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14193,7 +14193,7 @@
       "integrity": "sha1-Mcak0w59rdhDQNt/sb9P5e+7eVE="
     },
     "svg.textflow.js": {
-      "version": "github:fgpv-vpgf/svg.textflow.js#5c7cd52e91e820920c1c8124dcbecee278bfeaa2",
+      "version": "github:fgpv-vpgf/svg.textflow.js#ae147794bb3cc45a388d0c2bcddf37963c344c8f",
       "from": "github:fgpv-vpgf/svg.textflow.js"
     },
     "svgo": {

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -13,19 +13,21 @@ if (isIE11) {
      * See: https://github.com/fgpv-vpgf/fgpv-vpgf/issues/1272#issuecomment-255395614
      */
     function serializeSvgContent(e){for(var n="<"+e.nodeName,l=null,t=null,r=0;r<e.attributes.length;r++){var i=e.attributes[r],o=i.name||i.nodeName,a=(i.value||i.nodeValue).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&apos;");o===l&&a===t||(n+=" "+o+'="'+a+'"',l=o,t=a)}if(l=null,t=null,e.childNodes.length>0){for(n+=">",r=0;r<e.childNodes.length;r++){var d=e.childNodes[r];1===d.nodeType?n+=serializeSvgContent(d):3===d.nodeType&&(n+=d.nodeValue.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&apos;"))}n+="</"+e.nodeName+">"}else n+="/>";return n}function newSvg(e){var n=document.createElement("svg");if(!(e&&this instanceof SVG.Parent))return n.appendChild(e=document.createElement("svg")),this.writeDataToDom(),e.appendChild(this.node.cloneNode(!0)),serializeSvgContent(e).replace(/^<svg>/i,"").replace(/<\/svg>$/i,"");n.innerHTML="<svg>"+e.replace(/\n/,"").replace(/<(\w+)([^<]+?)\/>/g,"<$1$2></$1>")+"</svg>";for(var l=0,t=n.firstChild.childNodes.length;l<t;l++);return this.node.appendChild(n.firstChild.firstChild),this}Object.defineProperty(SVGElement.prototype,"outerHTML",{get:function(){return serializeSvgContent(this)},enumerable:!1,configurable:!0}),window.RV=window.RV?window.RV:{},window.RV._deferredPolyfills=window.RV._deferredPolyfills?window.RV._deferredPolyfills:[],window.RV._deferredPolyfills.push(function(){SVG.extend(SVG.Element,{svg:newSvg})});
-    
-    // NodeList forEach support
-    window.NodeList&&!NodeList.prototype.forEach&&(NodeList.prototype.forEach=function(o,t){t=t||window;for(var i=0;i<this.length;i++)o.call(t,this[i],i,this)});
 }
 
-if(!TextEncoder) {
-    function TextEncoder(){}
-    TextEncoder.prototype.encode=function(e){for(var o=[],t=e.length,r=0;r<t;){var n=e.codePointAt(r),c=0,f=0;for(n<=127?(c=0,f=0):n<=2047?(c=6,f=192):n<=65535?(c=12,f=224):n<=2097151&&(c=18,f=240),o.push(f|n>>c),c-=6;c>=0;)o.push(128|n>>c&63),c-=6;r+=n>=65536?2:1}return o};
+// NodeList forEach support: https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+if (window.NodeList && !NodeList.prototype.forEach) {
+    NodeList.prototype.forEach = Array.prototype.forEach;
 }
 
-if (!TextDecoder) {
-    function TextDecoder(){}
-    TextDecoder.prototype.decode=function(e){for(var o="",t=0;t<e.length;){var r=e[t],n=0,c=0;if(r<=127?(n=0,c=255&r):r<=223?(n=1,c=31&r):r<=239?(n=2,c=15&r):r<=244&&(n=3,c=7&r),e.length-t-n>0)for(var f=0;f<n;)c=c<<6|63&(r=e[t+f+1]),f+=1;else c=65533,n=e.length-t;o+=String.fromCodePoint(c),t+=n+1}return o};
+if(!window.TextEncoder) {
+    window.TextEncoder = function (){}
+    window.TextEncoder.prototype.encode=function(e){for(var o=[],t=e.length,r=0;r<t;){var n=e.codePointAt(r),c=0,f=0;for(n<=127?(c=0,f=0):n<=2047?(c=6,f=192):n<=65535?(c=12,f=224):n<=2097151&&(c=18,f=240),o.push(f|n>>c),c-=6;c>=0;)o.push(128|n>>c&63),c-=6;r+=n>=65536?2:1}return o};
+}
+
+if (!window.TextDecoder) {
+    window.TextDecoder = function (){}
+    window.TextDecoder.prototype.decode=function(e){for(var o="",t=0;t<e.length;){var r=e[t],n=0,c=0;if(r<=127?(n=0,c=255&r):r<=223?(n=1,c=31&r):r<=239?(n=2,c=15&r):r<=244&&(n=3,c=7&r),e.length-t-n>0)for(var f=0;f<n;)c=c<<6|63&(r=e[t+f+1]),f+=1;else c=65533,n=e.length-t;o+=String.fromCodePoint(c),t+=n+1}return o};
 }
 
 if(SVGElement.prototype.contains) {


### PR DESCRIPTION
## Description
This update makes the `NodeList.forEach` polyfill available for all browsers - previously it was restricted to IE11.

Also, the `TextEncoder` and `TextDecoder` polyfill code has been updated so that it gets properly applied by the Microsoft Edge browser. This fixes issues with file based layer loading as discussed [here](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2700#issuecomment-445911366).

## Testing
Tested file based layer loading on ie11, Edge 15, and chrome.

Layer used: [oddProjDownsview.zip](https://github.com/fgpv-vpgf/fgpv-vpgf/files/2686615/oddProjDownsview.zip)



### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
Inline as needed

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [ ] orignal issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3190)
<!-- Reviewable:end -->
