### PR TITLE
Panels: reopenAfterOverlay implementation 

### DIFF
--- a/api/src/panel/index.ts
+++ b/api/src/panel/index.ts
@@ -96,6 +96,14 @@ export class Panel {
         return this._offscreen;
     }
 
+    set reopenAfterOverlay(reopen: boolean) {
+        this._reopenAfterOverlay = reopen;
+    }
+
+    get reopenAfterOverlay() {
+        return this._reopenAfterOverlay;
+    }
+
     set api(api: ViewerAPI) {
         this._api = api;
     }
@@ -112,7 +120,11 @@ export class Panel {
     }
 
     get isClosed() {
-        return this.element.css('display') === 'none';
+        return this.element.css('visibility') === 'hidden';
+    }
+
+    get isOpen() {
+        return !this.isClosed;
     }
 
     /**
@@ -162,6 +174,7 @@ export class Panel {
                     if (changedCSS.length > 0) {
                         this.api.panels.all.forEach(p => p.underlayRuleCheck(this));
                         this.offScreenRuleCheck('Panel position was moved offscreen.');
+                        this.api.panels.reopenOverlay();
                     }
                 }
             });
@@ -194,7 +207,7 @@ export class Panel {
         } catch {
             // nothing to do, observer is already disconnected.
         }
-        this.element.css('display', 'none');
+        this.element.css('visibility', 'hidden');
 
         if (!opts.silent) {
             const closingResponse: ClosingResponse = {
@@ -223,6 +236,12 @@ export class Panel {
             this.open();
         } else {
             this.close({'destroy': false});
+        }
+    }
+
+    reopen() {
+        if (!this.api.panels.opened.find(p => this.underlayRuleCheck(p, false))) {
+            this.open();
         }
     }
 
@@ -304,7 +323,7 @@ export class Panel {
 
         this.element.attr('id', id);
         this.element.append(this.body);
-        this.element.css({'display': 'none'});
+        this.element.css({'visibility': 'hidden'});
         const documentFragment = document.createDocumentFragment();
         documentFragment.appendChild(this.element[0]);
 
@@ -318,14 +337,15 @@ export class Panel {
       *
       * @param otherPanel The overlaying panel instance
       */
