### PR TITLE
chore(api): add back support for legacy api

### DIFF
--- a/docs/developer/legacy_api.md
+++ b/docs/developer/legacy_api.md
@@ -1,0 +1,108 @@
+---
+nav: dev
+---
+
+While the new API is accessible through `window.RZ`, the legacy API continues to be supported until the next major release (version 4+). Access to the legacy API continues through `window.RV`.
+
+## What's changed
+
+The legacy API is no longer loaded automatically - to continue using it you'll need to **include a script named `legacy-api.js`** which is included with all version 3+ ramp builds.
+
+```html
+<script src="../legacy-api.js"></script>
+<script src="../rv-main.js"></script>
+
+<script>
+RV.getMap('sample-map').getBookmark().then(function(bookmark) {
+    console.log('The bookmark: ' + bookmark);
+});
+</script>
+```
+
+You should include the `legacy-api.js` file before `rv-main.js` (the main ramp viewer file) and before trying to access the `RV` global variable for the first time. 
+
+## Removed Methods
+
+`registerPlugin` and `openDialogInfo` have been removed and are no longer available.
+
+See [registering a plugin](/developer/plugins?id=register) for help migrating to the new plugin system. Note that you can continue to access the legacy API (`RV`) even when it's loaded through the new plugin system.
+
+See [opening and closing panels](/developer/panels?id=open-close) for help with controlling panels. 
+
+## Available Methods
+
+```ts
+setLanguage: (language: string) => Promise<void>;
+```
+
+```ts
+panelVisibility: (panelName: string, isVisible: boolean = true) => Promise<void>;
+```
+
+```ts
+getCurrentLang: () => Promise<string>;
+```
+
+```ts
+loadRcsLayers: (string[]) => Promise<void>;
+```
+
+```ts
+getBookmark: () => Promise<string>;
+```
+
+```ts
+centerAndZoom: (x: number, y: number, spatialReference: Object, zoom: number) => Promise<void>;
+```
+
+```ts
+setExtent: (extent[]) => Promise<void>;
+```
+
+```ts
+useBookmark: (bookmark: string) => Promise<void>;
+```
+
+```ts
+getRcsLayerIDs: () => Promise<string[]>;
+```
+
+```ts
+appInfo: () => Promise<Object>;
+```
+
+```ts
+northArrow: () => Promise<Object>;
+```
+
+```ts
+mapCoordinates: (point: Object, outMouseWKID: Object) => Promise<Object[]>;
+```
+
+```ts
+getMapClickInfo: (clickHandler: Function) => Promise<Event>;
+```
+
+```ts
+convertDDToDMS: (lat: number, long: number) => Promise<Object>;
+```
+
+```ts
+setMapCursor: (cursor: string) => Promise<void>;
+```
+
+```ts
+projectGeometry: (geometry: Object, outSR: number) => Promise<Object>;
+```
+
+```ts
+toggleSideNav: (open: boolean) => Promise<void>;
+```
+
+```ts
+reInitialize: (bookmark: string) => Promise<void>;
+```
+
+```ts
+getConfig: (section: string) => Promise<Object>;
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,8 +28,7 @@
             ],
             author: [
                 {title: 'Introduction', path: '/mapauthor/intro'},
-                {title: 'Configuration', path: '/mapauthor/working_examples'},
-                {title: 'Setup on a webpage', path: '/mapauthor/working_examples'}
+                {title: 'Setup on host page', path: '/mapauthor/working_examples'}
             ],
             dev: [
                 {title: 'Home', path: '/'},
@@ -41,7 +40,7 @@
                     {type: 'sep'},
                     {type: 'label', title: 'Layers'},
                 ]},
-
+                {title: 'Legacy API', path: '/developer/legacy_api'},
                 {title: 'Plugins', path: '/developer/plugins'},
                 {title: 'Technical Documentation', path: `${url}developer/api/tech_docs`}
             ],

--- a/docs/mapauthor/intro.md
+++ b/docs/mapauthor/intro.md
@@ -1,3 +1,7 @@
+---
+nav: author
+---
+
 # A guide for map authors
 
 This guide is intended for those who are looking to use the RAMP viewer for their webpage or project.

--- a/docs/mapauthor/working_examples.md
+++ b/docs/mapauthor/working_examples.md
@@ -1,3 +1,7 @@
+---
+nav: author
+---
+
 This section will show you how to load a viewer on your own host page.
 
 ### Getting the source

--- a/package-lock.json
+++ b/package-lock.json
@@ -9245,7 +9245,7 @@
     },
     "lru-cache": {
       "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "lru-queue": {

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -1,12 +1,323 @@
 angular
     .module('app.core')
+    .run(debugBlock)
+    .run(apiBlock)
     .run(runBlock);
 
-function runBlock($rootScope, events, configService) {
+/**
+ * @function runBlock
+ * @private
+ * @memberof app.core
+ * @description
+ *
+ * The `runBlock` triggers config and locale file loading, sets language of the app.
+ */
+function runBlock($rootScope, $rootElement, reloadService, events, configService, appInfo, LEGACY_API) {
 
     // initialize config service
     configService.initialize();
 
+    // Do nothing if legacy-api.js is not present on the page
+    if(!LEGACY_API) {
+        events.$on(events.rvCfgInitialized, () => $rootScope.$broadcast(events.rvReady));
+        return;
+    }
+
     // wait on the config and geoapi
-    events.$on(events.rvCfgInitialized, () => $rootScope.$broadcast(events.rvReady));
+    events.$on(events.rvCfgInitialized, () => readyDelay());
+
+    $rootScope.uid = uid;
+
+    /********************/
+
+    /**
+     * Waits on bookmark to modify the config if needed
+     *
+     * @function readyDelay
+     * @private
+     */
+    function readyDelay() {
+        const waitAttr = $rootElement.attr('rv-wait');
+
+        preLoadApiBlock();
+
+        if (typeof waitAttr !== 'undefined') {
+            reloadService.bookmarkBlocking = true;
+            const deRegister = $rootScope.$on(events.rvBookmarkInit, () => {
+                $rootScope.$broadcast(events.rvReady);
+                deRegister(); // de-register `rvBookmarkInit` listener to prevent broadcasting `rvReady` in the future
+            });
+        } else {
+            $rootScope.$broadcast(events.rvReady);
+        }
+    }
+
+    /**
+     * Allows API calls to be exposed before map creation
+     *
+     * @function preLoadApiBlock
+     * @private
+     */
+    function preLoadApiBlock() {
+        const preMapService = {
+            initialBookmark,
+            restoreSession,
+            start
+        };
+
+        const legacyAPI = LEGACY_API.getMap(appInfo.id);
+        Object.assign(legacyAPI.legacyFunctions, preMapService);
+
+        legacyAPI.runQueue();
+
+        /******************/
+
+        /**
+         * Loads using a bookmark
+         *
+         * @function initialBookmark
+         * @param {String} bookmark      bookmark containing viewer state
+         */
+        function initialBookmark(bookmark) {
+            const storage = sessionStorage.getItem(appInfo.id);
+            if (storage) {
+                sessionStorage.removeItem(appInfo.id);
+            }
+
+            reloadService.loadWithBookmark(bookmark, true);
+        }
+
+        /**
+         * Loads using a bookmark from sessionStorage (if found) and a keyList
+         *
+         * @function restoreSession
+         * @param {Array} keys      list of keys to load with
+         */
+        function restoreSession(keys) {
+            const bookmark = sessionStorage.getItem(appInfo.id);
+
+            if (bookmark) {
+                reloadService.loadWithExtraKeys(bookmark, keys);
+                sessionStorage.removeItem(appInfo.id);
+            } else {
+                legacyAPI.loadRcsLayers(keys);
+                start();
+            }
+        }
+
+        /**
+         * Bypasses the rv-wait block
+         *
+         * @function start
+         */
+        function start() {
+            console.log('preLoadApiBlock', 'bypassing *rv-wait*');
+            reloadService.bookmarkBlocking = false;
+            $rootScope.$broadcast(events.rvBookmarkInit);
+        }
+
+    }
+
+    /**
+     * A helper function to create ids for template elements inside directives.
+     * Should be called with a scope id and an optional suffix if several different ids needed inside a single directive (each scope has a different id).
+     * Adding `{{ ::$root.uid($id) }}` inside a template will return a `{appid}-{scopeid}` string. If this used several times inside a single template, the same id is returned, so you don't have to store it to reuse. Don't forget a one-time binding.
+     * @function uid
+     * @private
+     * @param {String|Number} id ui element id
+     * @param {String|Number} [suffix] an optional suffix to be appended to the resulting id
+     * @return {String} generated template element id
+     */
+    function uid(id, suffix) {
+        suffix = suffix ? `-${suffix}` : '';
+        return `${appInfo.id}-id-${id}${suffix}`;
+    }
+}
+
+/**
+ * @function apiBlock
+ * @private
+ * @memberof app.core
+ * @description
+ *
+ * `apiBlock` sets up language and RCS calls for the global API
+ */
+function apiBlock($rootScope, geoService, configService, events,
+    bookmarkService, gapiService, reloadService, appInfo, stateManager, detailService, mapToolService, $mdSidenav, LEGACY_API) {
+    
+    // Do nothing if legacy-api.js is not present on the page
+    if(!LEGACY_API) {
+        return;
+    }
+
+    const service = {
+        setLanguage,
+        panelVisibility,
+        getCurrentLang,
+        loadRcsLayers,
+        getBookmark,
+        centerAndZoom,
+        setExtent,
+        useBookmark,
+        getRcsLayerIDs: () => geoService.getRcsLayerIDs(),
+        appInfo,
+        northArrow: mapToolService.northArrow,
+        mapCoordinates: mapToolService.mapCoordinates,
+        getMapClickInfo: mapToolService.getMapClickInfo,
+        convertDDToDMS: mapToolService.convertDDToDMS,
+        setMapCursor,
+        projectGeometry,
+        toggleSideNav: val => { $mdSidenav('left')[val](); },
+        reInitialize: bookmark => reloadService.reloadConfig(bookmark),
+        getConfig
+    };
+
+    Object.assign(LEGACY_API.getMap(appInfo.id).legacyFunctions, service);
+
+    /**
+     * Sets the translation language and reloads the map
+     *
+     * @memberof app.core
+     * @function
+     * @inner
+     * @param {String}  lang    the language to switch to
+     */
+    function setLanguage(lang) {
+        reloadService.loadNewLang(lang);
+    }
+
+    function panelVisibility(panelName, isVisible = true) {
+        // Prevent some panels from being opened by this API method as they have more complex opening logic.
+        if (isVisible && !!['sideMetadata', 'sideSettings', 'table', 'mainDetails'].find(x => x === panelName)) {
+            console.warn(`You cannot open ${panelName} via this API method.`);
+            return;
+        }
+
+        // Details panel has own closing logic.
+        if (!isVisible && panelName === 'mainDetails') {
+            detailService.closeDetails();
+        } else {
+            stateManager.setActive({ [panelName]: isVisible });
+        }
+
+        $rootScope.$applyAsync();
+    }
+
+    /**
+     * Get current language
+     *
+     * @function getCurrentLang
+     */
+    function getCurrentLang() {
+        return configService.getSync.language;
+    }
+
+    /**
+     * Load RCS layers after the map has been instantiated
+     *
+     * @memberof app.core
+     * @function
+     * @inner
+     * @param {Array}  keys  array of RCS keys (String) to be added
+     */
+    function loadRcsLayers(keys) {
+        // trigger RCS web call
+        configService.rcsAddKeys(keys);
+    }
+
+    /**
+     * Retrieves a bookmark for the current state
+     *
+     * @function getBookmark
+     * @returns {String}    The bookmark containing the state of the viewer
+     */
+    function getBookmark() {
+        return bookmarkService.getBookmark();
+    }
+
+    /**
+     * Updates the map using bookmark. If initial is set, will only be used if its the first call to be received.
+     *
+     * @function useBookmark
+     * @param {String} bookmark     The bookmark containing the desired state of the viewer
+     */
+    function useBookmark(bookmark) {
+        reloadService.loadWithBookmark(bookmark, false);
+    }
+
+    /**
+     * Updates the extent of the map.
+     *
+     * @function centerAndZoom
+     * @param {Array}  x                    The x coord to center on
+     * @param {Number} y                    The y coord to center on
+     * @param {Object} spatialReference     The spatial Reference for the coordinates
+     * @param {Number} zoom                 The level to zoom to
+     */
+    function centerAndZoom(x, y, spatialReference, zoom) {
+        const coords = gapiService.gapi.proj.localProjectPoint(
+            spatialReference, geoService.mapObject.spatialReference, { x: x, y: y }
+        );
+        const zoomPoint = gapiService.gapi.proj.Point(coords.x, coords.y, geoService.mapObject.spatialReference);
+
+        // separate zoom and center calls, calling centerAndZoom sets the map to an extent made up of NaN
+        configService.getSync.map.instance.setZoom(zoom);
+        configService.getSync.map.instance.centerAt(zoomPoint);
+    }
+
+    /**
+     * Set extent of the map.
+     *
+     * @function setExtent
+     * @param {Array}  extent                   The extent to set
+     */
+    function setExtent(extent) {
+        configService.getSync.map.instance.setExtent(configService.getSync.map.instance.enhanceConfigExtent(extent), true);
+    }
+
+    /**
+     * Get config section.
+     *
+     * @function getConfig
+     * @param {String}  section     The config section name
+     * @return {Object}             The config section
+     */
+    function getConfig(section) {
+        return configService.getSync[section];
+    }
+
+    /**
+     * Set map cursor.
+     *
+     * @function setMapCursor
+     * @param {String} cursor     The to set
+     */
+    function setMapCursor(cursor) {
+        geoService.map.setMapCursor(cursor);
+    }
+
+    /**
+     * Project a geometry
+     *
+     * @function projectGeometry
+     * @param {Object} geometry     The geometry to project
+     * @param {Number} outSR        The output spatial reference ID
+     * @return {Object}             The projected geometry
+     */
+    function projectGeometry(geometry, outSR) {
+        return gapiService.gapi.proj.localProjectGeometry(outSR, geometry);
+    }
+}
+
+/**
+ * @function debugBlock
+ * @private
+ * @memberof app.core
+ * @description
+ *
+ * Exposes inner services for debugging purposes
+ */
+function debugBlock($rootElement, appInfo, geoService) {
+    // store app id in a value
+    appInfo.id = $rootElement.attr('id');
 }

--- a/src/app/core/global-registry.service.js
+++ b/src/app/core/global-registry.service.js
@@ -9,4 +9,5 @@
  */
 angular
     .module('app.core')
-    .constant('api', window.RZ);
+    .constant('api', window.RZ)
+    .constant('LEGACY_API', window.RV);

--- a/src/legacy-api.ts
+++ b/src/legacy-api.ts
@@ -1,0 +1,144 @@
+const mapInstances = {};
+
+class MapInstance {
+    id: string;
+    queues: { [key:number]: Array<() => void>; }; // queue function list waiting to be executed
+    legacyFunctions: { [key:string]: (...args: any[]) => any };
+
+    constructor(id: string) {
+        this.id = id;
+        this.queues = {};
+        this.legacyFunctions = {};
+    }
+
+    /**
+     * Runs all queues - highest priority queues execute first.
+     */
+    runQueue() {
+        Object.keys(this.queues)
+            .sort()
+            .reverse()
+            .forEach(key => {
+                let k = parseInt(key);
+                this.queues[k].forEach(qItem => qItem())
+            })
+    }
+
+    /**
+     * Adds a legacy api call to a queue which gets executed when ramp is ready to receive them. 
+     * 
+     * @param {string} action       legacy api function name to be queued
+     * @param {number} priority     the order in which this queued call will be executed, higher numbers go first
+     * @param {...any} args         legacy api function parameters
+     */
+    queue(action: string, priority: number, ...args: any[]) {
+        // ramp has defined the legacy function, call immediately
+        if (this.legacyFunctions[action]) {
+            return new Promise(resolve => resolve(this.legacyFunctions[action](...args)));
+        }
+
+        // ramp is not yet ready, queue the function call
+        this.queues[priority] = this.queues[priority] || [];
+
+        return new Promise(resolve => {
+            this.queues[priority].push(() => this.legacyFunctions[action] && resolve(this.legacyFunctions[action](...args)));
+        });
+    }
+
+    setLanguage(...args: any[]) {
+        return this.queue('setLanguage', 0, ...args);
+    }
+
+    panelVisibility(...args: any[]) {
+        return this.queue('panelVisibility', 0, ...args);
+    }
+
+    getCurrentLang(...args: any[]) {
+        return this.queue('getCurrentLang', 0, ...args);
+    }
+
+    loadRcsLayers(...args: any[]) {
+        return this.queue('loadRcsLayers', 0, ...args);
+    }
+
+    getBookmark(...args: any[]) {
+        return this.queue('getBookmark', 0, ...args);
+    }
+
+    centerAndZoom(...args: any[]) {
+        return this.queue('centerAndZoom', 0, ...args);
+    }
+
+    setExtent(...args: any[]) {
+        return this.queue('setExtent', 0, ...args);
+    }
+
+    useBookmark(...args: any[]) {
+        return this.queue('useBookmark', 0, ...args);
+    }
+
+    getRcsLayerIDs(...args: any[]) {
+        return this.queue('getRcsLayerIDs', 0, ...args);
+    }
+
+    appInfo(...args: any[]) {
+        return this.queue('appInfo', 0, ...args);
+    }
+
+    northArrow(...args: any[]) {
+        return this.queue('northArrow', 0, ...args);
+    }
+
+    mapCoordinates(...args: any[]) {
+        return this.queue('mapCoordinates', 0, ...args);
+    }
+
+    getMapClickInfo(...args: any[]) {
+        return this.queue('getMapClickInfo', 0, ...args);
+    }
+
+    convertDDToDMS(...args: any[]) {
+        return this.queue('convertDDToDMS', 0, ...args);
+    }
+
+    setMapCursor(...args: any[]) {
+        return this.queue('setMapCursor', 0, ...args);
+    }
+
+    projectGeometry(...args: any[]) {
+        return this.queue('projectGeometry', 0, ...args);
+    }
+
+    toggleSideNav(...args: any[]) {
+        return this.queue('toggleSideNav', 0, ...args);
+    }
+
+    reInitialize(...args: any[]) {
+        return this.queue('reInitialize', 0, ...args);
+    }
+
+    getConfig(...args: any[]) {
+        return this.queue('getConfig', 0, ...args);
+    }
+
+    initialBookmark(...args: any[]) {
+        return this.queue('initialBookmark', 1, ...args);
+    }
+
+    restoreSession(...args: any[]) {
+        return this.queue('restoreSession', 1, ...args);
+    }
+
+    start(...args: any[]) {
+        return this.queue('start', 1, ...args);
+    }
+}
+
+(<any>window).RV = {
+    getMap: (id: string) => {
+        (<any>mapInstances)[id] = (<any>mapInstances)[id] || new MapInstance(id);
+        return (<any>mapInstances)[id];
+    }
+};
+
+console.warn('The RAMP viewers legacy API is deprecated and will be removed on the next major release.');

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -28,6 +28,7 @@ module.exports = function (env) {
 
     const config = {
         entry: {
+            'legacy-api': path.resolve(__dirname, 'src/legacy-api.ts'),
             'rv-main': path.resolve(__dirname, 'src/app/app-loader.js')
         },
 
@@ -64,7 +65,7 @@ module.exports = function (env) {
                 },
                 {
                     test: /\.ts$/,
-                    include: [path.resolve(__dirname, 'intention'), path.resolve(__dirname, 'api'), path.resolve(__dirname, 'src/app')],
+                    include: [path.resolve(__dirname, 'intention'), path.resolve(__dirname, 'api'), path.resolve(__dirname, 'src/app'), path.resolve(__dirname, 'src/legacy-api.ts')],
                     use: [{
                         loader: 'babel-loader',
                         options: babelPresets


### PR DESCRIPTION
## Description
Completes code portion of https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3153.

The ramp build now outputs a `legacy-api.js` file which needs to be included on the host page before any legacy api calls are made. This file contains the proxy logic in the form of a priority queue. 

`getMap` continues to be synchronous while all subsequent api calls are async. No changes are needed to legacy api calls when upgrading to v3 except for including the `legacy-api.js` file.

## Testing
👀 on chrome, IE, and Edge

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [x] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
Inline. User documentation to follow.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3204)
<!-- Reviewable:end -->
