### PR TITLE
Configurable fields for WFS services + First Column Sort Indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@claviska/jquery-minicolors": "github:claviska/jquery-minicolors",
-    "@fgpv/rv-plugins": "v0.0.5-1",
+    "@fgpv/rv-plugins": "github:fgpv-vpgf/plugins#8387a5ee75a209883eb081b44ad76e14d0de6ee5",
     "@flowjs/ng-flow": "2.7.8",
     "angular": "1.7.5",
     "angular-animate": "1.7.5",

--- a/src/app/geo/layer-blueprint.class.ts
+++ b/src/app/geo/layer-blueprint.class.ts
@@ -521,7 +521,7 @@ function LayerBlueprint($http: any, $q: any, Geo: any, gapiService: any, ConfigO
      * @class WFSServiceSource
      * @extends {mixins(BlueprintBase, ClientSideData)}
      */
-    class WFSServiceSource extends mixins(BlueprintBase, ClientSideData) {
+    class WFSServiceSource extends mixins(BlueprintBase, ClientSideData, FieldsOption) {
         _urlWrapper: UrlWrapper;
 
         constructor(rawConfig: any) {
@@ -560,12 +560,15 @@ function LayerBlueprint($http: any, $q: any, Geo: any, gapiService: any, ConfigO
         /**
          * Validates WFS layer as GeoJSON. Default validation uses the service type, and there is no explicit validation function for WFS.
          *
-         * @returns {Promise<any>}
+         * @returns any
          * @memberof WFSServiceSource
          */
-        validate(): Promise<any> {
+        validate(): any {
             // WFS layer data is not encoded as a byte array, it's pure JSON
-            return super.validate(Geo.Service.Types.GeoJSON, false);
+            return super.validate(Geo.Service.Types.GeoJSON, false).then(validationResult => {
+                this.setFieldsOptions(validationResult);
+                return validationResult;
+            });
         }
 
         get layerFactory(): LayerFactory {

--- a/src/app/ui/loader/loader-service.html
+++ b/src/app/ui/loader/loader-service.html
@@ -1,23 +1,12 @@
-<rv-content-pane
-    close-panel="self.closeLoaderService()"
-    floating-header="true"
-    rv-trap-focus="{{ ::self.appID }}">
+<rv-content-pane close-panel="self.closeLoaderService()" floating-header="true" rv-trap-focus="{{ ::self.appID }}">
 
     <div class="rv-loader-service">
-        <rv-stepper-item
-            step="self.connect.step"
-            form="self.connect.form"
-            summary-value="{{ self.connect.step.isCompleted ? self.connect.serviceUrl : '' }}">
+        <rv-stepper-item step="self.connect.step" form="self.connect.form" summary-value="{{ self.connect.step.isCompleted ? self.connect.serviceUrl : '' }}">
 
             <md-input-container class="md-block">
                 <label>{{ 'import.service.connect.serviceurl' | translate }}</label>
-                <input
-                    name="serviceUrl"
-                    type="url"
-                    ng-change="self.connect.serviceUrlResetValidation()"
-                    ng-model="self.connect.serviceUrl"
-                    ng-model-options="{ updateOn: 'default blur', debounce: { default: 30, blur: 0 } }"
-                    ng-keypress="self.connect.step.onKeypress($event)"
+                <input name="serviceUrl" type="url" ng-change="self.connect.serviceUrlResetValidation()" ng-model="self.connect.serviceUrl"
+                    ng-model-options="{ updateOn: 'default blur', debounce: { default: 30, blur: 0 } }" ng-keypress="self.connect.step.onKeypress($event)"
                     required>
                 <div ng-messages="self.connect.form.serviceUrl.$error">
                     <div ng-message="url">{{ 'import.service.connect.invalidurl' | translate }}</div>
@@ -30,18 +19,12 @@
 
         <!-- Selecting layer type -->
 
-        <rv-stepper-item step="self.select.step" form="self.select.form"
-            summary-value="{{ self.select.step.isCompleted ? 'import.service.type.' + self.layerBlueprint.type : '' }}">
+        <rv-stepper-item step="self.select.step" form="self.select.form" summary-value="{{ self.select.step.isCompleted ? 'import.service.type.' + self.layerBlueprint.type : '' }}">
             <md-input-container class="md-block">
                 <label>{{ 'import.service.select.servicetype' | translate }}</label>
-                <md-select
-                    name="serviceType"
-                    ng-disabled="self.layerBlueprintOptions.length === 1"
-                    ng-model="self.layerBlueprint"
-                    md-on-open="self.select.serviceTypeResetValidation()" required>
-                    <md-option
-                        ng-repeat="sourceOption in self.layerBlueprintOptions"
-                        ng-value="sourceOption">
+                <md-select name="serviceType" ng-disabled="self.layerBlueprintOptions.length === 1" ng-model="self.layerBlueprint" md-on-open="self.select.serviceTypeResetValidation()"
+                    required>
+                    <md-option ng-repeat="sourceOption in self.layerBlueprintOptions" ng-value="sourceOption">
                         {{ 'import.service.type.' + sourceOption.type | translate }}
                     </md-option>
                 </md-select>
@@ -53,14 +36,9 @@
 
         <!-- Configuring layer -->
 
-        <rv-stepper-item
-            step="self.configure.step"
-            form="self.configure.form"
-            ng-switch on="self.layerBlueprint.type">
+        <rv-stepper-item step="self.configure.step" form="self.configure.form" ng-switch on="self.layerBlueprint.type">
 
-            <md-input-container class="md-block"
-                ng-switch-when="featurelayer|wms"
-                ng-switch-when-separator="|">
+            <md-input-container class="md-block" ng-switch-when="featurelayer|wms" ng-switch-when-separator="|">
                 <label>{{ 'import.service.configure.layername' | translate }}</label>
                 <input name="layerServiceName" ng-model="self.layerBlueprint.config.name" required>
                 <!-- TODO: decide whether and how to display a hint or error messages -->
@@ -71,12 +49,9 @@
             </md-input-container>
 
             <div ng-switch-when="featurelayer">
-                <md-input-container class="md-block" >
+                <md-input-container class="md-block">
                     <label>{{ 'import.service.configure.primaryfield' | translate }}</label>
-                    <md-select
-                        name="primaryField"
-                        ng-model="self.layerBlueprint.config.nameField"
-                        required>
+                    <md-select name="primaryField" ng-model="self.layerBlueprint.config.nameField" required>
                         <md-option ng-repeat="field in self.layerBlueprint.fields" value="{{ field.name }}">
                             {{ field.alias || field.name }}
                         </md-option>
@@ -88,9 +63,7 @@
                 </md-input-container>
                 <md-input-container class="md-block">
                     <label>{{ 'import.service.configure.tooltipField' | translate }}</label>
-                    <md-select
-                        name="tooltipField"
-                        ng-model="self.layerBlueprint.config.tooltipField">
+                    <md-select name="tooltipField" ng-model="self.layerBlueprint.config.tooltipField">
                         <md-option ng-repeat="field in self.layerBlueprint.fields" value="{{ field.name }}">
                             {{ field.alias || field.name }}
                         </md-option>
@@ -104,27 +77,18 @@
 
             <md-input-container class="md-block" ng-switch-when="dynamicservice">
                 <label>{{ 'import.service.configure.layers' | translate }}</label>
-                <md-select
-                    name="dynamicLayers"
-                    ng-model="self.layerBlueprint.config.layerEntries"
-                    ng-model-options="{ trackBy: '$value.index' }"
-                    ng-change="self.common.onDynamicLayerSection()"
-                    required multiple>
+                <md-select name="dynamicLayers" ng-model="self.layerBlueprint.config.layerEntries" ng-model-options="{ trackBy: '$value.index' }"
+                    ng-change="self.common.onDynamicLayerSection()" required multiple>
                     <md-select-header>
                         <md-input-container>
-                            <md-checkbox
-                                ng-checked="self.common.isAllLayersSelected()"
-                                md-indeterminate="self.common.isSomeLayersSelected()"
-                                ng-click="self.common.toggleLayers(); self.common.onDynamicLayerSection();"
+                            <md-checkbox ng-checked="self.common.isAllLayersSelected()" md-indeterminate="self.common.isSomeLayersSelected()" ng-click="self.common.toggleLayers(); self.common.onDynamicLayerSection();"
                                 class="md-primary rv-select-header-all">
                                 {{ 'import.service.configure.selectall' | translate }}
                             </md-checkbox>
                             <md-divider class="rv-layer-list-divider"></md-divider>
                         </md-input-container>
                     </md-select-header>
-                    <md-option
-                        ng-repeat="layer in self.layerBlueprint.layers"
-                        ng-value="layer">
+                    <md-option ng-repeat="layer in self.layerBlueprint.layers" ng-value="layer">
                         {{ layer.indent + ' ' + layer.name }}
                     </md-option>
                 </md-select>
@@ -136,25 +100,17 @@
             </md-input-container>
 
             <!-- the singleEntryCollapse option is enabled to user interaction only when a single layer entry is selected -->
-            <md-input-container class="md-block"
-                ng-switch-when="dynamicservice">
-                <md-checkbox
-                    ng-model="self.layerBlueprint.config.singleEntryCollapse"
-                    md-indeterminate="self.layerBlueprint.config.layerEntries.length === 0"
-                    ng-true-value="false"
-                    ng-false-value="true"
-                    ng-disabled="self.layerBlueprint.config.layerEntries.length !== 1"
+            <md-input-container class="md-block" ng-switch-when="dynamicservice">
+                <md-checkbox ng-model="self.layerBlueprint.config.singleEntryCollapse" md-indeterminate="self.layerBlueprint.config.layerEntries.length === 0"
+                    ng-true-value="false" ng-false-value="true" ng-disabled="self.layerBlueprint.config.layerEntries.length !== 1"
                     class="md-primary">
                     {{ 'import.service.configure.singleentrycollapse' | translate }}
                 </md-checkbox>
             </md-input-container>
 
-            <md-input-container class="md-block"
-                ng-if="!self.layerBlueprint.config.singleEntryCollapse"
-                ng-switch-when="dynamicservice">
+            <md-input-container class="md-block" ng-if="!self.layerBlueprint.config.singleEntryCollapse" ng-switch-when="dynamicservice">
                 <label>{{ 'import.service.configure.groupname' | translate }}</label>
-                <input name="layerServiceName"
-                    ng-model="self.layerBlueprint.config.name" required>
+                <input name="layerServiceName" ng-model="self.layerBlueprint.config.name" required>
                 <!-- TODO: decide whether and how to display a hint or error messages -->
                 <!--div ng-messages="self.configure.form.layerName.$error">
                     <div ng-message="required">This is required!</div>
@@ -164,18 +120,12 @@
 
             <md-input-container class="md-block" ng-switch-when="wms">
                 <label>{{ 'import.service.configure.layers' | translate }}</label>
-                <md-select
-                    name="wmsLayers"
-                    ng-model="self.layerBlueprint.config.layerEntries"
-                    ng-model-options="{ trackBy: '$value.index' }"
+                <md-select name="wmsLayers" ng-model="self.layerBlueprint.config.layerEntries" ng-model-options="{ trackBy: '$value.index' }"
                     required multiple>
                     <md-input-container class="md-block">
                         <md-select-header>
                             <md-input-container>
-                                <md-checkbox
-                                    ng-checked="self.common.isAllLayersSelected()"
-                                    md-indeterminate="self.common.isSomeLayersSelected()"
-                                    ng-click="self.common.toggleLayers()"
+                                <md-checkbox ng-checked="self.common.isAllLayersSelected()" md-indeterminate="self.common.isSomeLayersSelected()" ng-click="self.common.toggleLayers()"
                                     class="md-primary rv-select-header-all">
                                     {{ 'import.service.configure.selectall' | translate }}
                                 </md-checkbox>
@@ -183,8 +133,7 @@
                             </md-input-container>
                         </md-select-header>
                     </md-input-container>
-                    <md-option ng-repeat="layer in self.layerBlueprint.layers"
-                        ng-value="layer">
+                    <md-option ng-repeat="layer in self.layerBlueprint.layers" ng-value="layer">
                         {{ layer.indent + ' ' + layer.desc }}
                     </md-option>
                 </md-select>
@@ -195,10 +144,9 @@
                 </div-->
             </md-input-container>
 
-            <md-input-container class="md-block" ng-switch-when="geojson">
+            <md-input-container class="md-block" ng-switch-when="wfs">
                 <label>{{ 'import.layer.configure.layername' | translate }}</label>
-                <input name="layerName"
-                    ng-model="self.layerBlueprint.config.name" required>
+                <input name="layerName" ng-model="self.layerBlueprint.config.name" required>
                 <!-- TODO: decide whether and how to display a hint or error messages -->
                 <!--div ng-messages="self.configure.form.layerName.$error">
                     <div ng-message="required">This is required!</div>
@@ -206,13 +154,10 @@
                 </div-->
             </md-input-container>
 
-            <div ng-switch-when="geojson">
+            <div ng-switch-when="wfs">
                 <md-input-container class="md-block">
                     <label>{{ 'import.layer.configure.primaryfield ' | translate }}</label>
-                    <md-select
-                        name="primaryField"
-                        ng-model="self.layerBlueprint.config.nameField"
-                        required>
+                    <md-select name="primaryField" ng-model="self.layerBlueprint.config.nameField" required>
                         <md-option ng-repeat="field in self.layerBlueprint.fields" value="{{ field.name }}">
                             {{ field.name }}
                         </md-option>
@@ -224,9 +169,7 @@
                 </md-input-container>
                 <md-input-container class="md-block">
                     <label>{{ 'import.layer.configure.tooltipField' | translate }}</label>
-                    <md-select
-                        name="tooltipField"
-                        ng-model="self.layerBlueprint.config.tooltipField">
+                    <md-select name="tooltipField" ng-model="self.layerBlueprint.config.tooltipField">
                         <md-option ng-repeat="field in self.layerBlueprint.fields" value="{{ field.name }}">
                             {{ field.name }}
                         </md-option>
@@ -238,37 +181,33 @@
                 </md-input-container>
             </div>
 
-            <div layout="row" ng-switch-when="geojson">
-                <md-input-container class="md-block" flex>
-                    <label>{{ 'import.layer.configure.colourfield' | translate }}</label>
-                    <input rv-minicolors options="self.configure.colourPickerSettings"
-                        name="layerName"
-                        ng-change="self.configure.configureResetValidation()"
-                        ng-model="self.layerBlueprint.colour" required>
-                    <!-- TODO: decide whether and how to display a hint or error messages -->
-                    <!--div ng-messages="self.configure.form.layerName.$error">
+            <div>
+                <div layout="row" ng-switch-when="wfs">
+                    <md-input-container class="md-block" flex>
+                        <label>{{ 'import.layer.configure.colourfield' | translate }}</label>
+                        <input rv-minicolors options="self.configure.colourPickerSettings" name="layerName" ng-change="self.configure.configureResetValidation()"
+                            ng-model="self.layerBlueprint.config.colour" required>
+                        <!-- TODO: decide whether and how to display a hint or error messages -->
+                        <!--div ng-messages="self.configure.form.layerName.$error">
                         <div ng-message="required">This is required!</div>
                         <div ng-message="md-maxlength">That's too long!</div>
                     </div-->
-                </md-input-container>
+                    </md-input-container>
+                </div>
             </div>
 
             <div ng-if="self.isWMSLayerWithMultipleStyles()" class="rv-styles-list">
-                <md-button
-                    class="rv-group-body-button rv-button-square style-title"
-                    ng-click="section.isExpanded = !section.isExpanded">
+                <md-button class="rv-group-body-button rv-button-square style-title" ng-click="section.isExpanded = !section.isExpanded">
 
                     {{ 'settings.label.styles' | translate }}
 
                     <div class="rv-icon-24 rv-group-toggle-icon">
-                        <md-icon
-                            class="md-toggle-icon"
-                            ng-class="{ 'rv-toggled' : section.isExpanded }"
-                            md-svg-src="hardware:keyboard_arrow_down"></md-icon>
+                        <md-icon class="md-toggle-icon" ng-class="{ 'rv-toggled' : section.isExpanded }" md-svg-src="hardware:keyboard_arrow_down"></md-icon>
                     </div>
                 </md-button>
 
-                <md-input-container ng-show="section.isExpanded" class="wms-styles" ng-repeat="entry in self.layerBlueprint.config.layerEntries" ng-if="::(entry.allStyles.length > 1)">
+                <md-input-container ng-show="section.isExpanded" class="wms-styles" ng-repeat="entry in self.layerBlueprint.config.layerEntries"
+                    ng-if="::(entry.allStyles.length > 1)">
                     <label>{{ entry.desc }}</label>
                     <md-select ng-model="entry.currentStyle">
                         <md-option ng-value="style" ng-repeat="style in entry.allStyles">{{ style }}</md-option>


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->

Closes: 
- https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3301: WFS layers are configurable through wizard
- https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3306: leftmost indicator arrow appears in `enhancedTable`

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Test with WFS Layers (eg: http://geo.wxod-dev.cmc.ec.gc.ca/geomet/features/collections/hydrometric-stations/items?startindex=6000)

they should be configurable like this:

![image](https://user-images.githubusercontent.com/25359812/53838499-41d06780-3f63-11e9-999d-5a237a97b85b.png)

Primary Field should correspond to the field shown in identify: 
![image](https://user-images.githubusercontent.com/25359812/53838569-6d535200-3f63-11e9-8a0e-3dac21fbb3d2.png)

Tooltip should correspond to hovertip: 

![image](https://user-images.githubusercontent.com/25359812/53838638-91af2e80-3f63-11e9-8efa-edfa8913c015.png)


### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [ ] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [x] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->
n/a

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~[ ] Help files and documentation have been updated~
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3336)
<!-- Reviewable:end -->
