### PR TITLE
fix(ui): symbology stack image enlarge button missing

### DIFF
--- a/api/src/schema.d.ts
+++ b/api/src/schema.d.ts
@@ -930,7 +930,7 @@ export interface FeatureLayerNode {
      */
     title?: string;
     /**
-     * Specifies the additional information to display in the setting panel to give more information about a table.
+     * Deprecated as settings panel no longer exists. Specifies the additional information to display in the setting panel to give more information about a table.
      */
     description?: string;
     /**
@@ -991,7 +991,7 @@ export interface ColumnNode {
    */
   title?: string;
   /**
-   * Specifies the additional information to display in the setting panel to give more information about a column. Do not add description if missing.
+   * Deprecated as settings panel no longer exists. Specifies the additional information to display in the setting panel to give more information about a column. Do not add description if missing.
    */
   description?: string;
   /**
@@ -1097,7 +1097,7 @@ export interface FileLayerNode {
      */
     title?: string;
     /**
-     * Specifies the additional information to display in the setting panel to give more information about a table.
+     * Deprecated as settings panel no longer exists. Specifies the additional information to display in the setting panel to give more information about a table.
      */
     description?: string;
     /**
@@ -1204,7 +1204,7 @@ export interface WfsLayerNode {
      */
     title?: string;
     /**
-     * Specifies the additional information to display in the setting panel to give more information about a table.
+     * Deprecated as settings panel no longer exists. Specifies the additional information to display in the setting panel to give more information about a table.
      */
     description?: string;
     /**
@@ -1470,7 +1470,7 @@ export interface DynamicLayerEntryNode {
      */
     title?: string;
     /**
-     * Specifies the additional information to display in the setting panel to give more information about a table.
+     * Deprecated as settings panel no longer exists. Specifies the additional information to display in the setting panel to give more information about a table.
      */
     description?: string;
     /**

--- a/src/app/ui/common/expand-image.directive.js
+++ b/src/app/ui/common/expand-image.directive.js
@@ -13,7 +13,7 @@ angular
     .module('app.ui')
     .directive('rvExpandImage', rvExpandImage);
 
-function rvExpandImage($mdDialog, referenceService, $rootScope, $compile, $templateCache, layoutService) {
+function rvExpandImage($mdDialog, referenceService, $rootScope, $compile, $templateCache, layoutService, appInfo) {
     const directive = {
         restrict: 'A',
         link
@@ -45,7 +45,7 @@ function rvExpandImage($mdDialog, referenceService, $rootScope, $compile, $templ
         // also get the natural width and height of the image
         const img = new Image();
         img.onload = function() {
-            newScope.self.canEnlarge = this.width + 50 > referenceService.panels.main.width();
+            newScope.self.canEnlarge = this.width + 50 > appInfo.mapi.panels.legend.element.width();
             width = Math.min(this.width + 50, shellNode.width() * 0.8);
             height = Math.min(this.height, shellNode.height() * 0.8);
         }

--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -452,7 +452,7 @@ function rvSymbologyStack($rootScope, $q, Geo, animationService, layerRegistry, 
                         );
                     })
                 ),
-                ref.containerWidth
+                ref.containerWidth - 28 // subtract symbol stack left offset
             );
 
             //permit ref to be ready only when all symbology images are properly loaded


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3183
## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
:eyes: sample 87
### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3433)
<!-- Reviewable:end -->
