### PR TITLE
3112/3172/3183 minor fixes

### DIFF
--- a/src/app/ui/geosearch/geosearch-filters.service.js
+++ b/src/app/ui/geosearch/geosearch-filters.service.js
@@ -108,7 +108,7 @@ function geosearchFiltersService($translate, events, configService, geoService, 
         geosearchService.getProvinces().then(values =>
             (service.provinces = values));
 
-        geoSearch.getTypes().then(values => {
+        geosearchService.getTypes().then(values => {
             const disabledSearches = configService.getSync.services.search.disabledSearches || [];
             service.types = values.filter(x => !disabledSearches.includes(x.code))
         });

--- a/src/app/ui/geosearch/geosearch-filters.service.js
+++ b/src/app/ui/geosearch/geosearch-filters.service.js
@@ -108,7 +108,9 @@ function geosearchFiltersService($translate, events, configService, geoService, 
         geosearchService.getProvinces().then(values =>
             (service.provinces = values));
 
-        geosearchService.getTypes().then(values =>
-            (service.types = values));
+        geoSearch.getTypes().then(values => {
+            const disabledSearches = configService.getSync.services.search.disabledSearches || [];
+            service.types = values.filter(x => !disabledSearches.includes(x.code))
+        });
     }
 }

--- a/src/content/samples/config/config-sample-01.json
+++ b/src/content/samples/config/config-sample-01.json
@@ -102,7 +102,15 @@
                     "layerId": "powerplant100mw-electric"
                   },
                   {
-                    "layerId": "powerplant100mw-naturalGas"
+                    "layerId": "powerplant100mw-naturalGas",
+                    "symbologyStack": [{
+                      "image": "http://fgpv.cloudapp.net/demo/__assets__/beautiful.png",
+                      "text": ""
+                    }, {
+                      "image": "http://fgpv.cloudapp.net/demo/__assets__/step1.gif",
+                      "text": ""
+                    }],
+                    "symbologyRenderStyle": "images"
                   },
                   {
                     "layerId": "powerplant100mw-liquids"

--- a/src/content/samples/config/config-sample-01.json
+++ b/src/content/samples/config/config-sample-01.json
@@ -42,6 +42,7 @@
       }
     },
     "search": {
+      "disabledSearches": ["NTS", "FSA"],
       "serviceUrls": {
         "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
         "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",

--- a/src/content/samples/config/config-sample-01.json
+++ b/src/content/samples/config/config-sample-01.json
@@ -53,7 +53,7 @@
     }
   },
   "map": {
-    "initialBasemapId": "baseNrCan",
+    "initialBasemapId": "baseEsriWorld",
     "components": {
       "geoSearch": {
         "enabled": true,
@@ -526,6 +526,12 @@
             "id": "World_Imagery",
             "layerType": "esriFeature",
             "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+          },
+          {
+            "id": "World_Physical_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer",
+            "opacity": 0.7
           }
         ],
         "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"

--- a/src/content/samples/config/config-sample-87.json
+++ b/src/content/samples/config/config-sample-87.json
@@ -53,7 +53,7 @@
     }
   },
   "map": {
-    "initialBasemapId": "baseNrCan",
+    "initialBasemapId": "baseEsriWorld",
     "components": {
       "geoSearch": {
         "enabled": true,
@@ -102,7 +102,15 @@
                     "layerId": "powerplant100mw-electric"
                   },
                   {
-                    "layerId": "powerplant100mw-naturalGas"
+                    "layerId": "powerplant100mw-naturalGas",
+                    "symbologyStack": [{
+                      "image": "http://fgpv.cloudapp.net/demo/__assets__/beautiful.png",
+                      "text": ""
+                    }, {
+                      "image": "http://fgpv.cloudapp.net/demo/__assets__/step1.gif",
+                      "text": ""
+                    }],
+                    "symbologyRenderStyle": "images"
                   },
                   {
                     "layerId": "powerplant100mw-liquids"
@@ -518,6 +526,12 @@
             "id": "World_Imagery",
             "layerType": "esriFeature",
             "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+          },
+          {
+            "id": "World_Physical_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer",
+            "opacity": 0.7
           }
         ],
         "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"

--- a/src/content/samples/config/config-sample-87.json
+++ b/src/content/samples/config/config-sample-87.json
@@ -42,6 +42,7 @@
       }
     },
     "search": {
+      "disabledSearches": ["NTS", "FSA"],
       "serviceUrls": {
         "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
         "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",

--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -181,6 +181,7 @@
                 <option value="config/config-sample-84.json">84. Local Export + Tainted Images + cleanCanvas option</option>
                 <option value="config/config-sample-85.json">85. File based layers</option>
                 <option value="config/config-sample-86.json">86. API 2 blocks for a single layer</option>
+                <option value="config/config-sample-87.json">87. Enlarge correct symbology from stack</option>
             </select>
         </div>
 

--- a/src/content/styles/vendor/_esri.scss
+++ b/src/content/styles/vendor/_esri.scss
@@ -30,7 +30,7 @@
         }
 
         &.rv-map-highlight .esriMapLayers {
-            > div:not(:first-child),
+            > div:not(:first-child) > img,
             > svg > g:not([id="rv_hilight_layer"]) {
                     opacity: 0.1 !important;
             }


### PR DESCRIPTION
## Description
Closes #3112 
Closes #3172
Closes #3183

## Testing
[Testing Link](http://fgpv.cloudapp.net/demo/users/JahidAhmed/3183-symbology-enlarge/dev/samples/index-samples.html?sample=87)

3112 - `NTS` and `FSA` disabled so they don't appear in the list of available types for Geosearch
3172 - Default basemap has 2 layers, both the basemap layers remain visible on identify
3183 - `Natural Gas Pipeline` has expandable symbology working as expected

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [ ] works in Edge
- [x] works with projection change
- [x] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [x] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
In-line comments.

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3297)
<!-- Reviewable:end -->
