### PR TITLE
fix(layerRecord): remove extra check for filter listener

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -313,7 +313,7 @@
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
           "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
           "requires": {
-            "tslib": "1.9.3"
+            "tslib": "^1.9.0"
           }
         }
       }
@@ -6380,8 +6380,8 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#1226230151b97d906bd4146a3a3bb7a0f273cce1",
-      "from": "github:fgpv-vpgf/geoApi#v3.0.0-13",
+      "version": "github:fgpv-vpgf/geoApi#v3.0.0-14",
+      "from": "github:fgpv-vpgf/geoApi#v3.0.0-14",
       "requires": {
         "babel-cli": "^6.24.1",
         "babel-preset-env": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "csvtojson": "1.1.11",
     "dotjem-angular-tree": "github:dotJEM/angular-tree",
     "file-saver": "2.0.0",
-    "geoApi": "github:fgpv-vpgf/geoApi#v3.0.0-13",
+    "geoApi": "github:fgpv-vpgf/geoApi#v3.0.0-14",
     "imports-loader": "0.8.0",
     "linkifyjs": "2.1.7",
     "marked": "0.5.2",

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -397,12 +397,7 @@ function layerRegistryFactory(
         // normal situation
         layerRecord.addStateListener(_onLayerRecordInitialLoad);
         layerRecord.addAttribListener(_onLayerAttribDownload);
-
-        if (layerRecord.addFilterListener !== undefined) {
-            // not possible to addFilterListener for tile records, wms records and image records
-            // tile records, wms records and image records don't support datatables so they don't need this listener
-            layerRecord.addFilterListener(_onLayerFilterChange);
-        }
+        layerRecord.addFilterListener(_onLayerFilterChange);
 
         mapBody.addLayer(layerRecord._layer);
         ref.loadingCount++;


### PR DESCRIPTION
## Description
Closes #3515 

## Testing
Remove the WMS layer in Sample 1 through the API: `RAMP.mapInstances[0].layersObj.removeLayer('wms')`

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [x] works with projection change
- [x] works with language change
- [x] works via config file
- [x] works via wizard
- [x] works via API
- [x] works via RCS
- [x] works via bookmark load
- [x] works in auto-legend
- [x] works in structured legend
- [x] works on layer reload
- ~~[ ] datagrid works~~
- ~~[ ] identify works~~

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- ~~[ ] Help files and documentation have been updated~~
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3526)
<!-- Reviewable:end -->
