### PR TITLE
fix(ui): remove border from colourpicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3419,8 +3419,8 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "colourpicker": {
-      "version": "git+https://github.com/fgpv-vpgf/colourpicker.git#7ede1d09e6fece2b5aa3fe62b18e35cc1f5aed87",
-      "from": "git+https://github.com/fgpv-vpgf/colourpicker.git",
+      "version": "git+https://github.com/fgpv-vpgf/colourpicker.git#2464e48ac0f373055dcdbe2fb0f8b3ab72244fef",
+      "from": "git+https://github.com/fgpv-vpgf/colourpicker.git#2464e48ac0f373055dcdbe2fb0f8b3ab72244fef",
       "requires": {
         "@ctrl/tinycolor": "^2.5.3"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "angular-sanitize": "1.7.5",
         "angular-translate": "2.18.1",
         "angular-translate-loader-static-files": "2.18.1",
-        "colourpicker": "https://github.com/fgpv-vpgf/colourpicker",
+        "colourpicker": "https://github.com/fgpv-vpgf/colourpicker#2464e48ac0f373055dcdbe2fb0f8b3ab72244fef",
         "csvtojson": "1.1.11",
         "dotjem-angular-tree": "github:dotJEM/angular-tree",
         "file-saver": "2.0.0",


### PR DESCRIPTION
## Description
The package-lock.json file was using an old commit hash. The border should no longer be visible on the colour picker.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
Test [here](http://fgpv-app.azureedge.net/demo/users/RyanCoulsonCA/fix-borders/dev/samples/index-samples.html)

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [x] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [ ] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3733)
<!-- Reviewable:end -->
