### PR TITLE
fix(core): prevent duplicate configService listeners

### DIFF
--- a/src/app/core/config.service.js
+++ b/src/app/core/config.service.js
@@ -295,17 +295,20 @@ function configService($q, $rootElement, $http, $translate, events, gapiService,
             if (_loadingState >= States.LOADED) {
                 listener(getConfigByLanguage(currentLang()).config);
             }
-            // check for any duplicate listeners
-            if (!this.listeners.map(l => l.toString()).includes(listener.toString())) {
-                this.listeners.push(listener);
-            }
-            return () => {
-                const idx = this.listeners.indexOf(listener);
+
+            // check for any duplicate listeners and de-register if found
+            let listenersToString = this.listeners.map(l => l.toString());
+            if (listenersToString.includes(listener.toString())) {
+                // get the index of the current listener by converting everything to string
+                const idx = listenersToString.indexOf(listener.toString());
                 if (idx < 0) {
                     throw new Error('Attempting to remove a listener which is not registered.');
                 }
                 this.listeners.splice(idx, 1);
-            };
+            }
+            this.listeners.push(listener);
+
+            return;
         }
 
         constructor() {


### PR DESCRIPTION
## Description
Closes #3582 

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [x] works with projection change
- [x] works with language change
- [x] works via config file
- ~~[ ] works via wizard~~
- ~~[ ] works via API~~
- ~~[ ] works via RCS~~
- ~~[ ] works via bookmark load~~
- [x] works in auto-legend
- [x] works in structured legend
- [x] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- ~~[ ] Release notes have been updated~~
- [x] PR targets the correct release version
- ~~[ ] Help files and documentation have been updated~~
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers
