### PR TITLE
feat(export): expose export generators on API

### DIFF
--- a/api/src/map.ts
+++ b/api/src/map.ts
@@ -147,6 +147,11 @@ export class Map {
         this.mapI.export();
     }
 
+    /** Expose export generators to allow export plugins to call them. */
+    get exportGenerators(): Object {
+        return this.mapI.exportGenerators;
+    }
+
     /** Triggers the map help screen. */
     help(): void {
         this.mapI.help();

--- a/api/src/schema.d.ts
+++ b/api/src/schema.d.ts
@@ -969,7 +969,7 @@ export interface FeatureLayerNode {
       [k: string]: any;
     };
     /**
-     * Specifies if simple filtering is on. If true, we match any substring of text entered. If false, search field accepts regex expressions. Note: Only effects text feilds
+     * Specifies if simple filtering is on. If true, we match any substring of text entered. If false, search field accepts regex expressions. Note: Only effects text fields
      */
     lazyFilter?: boolean;
     /**
@@ -1154,7 +1154,7 @@ export interface FileLayerNode {
       [k: string]: any;
     };
     /**
-     * Specifies if simple filtering is on. If true, we match any substring of text entered. If false, search field accepts regex expressions. Note: Only effects text feilds
+     * Specifies if simple filtering is on. If true, we match any substring of text entered. If false, search field accepts regex expressions. Note: Only effects text fields
      */
     lazyFilter?: boolean;
     /**
@@ -1265,7 +1265,7 @@ export interface WfsLayerNode {
       [k: string]: any;
     };
     /**
-     * Specifies if simple filtering is on. If true, we match any substring of text entered. If false, search field accepts regex expressions. Note: Only effects text feilds
+     * Specifies if simple filtering is on. If true, we match any substring of text entered. If false, search field accepts regex expressions. Note: Only effects text fields
      */
     lazyFilter?: boolean;
     /**
@@ -1535,7 +1535,7 @@ export interface DynamicLayerEntryNode {
       [k: string]: any;
     };
     /**
-     * Specifies if simple filtering is on. If true, we match any substring of text entered. If false, search field accepts regex expressions. Note: Only effects text feilds
+     * Specifies if simple filtering is on. If true, we match any substring of text entered. If false, search field accepts regex expressions. Note: Only effects text fields
      */
     lazyFilter?: boolean;
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -296,7 +296,7 @@
       }
     },
     "@claviska/jquery-minicolors": {
-      "version": "github:claviska/jquery-minicolors#864e5991fadd77a9939c2350e44837193576422d",
+      "version": "github:claviska/jquery-minicolors#f5b0ab6d9e74f3691184516d87a3c9c017999ca0",
       "from": "github:claviska/jquery-minicolors"
     },
     "@fgpv/rv-plugins": {
@@ -6406,6 +6406,7 @@
         "csv2geojson": "5.0.2",
         "dgeni": "^0.4.7",
         "dgeni-packages": "^0.19.1",
+        "docdash": "git+https://github.com/alyec/docdash.git#0ac9d0dd482a9b65aa0885d5279fafc566a91f9b",
         "jasmine": "^2.6.0",
         "js-sql-parser": "1.0.7",
         "jsdoc": "^3.4.0",
@@ -6413,9 +6414,11 @@
         "proj4": "^2.4.3",
         "rcolor": "1.0.1",
         "rgbcolor": "1.0.1",
+        "shpjs": "git+https://github.com/fgpv-vpgf/shapefile-js.git#dd6b31899dee1d70f106b3725430f2eb5f0b350c",
         "svg.js": "2.6.1",
         "terraformer": "~1.0.8",
         "terraformer-arcgis-parser": "~1.0.5",
+        "terraformer-proj4js": "git+https://github.com/RAMP-PCAR/terraformer-proj4js.git#b2bac5f00e95cf37dd53d5c18821cfa429b9eaf4",
         "text-encoding": "0.6.4"
       },
       "dependencies": {
@@ -7458,7 +7461,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -7547,8 +7549,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-fresh": {
       "version": "2.0.0",
@@ -8432,6 +8433,14 @@
         }
       }
     },
