### PR TITLE
chore(plugins): autoload from plugin repo

### DIFF
--- a/api/plugin-loader.ts
+++ b/api/plugin-loader.ts
@@ -1,8 +1,12 @@
 import Table from '../features/table/table.feature';
 import EPSG from '../features/epsg/epsg.feature';
 import geoSearch from '../features/geosearch/geosearch.feature';
-
+import { BackToCart }  from '@fgpv/rv-plugins';
 import { FgpvConfigSchema } from 'api/schema';
+
+const AUTOLOAD_PLUGINS: any = {
+    'backToCart': BackToCart
+};
 
 const loadFeatures: any = {
     epsg: EPSG,
@@ -36,6 +40,19 @@ export default class Loader {
     loader() {
         const rvPluginAttr = this.mapElem.attr('rv-plugins');
         const pluginList = rvPluginAttr ? rvPluginAttr.split(',').map(x => x.trim()) : [];
+
+        Object.keys(AUTOLOAD_PLUGINS).forEach(pk => {
+            const pI = pluginList.findIndex(p => p === pk || p === `no-${pk}`);
+            const pN = pluginList[pI];
+
+            if (!pN) {
+                const plugin = new AUTOLOAD_PLUGINS[pk]();
+                this.plugins.push(plugin);
+                console.warn(`The plugin ${pk} was loaded automatically. This functionality is being removed in the next major release. Please load this plugin on the host page instead (see ramp documentation) or add 'no-${pk}' to rv-plugins to stop this plugin from being autoloaded.`);
+            } else if (pN === `no-${pk}`) {
+                pluginList.splice(pI, 1);
+            }
+        });
 
         pluginList
             .forEach((p: any) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,6 +299,14 @@
       "version": "github:claviska/jquery-minicolors#f5b0ab6d9e74f3691184516d87a3c9c017999ca0",
       "from": "github:claviska/jquery-minicolors"
     },
+    "@fgpv/rv-plugins": {
+      "version": "0.0.3-0",
+      "resolved": "https://registry.npmjs.org/@fgpv/rv-plugins/-/rv-plugins-0.0.3-0.tgz",
+      "integrity": "sha512-sWLQm5Zrz9ahD4TmBqbiGyDwsXKHpWi3YxqGrvctk4kmoskrWYUzc9IAPbvUg/Ad8gwJSNo7Oe/qesDfrTuDDg==",
+      "requires": {
+        "rxjs": "6.3.3"
+      }
+    },
     "@flowjs/ng-flow": {
       "version": "2.7.8",
       "resolved": "http://registry.npmjs.org/@flowjs/ng-flow/-/ng-flow-2.7.8.tgz",
@@ -1316,7 +1324,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-each": {
@@ -1781,22 +1789,22 @@
     },
     "babel-plugin-syntax-async-generators": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
       "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o="
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
     "babel-plugin-syntax-decorators": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
       "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs="
     },
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
       "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
     },
     "babel-plugin-syntax-exponentiation-operator": {
@@ -1806,7 +1814,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -2135,7 +2143,6 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
-      "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "^6.22.0",
         "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
@@ -4673,7 +4680,7 @@
       "dependencies": {
         "marked": {
           "version": "0.3.19",
-          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
         }
       }
@@ -4728,6 +4735,10 @@
       "requires": {
         "buffer-indexof": "^1.0.0"
       }
+    },
+    "docdash": {
+      "version": "git+https://github.com/alyec/docdash.git#0ac9d0dd482a9b65aa0885d5279fafc566a91f9b",
+      "from": "git+https://github.com/alyec/docdash.git#master"
     },
     "doctrine": {
       "version": "2.1.0",
@@ -5866,7 +5877,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6231,7 +6243,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6279,6 +6292,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6317,11 +6331,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -6372,7 +6388,7 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#v3.0.0-4",
+      "version": "github:fgpv-vpgf/geoApi#a579b663d2f1e3e2c6cf855281aef0ed92d56318",
       "from": "github:fgpv-vpgf/geoApi#v3.0.0-4",
       "requires": {
         "babel-cli": "^6.24.1",
@@ -6383,6 +6399,7 @@
         "csv2geojson": "5.0.2",
         "dgeni": "^0.4.7",
         "dgeni-packages": "^0.19.1",
+        "docdash": "git+https://github.com/alyec/docdash.git#master",
         "jasmine": "^2.6.0",
         "js-sql-parser": "1.0.7",
         "jsdoc": "^3.4.0",
@@ -6390,9 +6407,11 @@
         "proj4": "^2.4.3",
         "rcolor": "1.0.1",
         "rgbcolor": "1.0.1",
+        "shpjs": "git+https://github.com/fgpv-vpgf/shapefile-js.git#v3.6.0",
         "svg.js": "2.6.1",
         "terraformer": "~1.0.8",
         "terraformer-arcgis-parser": "~1.0.5",
+        "terraformer-proj4js": "git+https://github.com/RAMP-PCAR/terraformer-proj4js.git#v0.2.2",
         "text-encoding": "0.6.4"
       }
     },
@@ -7376,6 +7395,14 @@
         }
       }
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "icss-replace-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
@@ -7460,8 +7487,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-fresh": {
       "version": "2.0.0",
