### PR TITLE
Use tagged docs instead of ghpages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ For more information on this project, please see one of the sections below:
 * [Building the Project](#building-the-project)
 * [Support](#support)
 
-Also, please visit the [Documentation Site](http://fgpv-vpgf.github.io/fgpv-vpgf/ghpages-docs/#/home) for additional content on:
+Also, please visit the [Documentation Site](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.0.0/#/home) for additional content on:
 
-* [Map Author Guide](http://fgpv-vpgf.github.io/fgpv-vpgf/ghpages-docs/#/mapauthor/intro)
-* [Contributing to the RAMP Project](http://fgpv-vpgf.github.io/fgpv-vpgf/ghpages-docs/#/contribute/getting_started)
+* [Map Author Guide](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.0.0/#/mapauthor/intro)
+* [Contributing to the RAMP Project](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.0.0/#/contribute/getting_started)
 * [Interactive Schema Documentation](https://fgpv-vpgf.github.io/schema-to-docs/)
-* [Developer Guide](http://fgpv-vpgf.github.io/fgpv-vpgf/ghpages-docs/#/developer/intro)
-* [Technical Documentation](http://fgpv-vpgf.github.io/fgpv-vpgf/ghpages-docs/#/technical/architecture)
+* [Developer Guide](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.0.0/#/developer/intro)
+* [Technical Documentation](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.0.0/#/technical/architecture)
 
 ## Usage
 
@@ -52,7 +52,7 @@ Now that you have the required files on your page we should add the map element.
 
 A map should now load on your page. Theres much more you can do with RAMP, a good place to start (I'm mentioning it again!) is the [map author guide](#map-author-guide)
 
-### [Some samples](http://fgpv.cloudapp.net/demo/develop/dev/samples/index-samples.html)
+### [Some samples](http://fgpv.cloudapp.net/demo/master/dev/samples/index-samples.html)
 
 ## Building the project
 
@@ -67,7 +67,7 @@ Running a local build:
 3. Run `npm install` to install dependencies
 4. Run `npm run serve` to build and launch a dev server
 
-We use a fork and pull model for contributions, see our [contributing guidelines](http://fgpv-vpgf.github.io/fgpv-vpgf/ghpages-docs/#/contribute/getting_started) for more details.
+We use a fork and pull model for contributions, see our [contributing guidelines](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.0.0/#/contribute/getting_started) for more details.
 
 ### Generating Local Builds
 
@@ -135,4 +135,4 @@ Plugins: https://github.com/fgpv-vpgf/plugins
 
 GeoSearch: https://github.com/ramp-pcar/geosearch
 
-If you need help contributing, make sure to give the [contribution docs](http://fgpv-vpgf.github.io/fgpv-vpgf/ghpages-docs/#/contribute/getting_started) a read. If you still have questions let us know.
+If you need help contributing, make sure to give the [contribution docs](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.0.0/#/contribute/getting_started) a read. If you still have questions let us know.

--- a/docs/developer/legacy_api.md
+++ b/docs/developer/legacy_api.md
@@ -38,9 +38,9 @@ init(api) {
 
 `registerPlugin` and `openDialogInfo` have been removed and are no longer available.
 
-See [registering a plugin](http://fgpv-vpgf.github.io/fgpv-vpgf/ghpages-docs/#/developer/plugins?id=register) for help migrating to the new plugin system. Note that you can continue to access the legacy API (`RV`) even when it's loaded through the new plugin system.
+See [registering a plugin](/developer/plugins?id=register) for help migrating to the new plugin system. Note that you can continue to access the legacy API (`RV`) even when it's loaded through the new plugin system.
 
-See [opening and closing panels](http://fgpv-vpgf.github.io/fgpv-vpgf/ghpages-docs/#/developer/panels?id=open-close) for help with controlling panels.
+See [opening and closing panels](/developer/panels?id=open-close) for help with controlling panels.
 
 ## Available Methods and Alternatives
 


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->

Updating any docs pages referencing `ghpages-docs` to point to version specific cut of docs, as gh is not getting updated.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Tested new urls in browser.
Tested relative path changes in legacy api doc page using `npm run docute`

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [ ] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

I am documentation

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [x] Help files and documentation have been updated
- [ ] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3553)
<!-- Reviewable:end -->
