### PR TITLE
fix(geosearch): fix filter languages and changing languages with filters applied 

### DIFF
--- a/src/app/core/reload.service.js
+++ b/src/app/core/reload.service.js
@@ -84,13 +84,14 @@ function reloadService(events, bookmarkService, geoService, configService, state
         const bookmark = bookmarkService.getBookmark();
 
         geoService.destroyMap();
-        configService.setLang(lang);
 
         configService.getAsync.then(config => {
             bookmarkService.parseBookmark(bookmark);
             bookmarkService.adjustRcsLanguage(lang);
             geoService.assembleMap();
         });
+
+        configService.setLang(lang);
 
         events.$broadcast(events.rvLanguageChanged);
     }

--- a/src/app/ui/geosearch/geosearch-filters.service.js
+++ b/src/app/ui/geosearch/geosearch-filters.service.js
@@ -35,6 +35,13 @@ function geosearchFiltersService($translate, events, configService, geoService, 
         }
     });
 
+
+    events.$on(events.rvLanguageChanged, () => {
+        // on language change clear the filters
+        geosearchService.setProvince(undefined);
+        geosearchService.setType(undefined);
+    })
+
     return service;
 
     /**
@@ -104,13 +111,13 @@ function geosearchFiltersService($translate, events, configService, geoService, 
         // add loading label to the filters drop downs while their content is loading
         service.provinces = [{ name: $translate.instant('geosearch.loadingfilters.label') }];
         service.types = [{ name: $translate.instant('geosearch.loadingfilters.label') }];
-
-        geosearchService.getProvinces().then(values =>
-            (service.provinces = values));
-
-        geosearchService.getTypes().then(values => {
-            const disabledSearches = configService.getSync.services.search.disabledSearches || [];
-            service.types = values.filter(x => !disabledSearches.includes(x.code))
-        });
+        configService.getAsync.then(config => {
+            geosearchService.getProvinces().then(values =>
+                (service.provinces = values));
+            geosearchService.getTypes().then(values => {
+                const disabledSearches = configService.getSync.services.search.disabledSearches || [];
+                service.types = values.filter(x => !disabledSearches.includes(x.code))
+            });
+        })
     }
 }


### PR DESCRIPTION
## Description
Closes #3558 and #3559 

## Testing
Use any sample page. First, test that the province and type filters for geosearch are now in the correct language when changing languages. Next, apply a province and/or a type filter, then change languages and ensure that the search and filters still work as intended. 

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [x] works with projection change
- [x] works with language change
- [x] works via config file
- ~~[ ] works via wizard~~
- ~~[ ] works via API~~
- ~~[ ] works via RCS~~
- ~~[ ] works via bookmark load~~
- [x] works in auto-legend
- [x] works in structured legend
- [x] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- ~~[ ] Release notes have been updated~~
- [x] PR targets the correct release version
- ~~[ ] Help files and documentation have been updated~~
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3565)
<!-- Reviewable:end -->