@@ -8140,6 +8166,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.0.tgz",
       "integrity": "sha512-wlEBIZ5LP8usDylWbDNhKPEFVFdI5hCHpnVoT/Ysvoi/PRhJENm/Rlh9TvjYB38HFfKZN7OzEbRjmjvLkFw11g=="
     },
+    "js-sql-parser": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/js-sql-parser/-/js-sql-parser-1.0.7.tgz",
+      "integrity": "sha512-CxrwLnDARRP40CG5O2ihE+oGIuNdE4wIJYQRifiDcUbdpRlNQM09WoEeikb+LTwVrhgDtMbBoURzM8lOCAQPoQ=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -8331,6 +8362,14 @@
         }
       }
     },
+    "jszip": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
+      "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
+      "requires": {
+        "pako": "~1.0.2"
+      }
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -8399,6 +8438,14 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "linkifyjs": {
@@ -8703,6 +8750,11 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+    },
     "lru-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
@@ -8756,9 +8808,9 @@
       "integrity": "sha512-fdZvBa7/vSQIZCi4uuwo2N3q+7jJURpMVCcbaX0S1Mg65WZ5ilXvC67MviJAsdjqqgD+CEq4RKo5AYGgINkVAA=="
     },
     "math-random": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -9886,8 +9938,7 @@
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
-      "dev": true
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
     },
     "parallel-transform": {
       "version": "1.1.0",
@@ -9938,6 +9989,15 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
         "error-ex": "^1.2.0"
+      }
+    },
+    "parsedbf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parsedbf/-/parsedbf-1.0.0.tgz",
+      "integrity": "sha512-qm8G6BPAL8yesN4UP4cNq1rxI5g5OyQNwS/SiLvjVT87PZ+9sbRdIANqH8kPKWvIiDbFM2V3C0xUuh/jvUqRdQ==",
+      "requires": {
+        "iconv-lite": "^0.4.15",
+        "text-encoding-polyfill": "^0.6.7"
       }
     },
     "parseurl": {
@@ -13300,8 +13360,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -13705,6 +13764,17 @@
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      }
+    },
+    "shpjs": {
+      "version": "git+https://github.com/fgpv-vpgf/shapefile-js.git#dd6b31899dee1d70f106b3725430f2eb5f0b350c",
+      "from": "git+https://github.com/fgpv-vpgf/shapefile-js.git#v3.6.0",
+      "requires": {
+        "jszip": "^2.4.0",
+        "lie": "^3.0.1",
+        "lru-cache": "^2.7.0",
+        "parsedbf": "^1.0.0",
+        "proj4": "^2.1.4"
       }
     },
     "signal-exit": {
@@ -14663,6 +14733,13 @@
         "terraformer": "~1.0.4"
       }
     },
+    "terraformer-proj4js": {
+      "version": "git+https://github.com/RAMP-PCAR/terraformer-proj4js.git#b2bac5f00e95cf37dd53d5c18821cfa429b9eaf4",
+      "from": "git+https://github.com/RAMP-PCAR/terraformer-proj4js.git#v0.2.2",
+      "requires": {
+        "terraformer": "~1.0.4"
+      }
+    },
     "terser": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-3.14.0.tgz",
@@ -14885,8 +14962,13 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+    },
+    "text-encoding-polyfill": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
+      "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg=="
     },
     "text-table": {
       "version": "0.2.0",
@@ -18258,7 +18340,7 @@
     },
     "yargs": {
       "version": "3.32.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
         "camelcase": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@claviska/jquery-minicolors": "github:claviska/jquery-minicolors",
+    "@fgpv/rv-plugins": "0.0.3-0",
     "@flowjs/ng-flow": "2.7.8",
     "angular": "1.7.5",
     "angular-animate": "1.7.5",


### PR DESCRIPTION
## Description
Pulls in the plugins repo as an npm dependency and auto loads `backToCart` plugin if it is not included in `rv-plugins`. Displays a console warning that auto loaded plugin feature will be removed in next major release. Users can disable a plugin from auto loading by adding a `no-*` in front of the plugin name in `rv-plugins`. i.e. `rv-plugins="no-backToCart"`.

## Testing
Tested both plugins repo samples + index-enhanced-table.html on this repo.

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [ ] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
None (yet) - will add a new map author section once all auto load plugins are merged.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3260)
<!-- Reviewable:end -->
