### PR TITLE
fix(legendAPI): dynamic layers getting added to API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2550,7 +2550,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -4759,7 +4759,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -6412,7 +6412,7 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#47ff8b555f5bc6284e742fb072bf3c945aa47900",
+      "version": "github:fgpv-vpgf/geoApi#v3.1.0",
       "from": "github:fgpv-vpgf/geoApi#v3.1.0",
       "requires": {
         "babel-cli": "^6.24.1",
@@ -8289,7 +8289,7 @@
         },
         "marked": {
           "version": "0.3.19",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
           "dev": true
         },
@@ -11536,7 +11536,7 @@
       "dependencies": {
         "@types/q": {
           "version": "0.0.32",
-          "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+          "resolved": "http://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
           "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
           "dev": true
         },
@@ -12557,7 +12557,7 @@
       "dependencies": {
         "convert-source-map": {
           "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
           "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
           "dev": true
         }
@@ -12577,7 +12577,7 @@
     },
     "rgba-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
     },

--- a/src/app/geo/layer-registry.service.js
+++ b/src/app/geo/layer-registry.service.js
@@ -681,20 +681,29 @@ function layerRegistryFactory(
      * @private
      */
     function syncApiElementOrder() {
-        const legendEntries = configService.getSync.map.legendBlocks.entries.filter(entry => !entry.hidden);
-        const legendElements = mapApi.ui.configLegend.children;
-        let reorderedElements = [];
-        legendEntries.forEach((entry, index) => {
-            entry = entry.collapsed ? entry.entries[0] : entry;
-            if (legendElements && legendElements.length && entry !== legendElements[index]._legendBlock) {
-                const element = legendElements.find(legendElement => entry === legendElement._legendBlock) || reorderedElements.find(legendElement => entry === legendElement._legendBlock);
-                if (element) {
-                    reorderedElements.push(legendElements[index]);
-                    legendElements[index] = element;
+        if (mapApi) {
+            const legendEntries = configService.getSync.map.legendBlocks.entries.filter(entry => !entry.hidden);
+            const legendElements = mapApi.ui.configLegend.children;
+            let reorderedElements = [];
+            legendEntries.forEach((entry, index) => {
+                entry = entry.collapsed ? entry.entries[0] : entry;
+                if (legendElements && legendElements.length && entry !== legendElements[index]._legendBlock) {
+                    const element = legendElements.find(legendElement => entry === legendElement._legendBlock) || reorderedElements.find(legendElement => entry === legendElement._legendBlock);
+                    if (element) {
+                        reorderedElements.push(legendElements[index]);
+                        legendElements[index] = element;
+                    }
                 }
-            }
-        });
+            });
+        } else {
+            const deregisterListener = events.$on(events.rvApiMapAdded, () => {
+                deregisterListener(); // need to react only once
+
+                syncApiElementOrder()
+            });
+        }
     }
+
     /**
      * // TODO: make a wrapper for the bounding box layer
      *


### PR DESCRIPTION
## Description
Closes #3751 

Fixes issue with dynamic layers not getting added to legend / API due to timing issues. May need to revisit this problem to find a better overall solution to the timing relating to layers and legend objects.

## Testing
👀
Tested mainly using `NPRI_CO` since it used to error the most frequently
Link for testing: http://fgpv-app.azureedge.net/demo/users/JahidAhmed/legendAPI-timing/dev/samples/index-samples.html?keys=NPRI_CO

Seems to be working as expected in Chrome, IE11 and Edge.

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [x] works on layer reload
- [ ] datagrid works
- [ ] identify works

## Documentation
JSDoc, in-line comments

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [ ] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3743)
<!-- Reviewable:end -->
