### PR TITLE
fix(table): loaded attributes capped at maximum value

### DIFF
--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -1056,6 +1056,18 @@ function LegendBlockFactory(
 
                 timeSinceChunkLoad += updateDelta;
 
+                // if the estimate overshoots the total feature count, set it to the total feature count
+                // if the estimate is somehow less than 0, set it to 0
+                // this is to prevent the value display to be in the negatives or higher than the total amount required to load
+                if (this._derivedLoadedFeatureCount > this._proxyWrapper.featureCount) {
+                    this._derivedLoadedFeatureCount = this._proxyWrapper.featureCount;
+                } else if (this._derivedLoadedFeatureCount < 0) {
+                    this._derivedLoadedFeatureCount = 0;
+                }
+                if (this.loadingPanel !== undefined) {
+                    this.loadingPanel.prepareBody();
+                }
+
                 // when the actual loaded feature count changes...
                 if (previousCount !== this._proxyWrapper.loadedFeatureCount) {
                     // udpate time estimate on how long it takes to load a chunk
@@ -1080,17 +1092,6 @@ function LegendBlockFactory(
                         this._derivedLoadedFeatureCount,
                         this._proxyWrapper.loadedFeatureCount
                     );
-                    if (this.loadingPanel !== undefined) {
-                        this.loadingPanel.prepareBody();
-                    }
-                    // if the estimate overshoots the total feature count, set it to the total feature count
-                    // if the estimate is somehow less than 0, set it to 0
-                    // this is to prevent the value display to be in the negatives or higher than the total amount required to load
-                    if (this._derivedLoadedFeatureCount > this._proxyWrapper.featureCount) {
-                        this._derivedLoadedFeatureCount = this._proxyWrapper.featureCount;
-                    } else if (this._derivedLoadedFeatureCount < 0) {
-                        this._derivedLoadedFeatureCount = 0;
-                    }
                     if (this.loadingPanel !== undefined) {
                         this.loadingPanel.prepareBody();
                     }


### PR DESCRIPTION
## Description
(Hopefully) Closes #3476 

Moved around some of the previously added logic to prevent loaded attribute count going above the actual count to a more suitable spot since it was not doing its intended behaviour previously

## Testing
Hard to reproduce issue so wasn't easy to test. Tried slow layers / in IE and did not notice the issue. Can't fully confirm if the issue is resolved however.

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [x] datagrid works
- [ ] identify works

## Documentation
In-line comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3492)
<!-- Reviewable:end -->