+    "jszip": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
+      "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
+      "requires": {
+        "pako": "~1.0.2"
+      }
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -8500,6 +8509,14 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "linkifyjs": {
@@ -8803,6 +8820,11 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "lru-queue": {
       "version": "0.1.0",
@@ -9987,8 +10009,7 @@
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
-      "dev": true
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
     },
     "parallel-transform": {
       "version": "1.1.0",
@@ -10039,6 +10060,15 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
         "error-ex": "^1.2.0"
+      }
+    },
+    "parsedbf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parsedbf/-/parsedbf-1.0.0.tgz",
+      "integrity": "sha512-qm8G6BPAL8yesN4UP4cNq1rxI5g5OyQNwS/SiLvjVT87PZ+9sbRdIANqH8kPKWvIiDbFM2V3C0xUuh/jvUqRdQ==",
+      "requires": {
+        "iconv-lite": "^0.4.15",
+        "text-encoding-polyfill": "^0.6.7"
       }
     },
     "parseurl": {
@@ -13419,8 +13449,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -14565,7 +14594,7 @@
       "integrity": "sha1-Mcak0w59rdhDQNt/sb9P5e+7eVE="
     },
     "svg.textflow.js": {
-      "version": "github:fgpv-vpgf/svg.textflow.js#ae147794bb3cc45a388d0c2bcddf37963c344c8f",
+      "version": "github:fgpv-vpgf/svg.textflow.js#5c7cd52e91e820920c1c8124dcbecee278bfeaa2",
       "from": "github:fgpv-vpgf/svg.textflow.js"
     },
     "svgo": {
@@ -15001,6 +15030,11 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+    },
+    "text-encoding-polyfill": {
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
+      "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg=="
     },
     "text-table": {
       "version": "0.2.0",

--- a/src/app/core/graphics.service.js
+++ b/src/app/core/graphics.service.js
@@ -11,6 +11,13 @@ import 'svg.textflow.js';
 angular.module('app.core').factory('graphicsService', graphicsService);
 
 function graphicsService($q) {
+    window.RAMP.utils = {
+        svgToCanvas,
+        createCanvas,
+        mergeCanvases,
+        isTainted
+    };
+
     const service = {
         svgToCanvas,
         createSvg,

--- a/src/app/ui/export/export.service.js
+++ b/src/app/ui/export/export.service.js
@@ -19,7 +19,7 @@ const EXPORT_CLASS = '.rv-export';
  */
 angular.module('app.ui').service('exportService', exportService);
 
-function exportService($rootScope, $mdDialog, $mdToast, referenceService, configService, events, appInfo) {
+function exportService($rootScope, $mdDialog, $mdToast, referenceService, configService, events, appInfo, exportGenerators, exportSizesService) {
     const service = {
         open,
         close
@@ -32,7 +32,16 @@ function exportService($rootScope, $mdDialog, $mdToast, referenceService, config
                 throw new Error(`Invalid or unsupported file type ${fileType}.`);
             service.open(null, fileType);
         };
+
+
+        exportSizesService.update();
+
+        // expose the exoprt generators on the map instance which exposes it on the API
+        configService.getSync.map.instance.exportGenerators  = exportGenerators.allGenerators;
     });
+
+    let mApi = null;
+    events.$on(events.rvApiMapAdded, (_, api) => (mApi = api));
 
     return service;
 
@@ -79,8 +88,6 @@ function exportService($rootScope, $mdDialog, $mdToast, referenceService, config
     function ExportController(
         $translate,
         $mdToast,
-        $q,
-        $filter,
         appInfo,
         exportSizesService,
         exportComponentsService,
@@ -137,6 +144,7 @@ function exportService($rootScope, $mdDialog, $mdToast, referenceService, config
         self.exportComponents = exportComponentsService;
 
         // updating export components will initialize them if this is called for the first time;
+        // eslint-disable-next-line max-statements
         exportComponentsService.init().then(() => {
             // if an export plugin is present, use it to generate export graphics
             if (appInfo.features.export) {
@@ -148,6 +156,125 @@ function exportService($rootScope, $mdDialog, $mdToast, referenceService, config
                 // all other graphics will be offset relative to the base graphic
                 // when all promises have resolved, export is considered to be generated
                 // if any of the promises fail, the export is considered to have failed and a standard error message will be displayed
+
+                // CURRENTLY COMMENTED OUT WIP. Code modified though to use generators exposed on API
+                /*
+                /// PLUGIN CODE STARTS
+                const promises = [];
+
+                // create a base image and colour it white
+                const baseImage = graphicsService.createCanvas(
+                    self.exportSizes.selectedOption.width,
+                    self.exportSizes.selectedOption.height
+                );
+                const baseImageCtx = baseImage.getContext('2d');
+                baseImageCtx.fillStyle = '#ffffff';
+                baseImageCtx.fillRect(0, 0, baseImage.width, baseImage.height);
+
+                // create underlying base canvas
+                promises.push(
+                    Promise.resolve({
+                        graphic: baseImage
+                    })
+                );
+
+                //
+                const mapImageSize = {
+                    width: self.exportSizes.selectedOption.width * 0.8 - 20,
+                    height: self.exportSizes.selectedOption.height - 20
+                };
+
+                const sourceX = (self.exportSizes.selectedOption.width - mapImageSize.width) / 2;
+                const sourceY = (self.exportSizes.selectedOption.height - mapImageSize.height) / 2;
+
+                // svg export graphic needs to be generated first because generating a server-side map image hides svg layers (unless using local printing)
+                // TODO: prevent map generators from accepting export sizes
+                const apiGenerators = mApi.exportGenerators;
+
+                const pointsImage = apiGenerators.mapSVG().then(data => {
+                    const canvas = graphicsService.createCanvas(mapImageSize.width, mapImageSize.height);
+
+                    // crop the map image returned by the generator to fit into the layout
+                    // https://www.html5canvastutorials.com/tutorials/html5-canvas-image-crop/
+                    canvas
+                        .getContext('2d')
+                        .drawImage(
+                            data.graphic,
+                            sourceX,
+                            sourceY,
+                            mapImageSize.width,
+                            mapImageSize.height,
+                            0,
+                            0,
+                            mapImageSize.width,
+                            mapImageSize.height
+                        );
+
+                    return { graphic: canvas, offset: [10, 10] };
+                });
+                const mapImage = apiGenerators.mapImage().then(data => {
+                    const canvas = graphicsService.createCanvas(mapImageSize.width, mapImageSize.height, '#bfe8fe');
+
+                    // crop the map image returned by the generator to fit into the layout
+                    // https://www.html5canvastutorials.com/tutorials/html5-canvas-image-crop/
+                    canvas
+                        .getContext('2d')
+                        .drawImage(
+                            data.graphic,
+                            sourceX,
+                            sourceY,
+                            mapImageSize.width,
+                            mapImageSize.height,
+                            0,
+                            0,
+                            mapImageSize.width,
+                            mapImageSize.height
+                        );
+
+                    return { graphic: canvas, offset: [10, 10] };
+                });
+
+                const northArrowImage = apiGenerators.northArrow().then(data => ({
+                    graphic: data.graphic,
+                    offset: [40, 20]
+                }));
+
+                const scaleBarImage = apiGenerators.scaleBar().then(data => ({
+                    graphic: data.graphic,
+                    offset: [mapImageSize.width - 10 - 120, mapImageSize.height - 50 - 10]
+                }));
+
+                const legendImage = apiGenerators.legend({
+                    columnWidth: self.exportSizes.selectedOption.width * 0.2 - 20 - 10,
+                    width: self.exportSizes.selectedOption.width * 0.2 - 20 - 10,
+                    height: mapImageSize.height
+                }).then(data => ({
+                    graphic: data.graphic,
+                    offset: [mapImageSize.width + 30, 10]
+                }));
+
+                const titleImage = apiGenerators.title(
+                    `<span style="font-size: 35px; padding: 8px 14px; display: block; text-align: center;"><b>Interesting Fact</b> | Atomic Engineering Lab is out of <i>Cake</i></span>`
+                ).then(data => ({
+                    graphic: data.graphic,
+                    offset: [mapImageSize.width - 10 - data.graphic.width, 10 + 20]
+                }));
+
+                promises.push(mapImage, pointsImage, northArrowImage, scaleBarImage, legendImage, titleImage);
+
+                /// PLUGIN CODE ENDS
+
+                // RAMP-side; accepts a list of promises from the plugin
+                promises.map((pr, index) =>
+                    pr.then(component => {
+                        self.exportPlugin.components[index] = { offset: [0, 0], ...component };
+                        $rootScope.$applyAsync();
+                    })
+                );
+
+                // wait for all promises returned by the export plugin are resolved
+                Promise.all(promises).then(() => (self.exportPlugin.isGenerating = false));
+                */
 
                 return;
             }


### PR DESCRIPTION
## Description
Closes #3600 - expose export generators on API
Starts on #3602 - use array of API layers as the way to indicate which layers should be in export image (EDIT: need to change to using legendAPI if possible, after this PR)

Existing export behaviour remains the same.

Made some changes to existing code added by Aleks' but it is currently commented out:
`// CURRENTLY COMMENTED OUT WIP. Code modified though to use generators exposed on API`
Please also review this section to see if changes made are acceptable.

## Testing
Tested using breakpoints and viewing result in default export window.

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
In-line comments added

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3659)
<!-- Reviewable:end -->
