### PR TITLE
fix(geosearch): fix geosearch search term popping up after clearing by highlighting term 

### DIFF
--- a/src/app/ui/geosearch/geosearch-bar.directive.js
+++ b/src/app/ui/geosearch/geosearch-bar.directive.js
@@ -80,9 +80,8 @@ function Controller(appInfo, configService, sideNavigationService, debounceServi
 
         return () => {
             // because search value is cleared on esc, keep a reference if not empty or empty but user erase it
-            const prevLength = self.searchLength;
             const actualLength = self.service.searchValue.length;
-            if (self.service.searchValue !== '' || (prevLength === 1 && actualLength === 0)) {
+            if (self.service.searchValue !== '' || actualLength === 0) {
                 self.service.searchValuePerm = self.service.searchValue;
             }
             self.searchLength = self.service.searchValue.length;


### PR DESCRIPTION
## Description
Closes #3569 

## Testing
Use any sample page. Open geosearch and type in a search term longer than 1 character. Highlight and delete the term. Close geosearch and reopen, the search term should be cleared. 

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [x] works with projection change
- [x] works with language change
- [x] works via config file
- ~~[ ] works via wizard~~
- ~~[ ] works via API~~
- ~~[ ] works via RCS~~
- ~~[ ] works via bookmark load~~
- [x] works in auto-legend
- [x] works in structured legend
- [x] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- ~~[ ] Release notes have been updated~~
- [x] PR targets the correct release version
- ~~[ ] Help files and documentation have been updated~~
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3571)
<!-- Reviewable:end -->
