### PR TITLE
chore(build): fix GitHub Pages technical doc

### DIFF
--- a/scripts/travis/docs.sh
+++ b/scripts/travis/docs.sh
@@ -24,6 +24,7 @@ mv docs "gh-page-files/$TRAVIS_BRANCH"
 
 # generate the index page with all the branches and tags
 . scripts/travis/make_doc_index.sh gh-page-files > "gh-page-files/index.html"
+touch gh-page-files/.nojekyll
 
 # upload a copy to fgpv.org (as a backup)
 rsync -e 'ssh -i /tmp/docs_rsa' -r --delete-after --quiet "./gh-page-files/$TRAVIS_BRANCH" milesap@fgpv.org:/disk/static/docs/$(basename "$TRAVIS_REPO_SLUG")


### PR DESCRIPTION
## Description
Disables jekyll on GitHub pages allowing files leading with an `_` underscore to be served.

## Testing
This change retroactively corrects all prior doc deployments. 

Docs referenced in original issue: http://fgpv-vpgf.github.io/fgpv-vpgf/ghpages-docs/developer/api_tech_docs/ is working

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [x] works with projection change
- [x] works with language change
- [x] works via config file
- [x] works via wizard
- [x] works via API
- [x] works via RCS
- [x] works via bookmark load
- [x] works in auto-legend
- [x] works in structured legend
- [x] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [x] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3551)
<!-- Reviewable:end -->
