### PR TITLE
fix(details): display detail header title containing french apostrophe

### DIFF
--- a/api/src/panel/header.ts
+++ b/api/src/panel/header.ts
@@ -43,8 +43,21 @@ export default class Header extends Element {
      * Sets the panel title.
      */
     set title(title: string) {
+        // special characters to be checked
+        const escRegex = /[(!"#$%&\'*+,.\\\/:;<=>?@[\]^`{|}~)]/g;
+        let escMatch = escRegex.exec(title);
+        let newTitle = title;
+        let counter = 0;
+        // go through all the special characters that get matched
+        while (escMatch) {
+            // replace char at the escMatch.index with an \ before it to escape
+            newTitle = newTitle.substr(0, escMatch.index + counter) + `\\${escMatch[0]}` + newTitle.substr(escMatch.index + counter + 1);
+            escMatch = escRegex.exec(title);
+            counter++;
+        }
+
         const titleElem = this._header.find('header > h3').first();
-        const titleText = /{{/.test(title) ? title : `{{ '${title}' | translate }}`;
+        const titleText = `{{ '${newTitle}' | translate }}`;
         titleElem
             .css('display', '')
             .text(titleText);
@@ -93,7 +106,7 @@ export default class Header extends Element {
             this._closeButton = new CloseButton(this._panel);
             this.append(this._closeButton.elem);
         }
-        
+
         return this._closeButton.elem;
     }
 


### PR DESCRIPTION
## Description
Closes #3627

## Testing
Use any sample page with this layer: https://maps-cartes.ec.gc.ca/arcgis/rest/services/ICDE/MapServer/5. 
Click on one of the data points and make sure the details header title is displayed correctly. 

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [x] works with projection change
- [x] works with language change
- [x] works via config file 
- [x] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [x] works in auto-legend
- [x] works in structured legend
- [x] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3640)
<!-- Reviewable:end -->
