### PR TITLE
fix(ui): fix accessibility navigation issues with tab in some browsers

### DIFF
--- a/src/app/focus-manager.js
+++ b/src/app/focus-manager.js
@@ -779,7 +779,7 @@ HTMLElement.prototype.origfocus = HTMLElement.prototype.focus;
  * You may not use this method if the element is not part of a viewer.
  *
  * @function rvFocus
- * @param   {Object}    opts    configuration obect for setting focus, currently only supports on property (delay) which is the amount of time to delay a focus movement.
+ * @param   {Object}    opts    configuration object for setting focus, currently only supports on property (delay) which is the amount of time to delay a focus movement.
  */
 HTMLElement.prototype.rvFocus = $.fn.rvFocus = function (opts = {}) {
     const jqueryElem = $(this);
@@ -787,6 +787,9 @@ HTMLElement.prototype.rvFocus = $.fn.rvFocus = function (opts = {}) {
 
     if (!viewerGroup.trapped(jqueryElem) && !opts.exempt) {
         console.warn('focusManager', 'You cannot use *rvFocus* on elements that are outside the viewer');
+        if (elem) {
+            elem.origfocus();
+        }
         return;
     }
 


### PR DESCRIPTION
## Description
Fixes an issue where closing some panels using tab in IE, Firefox or Edge would result in tab no longer working. This fix prevents the tab key from being locked after closing a panel.

This change fixes the problem in Firefox and Edge completely and doesn't break anything in Chrome. In IE, this fixes the issue when closing some panels (the data grid and share panels) but does not work when closing the help or export menus. Another issue will be created to handle these.

## Testing
http://fgpv-app.azureedge.net/demo/users/RyanCoulsonCA/fix-3537/dev/samples/index-samples.html

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11 (in some cases)
- [x] works in Edge
- [x] works with projection change
- [x] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3667)
<!-- Reviewable:end -->
