### PR TITLE
fix(ui): fix keyboard nav for expanded symbology icons

### DIFF
--- a/src/app/ui/toc/symbology-stack.directive.js
+++ b/src/app/ui/toc/symbology-stack.directive.js
@@ -299,18 +299,24 @@ function rvSymbologyStack($rootScope, $q, Geo, animationService, layerRegistry, 
 
         scope.$watch('self.showSymbologyToggle', value => {
             if (value) {
-                element.find('.md-icon-button').addClass('show');
+                element
+                    .find('.md-icon-button')
+                    .addClass('show');
                 $.link(element.find('.md-icon-button'));
                 element
                     .find('button')
                     .not('.rv-symbol-trigger')
-                    .removeAttr('nofocus');
+                    .removeAttr('nofocus')
+                    .addClass('focusOnce');
             } else {
-                element.find('.md-icon-button').removeClass('show');
+                element
+                    .find('.md-icon-button')
+                    .removeClass('show');
                 element
                     .find('button')
                     .not('.rv-symbol-trigger')
-                    .attr('nofocus', true);
+                    .attr('nofocus', true)
+                    .removeClass('focusOnce');
             }
         });
 


### PR DESCRIPTION
## Description
Closes #3542 

## Testing
`index-fgp-en.html?keys=JOSM,CESI_Other` and `sample 91` 
Use keyboard navigation to expand the symbology and ensure that the navigation does not get stuck at any point with symbology expanded. 

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [x] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [x] works in structured legend
- [ ] works on layer reload
- [x] datagrid works
- [ ] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3684)
<!-- Reviewable:end -->
