### PR TITLE
fix(api): purge queued legacy api calls once invoked

### DIFF
--- a/src/legacy-api.ts
+++ b/src/legacy-api.ts
@@ -21,7 +21,8 @@ class MapInstance {
             .reverse()
             .forEach(key => {
                 let k = parseInt(key);
-                this.queues[k].forEach(qItem => qItem())
+                this.queues[k].forEach(qItem => qItem());
+                delete this.queues[k];
             })
     }
 


### PR DESCRIPTION
## Description
Since `runQueue`  be called multiple times (language/projection changes) this PR purges a priority queue once it has run so that a queued api call is never invoked more than once.

Closes #3255 

## Testing
Tested with http://fgpv.cloudapp.net/demo/users/milesap/3255-fix-legacy-queue/prod/samples/index-fgp-en.html?keys=josm in chrome, ie, and edge by toggling languages & projection changes. See https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3255#issue-402819769

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [x] works with projection change
- [x] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [x] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
None 

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] ~~Release notes have been updated~~
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3283)
<!-- Reviewable:end -->
