### PR TITLE
fix(enhancedTable): fix double negative signs filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -300,9 +300,8 @@
       "from": "github:claviska/jquery-minicolors"
     },
     "@fgpv/rv-plugins": {
-      "version": "3.1.0-9",
-      "resolved": "https://registry.npmjs.org/@fgpv/rv-plugins/-/rv-plugins-3.1.0-9.tgz",
-      "integrity": "sha512-z+ifjTNTvS48DTl9X8ectbvpaIuUSp4Iwc6e1xmsPAsTsSzNf3RDxtJghk/ILM3aN0MlKwJ5wjIT8AOTENZvGQ==",
+      "version": "github:yileifeng/plugins#ab007a190dcc6cff11dcd2c66031e9bc2dd8cda1",
+      "from": "github:yileifeng/plugins#ab007a190dcc6cff11dcd2c66031e9bc2dd8cda1",
       "requires": {
         "ag-grid-community": "19.0.0",
         "rxjs": "6.3.3"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "@claviska/jquery-minicolors": "github:claviska/jquery-minicolors",
-    "@fgpv/rv-plugins": "3.1.0-9",
+    "@fgpv/rv-plugins": "github:yileifeng/plugins#ab007a190dcc6cff11dcd2c66031e9bc2dd8cda1",
     "@flowjs/ng-flow": "2.7.8",
     "angular": "1.7.5",
     "angular-animate": "1.7.5",


### PR DESCRIPTION
## Description
Implements #3702 
Plugins PR: https://github.com/fgpv-vpgf/plugins/pull/134

## Testing
Any layer with lat/long column. Double negative signs are blocked and negative filters should still be working as intended. 

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [ ] works in IE11
- [x] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [x] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [x] datagrid works
- [x] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers
