### PR TITLE
fix(legendAPI): close any open panels when updating legend

### DIFF
--- a/src/app/geo/legend.service.js
+++ b/src/app/geo/legend.service.js
@@ -69,13 +69,9 @@ function legendServiceFactory(
         };
 
         configService.getSync.map.instance.setLegendConfig = (legendStructure) => {
-            stateManager.setActive({
-                tableFulldata: false
-            }, {
-                sideMetadata: false
-            }, {
-                sideSettings: false
-            });
+            mApi.panels.getById('enhancedTable').close();
+            mApi.panels.getById('sideMetadata').close();
+            mApi.panels.getById('sideSettings').close();
 
             const apiLayers = mApi.layers.allLayers
                 // filter on the existence of a viewerLayer config, this will strip out 'simpleLayer's


### PR DESCRIPTION
## Description
Update the legendAPI to close panels through new method

## [Testing](http://fgpv-app.azureedge.net/demo/users/JahidAhmed/cesi-legendAPI-bug/dev/samples/index-samples.html)
Sample 1
Opened a `Liquids Pipeline` panel and then in the console... `RAMP.mapInstances[0].ui.configLegend.configSnippets = [RAMP.mapInstances[0].ui.configLegend.configSnippets[0]]`

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
None

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [ ] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3682)
<!-- Reviewable:end -->
