### PR TITLE
feat(plugins): support destruction

### DIFF
--- a/api/plugin-loader.ts
+++ b/api/plugin-loader.ts
@@ -35,6 +35,15 @@ export default class Loader {
     }
 
     /**
+     * Calls each plugins `destroy` method, if defined.
+     */
+    destroyer() {
+        this.plugins.concat(
+            Object.keys(this.features).map(key => this.features[key])
+        ).forEach(p => p.destroy && p.destroy());
+    }
+
+    /**
      * Plugins are strictly loaded from the `rv-plugins` map element property.
      * We expect the string value, possibly comma-separated, to be present on the global window object which points to the plugin.
      */

--- a/src/app/core/reload.service.js
+++ b/src/app/core/reload.service.js
@@ -36,8 +36,6 @@ function reloadService(events, bookmarkService, geoService, configService, state
     function reloadConfig(bookmark) {
         events.$broadcast(events.rvApiHalt);
 
-        _closeOpenPanels();
-
         exportService.close();
 
         geoService._isMapReady = false;
@@ -63,8 +61,6 @@ function reloadService(events, bookmarkService, geoService, configService, state
     function changeProjection(startPoint) {
         events.$broadcast(events.rvApiHalt);
 
-        _closeOpenPanels();
-
         const bookmark = bookmarkService.getBookmark(startPoint);
         bookmarkService.parseBookmark(bookmark);
 
@@ -84,8 +80,6 @@ function reloadService(events, bookmarkService, geoService, configService, state
      */
     function loadNewLang(lang) {
         events.$broadcast(events.rvApiHalt);
-
-        _closeOpenPanels();
 
         const bookmark = bookmarkService.getBookmark();
 
@@ -112,12 +106,10 @@ function reloadService(events, bookmarkService, geoService, configService, state
     function loadWithBookmark(bookmark, initial, additionalKeys = []) {
         if (!bookmark) {
             events.$broadcast(events.rvBookmarkInit);
-            _closeOpenPanels();
             service.bookmarkBlocking = false;
         } else if (!initial || service.bookmarkBlocking) {
             events.$broadcast(events.rvApiHalt);
             events.$broadcast(events.rvBookmarkDetected);
-            _closeOpenPanels();
 
             // FIXME / TODO I think we need more analysis here for what happens if
             // this is not the initial bookmark and there are RCS layers involved.
@@ -195,19 +187,5 @@ function reloadService(events, bookmarkService, geoService, configService, state
         if (service.bookmarkBlocking) {
             loadWithBookmark(bookmark, true, keys);
         }
-    }
-
-    /**
-     * Closes open settings or datatable panels when re-loading configs.
-     *
-     * @function _closeOpenPanels
-     * @private
-     */
-    function _closeOpenPanels() {
-        stateManager.setActive({
-            side: false
-        }, {
-            table: false
-        });
     }
 }

--- a/src/app/geo/geo.service.js
+++ b/src/app/geo/geo.service.js
@@ -31,6 +31,7 @@ function geoService($rootScope, $rootElement, events, mapService, layerRegistry,
         get map() { return configService.getSync.map.instance; }
 
         destroyMap() {
+            this._pluginLoader.destroyer();
             mapService.destroyMap();
 
             return this;

--- a/src/content/samples/plugins/panels.js
+++ b/src/content/samples/plugins/panels.js
@@ -1,93 +1,97 @@
 /* class PanelTester {
-    init(api) {
-        this.panelCount = 0;
-        this.panelCountDialog = 0;
-        this.api = api;
-        this._makePanel();
-    }
+  init(api) {
+      this.panelCount = 0;
+      this.panelCountDialog = 0;
+      this.api = api;
+      this._makePanel();
+  }
 
-    makeCloseBtn(panel) {
-        if ($('#paneltester-chkclose').hasClass('md-checked')) {
-            panel.header.closeButton;
-        }
-    }
+  destroy() {
+    console.warn('Panel Tester Plugin: destroy was called');
+  }
 
-    panel() {
-        const p = this.api.panels.create('standard-pnl-' + this.panelCount);
-        p.element.css({
-            top: 80 * (this.panelCount % 7) + 'px',
-            left: 580 + this.panelCount * 80 + 'px',
-            height: '375px',
-            width: '400px'
-        });
-        p.body = `<h2>Hello!</h2><p>I'm a dialog</p>`;
-        this.makeCloseBtn(p);
-        this.panelCount = this.panelCount + 1;
-        p.allowUnderlay = !$('#paneltester-chkunderlay').hasClass('md-checked');
-        p.allowOffscreen = !$('#paneltester-chkoffscreen').hasClass('md-checked');
-        p.reopenAfterOverlay = $('#paneltester-chkoverlay').hasClass('md-checked');
+  makeCloseBtn(panel) {
+      if ($('#paneltester-chkclose').hasClass('md-checked')) {
+          panel.header.closeButton;
+      }
+  }
 
-        p.open();
-    }
+  panel() {
+      const p = this.api.panels.create('standard-pnl-' + this.panelCount);
+      p.element.css({
+          top: 80 * (this.panelCount % 7) + 'px',
+          left: 580 + this.panelCount * 80 + 'px',
+          height: '375px',
+          width: '400px'
+      });
+      p.body = `<h2>Hello!</h2><p>I'm a dialog</p>`;
+      this.makeCloseBtn(p);
+      this.panelCount = this.panelCount + 1;
+      p.allowUnderlay = !$('#paneltester-chkunderlay').hasClass('md-checked');
+      p.allowOffscreen = !$('#paneltester-chkoffscreen').hasClass('md-checked');
+      p.reopenAfterOverlay = $('#paneltester-chkoverlay').hasClass('md-checked');
 
-    dialog() {
-        this.panelCountDialog = this.panelCountDialog + 1;
-        const p = this.api.panels.create(`dialog-pnl-${this.panelCountDialog}`, this.api.panels.PANEL_TYPES.Dialog);
-        p.body = `<h2>Hello!</h2><p>I'm a dialog</p>`;
-        p.header.title = 'Dialog Title';
-        p.open();
-    }
+      p.open();
+  }
 
-    _makePanel() {
-        const p = this.api.panels.create('M');
-        p.element.css({
-            top: '0px',
-            left: '410px',
-            bottom: '50%',
-            width: '600px'
-        });
-        p.body = `
-          <div>
-            <md-button id="paneltester-btn1" class="md-raised md-primary">Open a dialog</md-button>
-            <br>
-            <md-button id="paneltester-btn2" class="md-raised md-primary">Open a panel</md-button>
-            <br><br>
-            <md-checkbox class="md-checked" id="paneltester-chkclose">Add a close button</md-checkbox>
-            <br>
-            <md-checkbox class="md-checked" id="paneltester-chkoffscreen">Panel closes when offscreen</md-checkbox>
-            <br>
-            <md-checkbox class="md-checked" id="paneltester-chkunderlay">Panel closes on overlay</md-checkbox>
-            <br>
-            <md-checkbox class="md-checked" id="paneltester-chkoverlay">Panel reopens after overlay</md-checkbox>
-            <br>
-            <b>Note:</b> Checkbox options are not applicable to dialog panels.
-          </div>
-        `;
-        p.header.title = 'Panel Tester';
-        p.header.subtitle = 'This is a subtitle.';
-        p.header.toggleButton;
-        p.allowOffscreen = true;
+  dialog() {
+      this.panelCountDialog = this.panelCountDialog + 1;
+      const p = this.api.panels.create(`dialog-pnl-${this.panelCountDialog}`, this.api.panels.PANEL_TYPES.Dialog);
+      p.body = `<h2>Hello!</h2><p>I'm a dialog</p>`;
+      p.header.title = 'Dialog Title';
+      p.open();
+  }
 
-
-        // make a custom button
-        const customBtn = new p.Button('Custom Btn');
-        customBtn.$.on('click', function() {
-            window.alert('You clicked the custom button!');
-        });
-
-        p.header.append(customBtn);
+  _makePanel() {
+      const p = this.api.panels.create('M');
+      p.element.css({
+          top: '0px',
+          left: '410px',
+          bottom: '50%',
+          width: '600px'
+      });
+      p.body = `
+        <div>
+          <md-button id="paneltester-btn1" class="md-raised md-primary">Open a dialog</md-button>
+          <br>
+          <md-button id="paneltester-btn2" class="md-raised md-primary">Open a panel</md-button>
+          <br><br>
+          <md-checkbox class="md-checked" id="paneltester-chkclose">Add a close button</md-checkbox>
+          <br>
+          <md-checkbox class="md-checked" id="paneltester-chkoffscreen">Panel closes when offscreen</md-checkbox>
+          <br>
+          <md-checkbox class="md-checked" id="paneltester-chkunderlay">Panel closes on overlay</md-checkbox>
+          <br>
+          <md-checkbox class="md-checked" id="paneltester-chkoverlay">Panel reopens after overlay</md-checkbox>
+          <br>
+          <b>Note:</b> Checkbox options are not applicable to dialog panels.
+        </div>
+      `;
+      p.header.title = 'Panel Tester';
+      p.header.subtitle = 'This is a subtitle.';
+      p.header.toggleButton;
+      p.allowOffscreen = true;
 
 
-        p.open();
+      // make a custom button
+      const customBtn = new p.Button('Custom Btn');
+      customBtn.$.on('click', function() {
+          window.alert('You clicked the custom button!');
+      });
 
-        $('#paneltester-btn1').on('click', () => {
-            this.dialog();
-        });
+      p.header.append(customBtn);
 
-        $('#paneltester-btn2').on('click', () => {
-            this.panel();
-        })
-    }
+
+      p.open();
+
+      $('#paneltester-btn1').on('click', () => {
+          this.dialog();
+      });
+
+      $('#paneltester-btn2').on('click', () => {
+          this.panel();
+      })
+  }
 }
 
 window.PanelTester = PanelTester; */
@@ -117,6 +121,11 @@ function () {
       this.api = api;
 
       this._makePanel();
+    }
+  }, {
+    key: "destroy",
+    value: function destroy() {
+      console.warn('destroy was called');
     }
   }, {
     key: "makeCloseBtn",


### PR DESCRIPTION
## Description
Adds support for an optional plugin method `destroy` which gets called right before the map is destroyed.

Closes #3391

## Testing
Added a console warning to the panel tester on `index-samples.html`.

![brain](https://user-images.githubusercontent.com/10187181/55344981-d9e74100-547c-11e9-9063-6b64a087895b.gif)


### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [ ] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [ ] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3393)
<!-- Reviewable:end -->
