### PR TITLE
fix(geosearch): type and province filters work in IE

### DIFF
--- a/src/app/ui/geosearch/geosearch-filters.service.js
+++ b/src/app/ui/geosearch/geosearch-filters.service.js
@@ -118,7 +118,7 @@ function geosearchFiltersService($translate, events, configService, geoService, 
         configService.getAsync.then(config => {
             geosearchService.getProvinces().then(values => {
                 service.provinces = values;
-                service.provinceIndexes = [...Array(service.provinces.length).keys()];
+                service.provinceIndexes = Array.from(Array(service.provinces.length), (prov, idx) => idx);
 
                 // sort the province filters in alphabetical order
                 service.provinces.sort((provA, provB) => (provA.name > provB.name) ? 1 : -1);
@@ -126,7 +126,7 @@ function geosearchFiltersService($translate, events, configService, geoService, 
             geosearchService.getTypes().then(values => {
                 const disabledSearches = configService.getSync.services.search.disabledSearches || [];
                 service.types = values.filter(x => !disabledSearches.includes(x.code))
-                service.typeIndexes = [...Array(service.types.length).keys()];
+                service.typeIndexes = Array.from(Array(service.types.length), (type, idx) => idx);
 
                 // sort the type filters in alphabetical order
                 service.types.sort((provA, provB) => (provA.name > provB.name) ? 1 : -1);


### PR DESCRIPTION
## Description
Fix for #3611 

Thanks to @yileifeng for finding this solution

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [x] works with projection change
- [x] works with language change
- [x] works via config file
- [x] works via wizard
- [x] works via API
- [x] works via RCS
- [x] works via bookmark load
- [x] works in auto-legend
- [x] works in structured legend
- [x] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- ~~[ ] Release notes have been updated~~
- [x] PR targets the correct release version
- ~~[ ] Help files and documentation have been updated~~
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3628)
<!-- Reviewable:end -->
