### PR TITLE
fix(details): display correct primary field for file layers

### DIFF
--- a/src/app/geo/layer-blueprint.class.ts
+++ b/src/app/geo/layer-blueprint.class.ts
@@ -342,8 +342,15 @@ function LayerBlueprint($http: any, $q: any, Geo: any, gapiService: any, ConfigO
             this.latFields = validationResult.latFields;
             this.longFields = validationResult.longFields;
 
-            this.config.latfield = validationResult.smartDefaults.lat;
-            this.config.lonfield = validationResult.smartDefaults.long;
+            // if the latField is already set once (through UI/config option), do not reset it to the default latitude
+            if (!this.config.latfield) {
+                this.config.latfield = validationResult.smartDefaults.lat;
+            }
+
+            // if the lonfield is already set once (through UI/config option), do not reset it to the default longitude
+            if (!this.config.lonfield) {
+                this.config.lonfield = validationResult.smartDefaults.long;
+            }
         }
     }
 

--- a/src/app/geo/layer-blueprint.class.ts
+++ b/src/app/geo/layer-blueprint.class.ts
@@ -359,7 +359,10 @@ function LayerBlueprint($http: any, $q: any, Geo: any, gapiService: any, ConfigO
         setFieldsOptions(validationResult: ValidationResult): void {
             // TODO: need to explicitly set this in the config object on creation
             // TODO: this won't be needed after proper typed configs are made for the file-based layers
-            this.config.nameField = validationResult.smartDefaults.primary;
+            // if the nameField is already set once (through UI/config option), do not reset it to the default primary
+            if (!this.config.nameField) {
+                this.config.nameField = validationResult.smartDefaults.primary;
+            }
             this.fields = validationResult.fields;
 
             // number all the fields, so even fields with equal names can be distinguished by the md selector


### PR DESCRIPTION
## Description
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3324
Closes #3329 

Also fixes a (related) unidentified bug where an incorrect tooltip field was being displayed for file layers.

## Testing
:eyes: 

Change the primary field and lat/long fields when adding a file-based layer through the import wizard

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [x] works via config file
- [x] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
In-line comment added

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~~[ ] Help files and documentation have been updated~~
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3328)
<!-- Reviewable:end -->