-    private underlayRuleCheck(otherPanel: Panel) {
+    private underlayRuleCheck(otherPanel: Panel, close = true) {
         if (
             otherPanel === this || // cannot overlay oneself
             otherPanel.isDialog ||
+            otherPanel.isClosed ||
             this.allowUnderlay ||
             this.element.css('z-index') > otherPanel.element.css('z-index') || // only enforce an overlap if the overlapping panel has a greater than or equal z-index (on top of - not below this panel)
             this.isFullScreen) {
-            return;
+            return false;
         }
 
         const rect1 = this.element[0].getBoundingClientRect();
@@ -336,9 +356,11 @@ export class Panel {
             rect1.bottom < rect2.top ||
             rect1.top > rect2.bottom);
 
-        if (overlap) {
+        if (overlap && close) {
             this.close({closingCode: CLOSING_CODES.OVERLAID, otherPanel: otherPanel});
         }
+
+        return overlap;
     }
 
     /**
@@ -349,7 +371,7 @@ export class Panel {
         this.element.wrap('<div class="dialog-container"></div>');
 
         this.header.closeButton;
-        this.element.css({'display': ''});
+        this.element.css({'visibility': ''});
         this._element = this.element.parent();
         this.element.prependTo($(this.api.innerShell).parent().parent());
 
@@ -375,7 +397,7 @@ export class Panel {
      */
     private openStandard() {
         this.element.css({'z-index': this.isCloseable ? 14 : 10});
-        this.element.css({'display': ''});
+        this.element.css({'visibility': ''});
 
         // this check must occur AFTER the element is placed in the DOM AND is visible.
         this.offScreenRuleCheck('Failed to open panel as all or part of it would render off the screen.');
@@ -391,6 +413,7 @@ export class Panel {
 
         this.allowUnderlay = true;
         this.allowOffscreen = false;
+        this.reopenAfterOverlay = false;
 
         this._style = {};
         this._initRXJS();
@@ -418,6 +441,7 @@ export interface Panel {
         width?: string;
         height?: string;
     };
+    _reopenAfterOverlay: boolean;
 
     //HTML parent Components
     _element: JQuery<HTMLElement>;

--- a/src/app/api-loader.ts
+++ b/src/app/api-loader.ts
@@ -56,11 +56,13 @@ RZInstance.mapAdded.subscribe(mapInstance => {
 });
 
 (<any>jQuery).expr.filters.offscreen = function(el: any) {
+    const elem = <any>jQuery(el);
+    const position = elem.position();
     const rvShell = <any>jQuery('rv-shell').first();
     return (
-             (el.offsetLeft + el.offsetWidth) > (rvShell.offsetWidth) ||
-             (el.offsetLeft + el.offsetWidth) < (rvShell.offsetTop) ||
-             (el.offsetTop + el.offsetHeight) > (rvShell.offsetHeight) ||
-             (el.offsetTop + el.offsetHeight) < (rvShell.offsetLeft)
+        (position.left + <any>elem.width()) > (rvShell.width()) ||
+        (position.left + <any>elem.width()) < 0 ||
+        (position.top + <any>elem.height()) > (rvShell.height()) ||
+        (position.top + <any>elem.height()) < 0
            );
   };

--- a/src/content/samples/plugins/panels.js
+++ b/src/content/samples/plugins/panels.js
@@ -25,6 +25,8 @@
         this.panelCount = this.panelCount + 1;
         p.allowUnderlay = !$('#paneltester-chkunderlay').hasClass('md-checked');
         p.allowOffscreen = !$('#paneltester-chkoffscreen').hasClass('md-checked');
+        p.reopenAfterOverlay = $('#paneltester-chkoverlay').hasClass('md-checked');
+
         p.open();
     }
 
@@ -54,7 +56,9 @@
             <br>
             <md-checkbox class="md-checked" id="paneltester-chkoffscreen">Panel closes when offscreen</md-checkbox>
             <br>
-            <md-checkbox class="" id="paneltester-chkunderlay">Panel closes on overlay</md-checkbox>
+            <md-checkbox class="md-checked" id="paneltester-chkunderlay">Panel closes on overlay</md-checkbox>
+            <br>
+            <md-checkbox class="md-checked" id="paneltester-chkoverlay">Panel reopens after overlay</md-checkbox>
             <br>
             <b>Note:</b> Checkbox options are not applicable to dialog panels.
           </div>
@@ -136,6 +140,7 @@ function () {
       this.panelCount = this.panelCount + 1;
       p.allowUnderlay = !$('#paneltester-chkunderlay').hasClass('md-checked');
       p.allowOffscreen = !$('#paneltester-chkoffscreen').hasClass('md-checked');
+      p.reopenAfterOverlay = $('#paneltester-chkoverlay').hasClass('md-checked');
       p.open();
     }
   }, {
@@ -159,7 +164,7 @@ function () {
         bottom: '50%',
         width: '600px'
       });
-      p.body = "\n          <div>\n            <md-button id=\"paneltester-btn1\" class=\"md-raised md-primary\">Open a dialog</md-button>\n            <br>\n            <md-button id=\"paneltester-btn2\" class=\"md-raised md-primary\">Open a panel</md-button>\n            <br><br>\n            <md-checkbox class=\"md-checked\" id=\"paneltester-chkclose\">Add a close button</md-checkbox>\n            <br>\n            <md-checkbox class=\"md-checked\" id=\"paneltester-chkoffscreen\">Panel closes when offscreen</md-checkbox>\n            <br>\n            <md-checkbox class=\"\" id=\"paneltester-chkunderlay\">Panel closes on overlay</md-checkbox>\n            <br>\n            <b>Note:</b> Checkbox options are not applicable to dialog panels.\n          </div>\n        ";
+      p.body = "\n          <div>\n            <md-button id=\"paneltester-btn1\" class=\"md-raised md-primary\">Open a dialog</md-button>\n            <br>\n            <md-button id=\"paneltester-btn2\" class=\"md-raised md-primary\">Open a panel</md-button>\n            <br><br>\n            <md-checkbox class=\"md-checked\" id=\"paneltester-chkclose\">Add a close button</md-checkbox>\n            <br>\n            <md-checkbox class=\"md-checked\" id=\"paneltester-chkoffscreen\">Panel closes when offscreen</md-checkbox>\n            <br>\n            <md-checkbox class=\"md-checked\" id=\"paneltester-chkunderlay\">Panel closes on overlay</md-checkbox>\n            <br>\n            <md-checkbox class=\"md-checked\" id=\"paneltester-chkoverlay\">Panel reopens after overlay</md-checkbox>\n            <br>\n            <b>Note:</b> Checkbox options are not applicable to dialog panels.\n          </div>\n        ";
       p.header.title = 'Panel Tester';
       p.header.subtitle = 'This is a subtitle.';
       p.header.toggleButton;


### PR DESCRIPTION
## Description
Adds a `reopenAfterOverlay` boolean option to panels which reopens a panel iff it was closed by an overlaying panel.

The panel registry keeps a list of panels in the order they were closed so they can be notified to check if they can reopen whenever:
- A panel closes
- The viewport size changes
- A panels position or width/height changes 

## Testing
Added a checkbox to index-samples.html which lets you create a panel with this setting. 

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [ ] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
None yet - will add prior to v3 merge

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [ ] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3377)
<!-- Reviewable:end -->
