### PR TITLE
Support for wkt projections

### DIFF
--- a/api/plugin-loader.ts
+++ b/api/plugin-loader.ts
@@ -78,7 +78,7 @@ export default class Loader {
             const pN = pluginList[pI];
 
             if (!pN && loadFeatures[pk]) {
-                console.warn(`The plugin ${pk} was loaded automatically. This functionality is being removed in the next major release. Please load this plugin on the host page instead (see ramp documentation) or add 'no-${pk}' to rv-plugins to stop this plugin from being autoloaded.`);
+                console.warn(`The plugin ${pk} was loaded automatically. This functionality may be removed in a future release. Please load this plugin on the host page instead (see ramp documentation) or add 'no-${pk}' to rv-plugins to stop this plugin from being autoloaded.`);
             } else if (pN === `no-${pk}`) {
                 delete loadFeatures[pk];
                 pluginList.splice(pI, 1);

--- a/api/src/events.ts
+++ b/api/src/events.ts
@@ -19,12 +19,14 @@ export class MouseEvent {
 
     constructor(event: esriMouseEvent | MouseEvent, mapInstance: Map) {
         if (isEsriMouseEvent(event)) {
-            this.xy = new XY(event.mapPoint.x, event.mapPoint.y, event.mapPoint.spatialReference.wkid);
+            const sr = event.mapPoint.spatialReference;
+            this.xy = new XY(event.mapPoint.x, event.mapPoint.y, sr.wkid || sr.wkt);
         } else {
             // need to use screen point to convert to the map point used in creating the XY
             // however, screenX/Y output the wrong map point value which is why layerX/Y needs to be used
             const mapPoint = mapInstance.mapI.toMap({ x: (<any>event).layerX, y: (<any>event).layerY });
-            this.xy = new XY(mapPoint.x, mapPoint.y, mapPoint.spatialReference.wkid);
+            const sr = mapPoint.spatialReference;
+            this.xy = new XY(mapPoint.x, mapPoint.y, sr.wkid || sr.wkt);
         }
 
         this.screenY = event.screenY;
@@ -92,7 +94,11 @@ export interface esriMouseEvent extends MouseEvent {
     mapPoint: {
         y: number;
         x: number;
-        spatialReference: { wkid: number };
+        spatialReference: {
+            wkid: number,
+            latestWkid: number,
+            wkt: string
+        };
     };
 }
 

--- a/api/src/geometry.ts
+++ b/api/src/geometry.ts
@@ -9,9 +9,16 @@ export class XY {
     /** Latitude in decimal degrees, bounded by ±90° */
     y: number;
 
-    constructor(x: number, y: number, wkid?: number) {
-        if (wkid) {
-            const normalizePoints = this.projectFromPoint(wkid, x, y);
+    /**
+     * Creates an XY object
+     *
+     * @param x - An X co-ordinate
+     * @param y - A Y co-ordinate
+     * @param [projection] - Projection of the provided co-ordinates. If not provided, assumes longitude/latitude. Accepts WKID or EPSG codes as integers, or WTK as string.
+     */
+    constructor(x: number, y: number, projection?: number | string) {
+        if (projection) {
+            const normalizePoints = this.projectFromPoint(projection, x, y);
             x = normalizePoints.x;
             y = normalizePoints.y;
         }
@@ -28,20 +35,32 @@ export class XY {
         this.y = y;
     }
 
-    /** Returns a projection Point */
-    projectToPoint(targetProjection: number) {
+    /**
+     * Returns the value of this XY in a different projection
+     *
+     * @param targetProjection - Projection of the result. Accepts WKID or EPSG codes as integers, or WTK as string.
+     * @returns a point object
+     */
+    projectToPoint(targetProjection: number | string) {
         const proj = (<any>window).RAMP.GAPI.proj;
 
-        let zoomPoint = proj.localProjectPoint(4326, targetProjection, [this.x, this.y]);
-        return new proj.Point(zoomPoint[0], zoomPoint[1], new proj.SpatialReference(targetProjection));
+        let projPoint = proj.localProjectPoint(4326, targetProjection, [this.x, this.y]);
+        return new proj.Point(projPoint[0], projPoint[1], new proj.SpatialReference(targetProjection));
     }
 
-    /** Returns a projection Point */
-    projectFromPoint(sourceProjection: number, x?: number, y?: number) {
+    /**
+     * Returns the value of a given point in longitude/latitude
+     *
+     * @param sourceProjection - Projection of the co-ordinates. Accepts WKID or EPSG codes as integers, or WTK as string.
+     * @param x - An X co-ordinate
+     * @param y - A Y co-ordinate
+     * @returns a point object
+     */
+    projectFromPoint(sourceProjection: number | string, x: number, y: number) {
         const proj = (<any>window).RAMP.GAPI.proj;
 
-        let point = proj.localProjectPoint(sourceProjection, 4326, [this.x || x, this.y || y]);
-        return new proj.Point(point[0], point[1], new proj.SpatialReference(sourceProjection));
+        let point = proj.localProjectPoint(sourceProjection, 4326, [x, y]);
+        return new proj.Point(point[0], point[1], new proj.SpatialReference(4326));
     }
 
     /**
@@ -1019,7 +1038,11 @@ export interface Extent {
     xmax: number;
     ymax: number;
     ymin: number;
-    spatialReference: { wkid: number };
+    spatialReference: {
+        wkid: number,
+        latestWkid: number,
+        wkt: string
+    };
     getCenter: Function;
 }
 

--- a/api/src/map.ts
+++ b/api/src/map.ts
@@ -248,7 +248,8 @@ export class Map {
     setCenter(xy: geo.XY | geo.XYLiteral): void;
     @geo.XYLiteral
     setCenter(xy: geo.XY): void {
-        this.mapI.centerAt(xy.projectToPoint(this.mapI.spatialReference.wkid));
+        const sr = this.mapI.spatialReference;
+        this.mapI.centerAt(xy.projectToPoint(sr.wkid || sr.wkt));
     }
 
     /** Returns the current zoom level applied on the map */

--- a/package-lock.json
+++ b/package-lock.json
@@ -6413,8 +6413,8 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#47ff8b555f5bc6284e742fb072bf3c945aa47900",
-      "from": "github:fgpv-vpgf/geoApi#v3.1.0",
+      "version": "github:fgpv-vpgf/geoApi#v3.2.0-1",
+      "from": "github:fgpv-vpgf/geoApi#v3.2.0-1",
       "requires": {
         "babel-cli": "^6.24.1",
         "babel-preset-env": "1.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6413,8 +6413,8 @@
       }
     },
     "geoApi": {
-      "version": "github:fgpv-vpgf/geoApi#v3.2.0-1",
-      "from": "github:fgpv-vpgf/geoApi#v3.2.0-1",
+      "version": "github:fgpv-vpgf/geoApi#v3.2.0-2",
+      "from": "github:fgpv-vpgf/geoApi#v3.2.0-2",
       "requires": {
         "babel-cli": "^6.24.1",
         "babel-preset-env": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "csvtojson": "1.1.11",
         "dotjem-angular-tree": "github:dotJEM/angular-tree",
         "file-saver": "2.0.0",
-        "geoApi": "github:fgpv-vpgf/geoApi#v3.2.0-1",
+        "geoApi": "github:fgpv-vpgf/geoApi#v3.2.0-2",
         "html2canvas": "github:fgpv-vpgf/html2canvas#v1.0.0-rc.1-patch",
         "imports-loader": "0.8.0",
         "linkifyjs": "2.1.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "csvtojson": "1.1.11",
         "dotjem-angular-tree": "github:dotJEM/angular-tree",
         "file-saver": "2.0.0",
-        "geoApi": "github:fgpv-vpgf/geoApi#v3.1.0",
+        "geoApi": "github:fgpv-vpgf/geoApi#v3.2.0-1",
         "html2canvas": "github:fgpv-vpgf/html2canvas#v1.0.0-rc.1-patch",
         "imports-loader": "0.8.0",
         "linkifyjs": "2.1.7",

--- a/schema.json
+++ b/schema.json
@@ -11,19 +11,24 @@
             "type": "object",
             "properties": {
                 "wkid": {
-                    "type": "number"
+                    "type": "number",
+                    "description": "an ESRI well known id denoting a projection"
                 },
                 "vcsWkid": {
-                    "type": "number"
+                    "type": "number",
+                    "description": "an ESRI well known id denoting a vertical co-ordinate system. RAMP currently does not support this property."
                 },
                 "latestWkid": {
-                    "type": "number"
+                    "type": "number",
+                    "description": "an ESRI well known id denoting a projection"
                 },
                 "latestVcsWkid": {
-                    "type": "number"
+                    "type": "number",
+                    "description": "an ESRI well known id denoting a vertical co-ordinate system. RAMP currently does not support this property."
                 },
                 "wkt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "a well known type projection definition"
                 }
             },
             "anyOf": [{
@@ -47,19 +52,24 @@
             "type": "object",
             "properties": {
                 "wkid": {
-                    "type": "number"
+                    "type": "number",
+                    "description": "an ESRI well known id denoting a projection"
                 },
                 "vcsWkid": {
-                    "type": "number"
+                    "type": "number",
+                    "description": "an ESRI well known id denoting a vertical co-ordinate system. RAMP currently does not support this property."
                 },
                 "latestWkid": {
-                    "type": "number"
+                    "type": "number",
+                    "description": "an ESRI well known id denoting a projection"
                 },
                 "latestVcsWkid": {
-                    "type": "number"
+                    "type": "number",
+                    "description": "an ESRI well known id denoting a vertical co-ordinate system. RAMP currently does not support this property."
                 },
                 "wkt": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "a well known type projection definition"
                 }
             },
             "anyOf": [{

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -2202,7 +2202,16 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
                 });
 
                 mapInstance.boundsChanged = Observable.create(subscriber => {
-                    events.$on(events.rvExtentChange, (_, d) => subscriber.next(extentToApi(d.extent)));
+                    events.$on(events.rvExtentChange, (_, d) => {
+                        try {
+                            const apiExtent = extentToApi(d.extent);
+                            subscriber.next(apiExtent);
+                        } catch(error) {
+                            // errors generally happen if the map view is enormous (e.g. earth wraparound, north pole in middle, etc)
+                            // TODO we will have a discussion on best way to handle the error case. warning for now
+                            console.warn('unable to convert extent to API format (lat-long co-ords). boundsChanged observable was not fired.');
+                        }
+                    });
                 });
 
                 // add this to avoid issues with projection changes

--- a/src/app/core/config.class.js
+++ b/src/app/core/config.class.js
@@ -1271,6 +1271,9 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
 
         /**
          * Returns the wkid of the basemap projection.
+         * NOTE: this is only being used to drive styles in the basemap selector.
+         *       Any code dealing with spatial references should use the spatialReference property.
+         *       This property will be undefined if using a non-wkid basemap.
          * @return {Number} wkid of the basemap projection
          */
         get wkid () { return this.spatialReference.wkid; }
@@ -1279,18 +1282,26 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
          * Returns the spatial reference of the basemap tile schema.
          * @return {Object} spatial reference
          */
-        get spatialReference () { return this._tileSchema.extentSet.spatialReference;  }
+        get spatialReference () { return this._tileSchema.extentSet.spatialReference; }
 
         /**
          * Returns the default extent as an Esri extent object.
          * @return {Object} Esri extent object
          */
         get default () { return this._tileSchema.extentSet.default; }
+
+        /**
+         * Returns the tile schema id.
+         * @return {String} the tile schema id
+         */
+        get tileSchemaId () { return this._tileSchema.id; }
+
         /**
          * Returns the full extent as an Esri extent object.
          * @return {Object} Esri extent object
          */
         get full () { return this._tileSchema.extentSet.full; }
+
         /**
          * Returns the maximum extent as an Esri extent object.
          * @return {Object} Esri extent object
@@ -2184,8 +2195,8 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
                     // trigger zoomChanged observable on rvExtentChange event and when levelChange is true
                     // fixes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3617
                     events.$on(events.rvExtentChange, (_, d) => {
-                        if (d.levelChange) {
-                            subscriber.next(mapInstance.zoom);
+                        if (d.levelChange && d.lod) {
+                            subscriber.next(d.lod.level);
                         }
                     });
                 });
@@ -2201,9 +2212,10 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
                 });
 
                 mapInstance.centerChanged = Observable.create(subscriber => {
+                    // note do not use `instance` here, as it will scope to old maps if projection change happens
                     events.$on(events.rvExtentChange, (_, d) => {
                         const centerXY = d.extent.getCenter();
-                        subscriber.next(pointToApi(centerXY.x, centerXY.y));
+                        subscriber.next(pointToApi(centerXY.x, centerXY.y, d.extent.spatialReference));
                     });
                 });
 
@@ -2219,8 +2231,8 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
                 return new XYBounds([xy.x1, xy.y1], [xy.x0, xy.y0]);
             }
 
-            function pointToApi(x, y) {
-                const xy = gapiService.gapi.proj.localProjectPoint(instance.spatialReference.wkid, 4326, [x, y]);
+            function pointToApi(x, y, spatialReference) {
+                const xy = gapiService.gapi.proj.localProjectPoint(spatialReference, 4326, [x, y]);
                 return new XY(xy[0], xy[1]);
             }
 

--- a/src/app/core/core.run.js
+++ b/src/app/core/core.run.js
@@ -302,7 +302,7 @@ function apiBlock($rootScope, geoService, configService, events,
      *
      * @function projectGeometry
      * @param {Object} geometry     The geometry to project
-     * @param {Number} outSR        The output spatial reference ID
+     * @param {Object} outSR        The output spatial reference (spatial reference object, wkid/epsg integer, or wkt string)
      * @return {Object}             The projected geometry
      */
     function projectGeometry(geometry, outSR) {

--- a/src/app/geo/identify.service.js
+++ b/src/app/geo/identify.service.js
@@ -34,7 +34,7 @@ function identifyService($q, configService, gapiService, referenceService, state
      */
     function XYtoFakeEvent(xy, mapInstance) {
         // shift from latlong (XY is native to that) to map projection
-        const mapPoint = xy.projectToPoint(mapInstance.spatialReference.wkid);
+        const mapPoint = xy.projectToPoint(mapInstance.spatialReference);
 
         // generate screen co-ords if possible. needed for WMS identifies.
         const screenPoint = mapInstance.toScreen(mapPoint);
@@ -257,7 +257,7 @@ function identifyService($q, configService, gapiService, referenceService, state
             const ubGraphics = gapi.hilight.getUnboundGraphics([graphicBundle], mapConfig.instance.spatialReference);
 
             ubGraphics[0].then(unboundG => {
-                console.log('unbound graphic for highlighting ', unboundG);
+                // console.log('unbound graphic for highlighting ', unboundG);
                 mapConfig.highlightLayer.addHilight(unboundG);
             });
         });

--- a/src/app/geo/layer-blueprint.class.ts
+++ b/src/app/geo/layer-blueprint.class.ts
@@ -1,4 +1,3 @@
-import RColor from 'rcolor';
 import to from 'await-to-js';
 import angular from 'angular';
 
@@ -211,8 +210,8 @@ function LayerBlueprint($http: any, $q: any, Geo: any, gapiService: any, ConfigO
 
             await this.validate();
 
-            // TODO: targetWkid property should be added to the WFS layer config node
-            this.config.targetWkid = configService.getSync.map.instance.spatialReference.wkid;
+            // TODO: targetSR property should be added to the WFS layer config node
+            this.config.targetSR = configService.getSync.map.instance.spatialReference;
 
             // clone data because the makeSomethingLayer functions mangle the config data
             const clonedFormattedData = angular.copy(this._formattedData);

--- a/src/app/geo/legend-block.class.js
+++ b/src/app/geo/legend-block.class.js
@@ -963,14 +963,15 @@ function LegendBlockFactory(
             if (this._bboxProxy) {
                 return;
             }
-
-            const currentWkid = ref.map.selectedBasemap.spatialReference.wkid;
             this._bboxProxy = layerRegistry.getBoundingBoxRecord(this.bboxId);
 
             if (!this._bboxProxy) {
                 // no cached bounding box found
                 this._bboxProxy = layerRegistry.registerBoundingBoxRecord(this.bboxId, this.proxyWrapper.extent);
-            } else if (this._bboxProxy.spatialReference.wkid !== currentWkid) {
+
+            } else if (!gapiService.gapi.proj.isSpatialRefEqual(
+                this._bboxProxy.spatialReference, ref.map.selectedBasemap.spatialReference)) {
+
                 // cached bbox projection not compatible
                 this._bboxProxy = layerRegistry.removeBoundingBoxRecord(this.bboxId);
                 this._bboxProxy = layerRegistry.registerBoundingBoxRecord(this.bboxId, this.proxyWrapper.extent);
@@ -992,11 +993,11 @@ function LegendBlockFactory(
         }
 
         set boundingBox(value) {
-            const currentWkid = ref.map.selectedBasemap.spatialReference.wkid;
-
             if (!value && !this._bboxProxy) {
                 return;
-            } else if (!this._bboxProxy || this._bboxProxy.spatialReference.wkid !== currentWkid) {
+            } else if (!this._bboxProxy || !gapiService.gapi.proj.isSpatialRefEqual(
+                this._bboxProxy.spatialReference, ref.map.selectedBasemap.spatialReference)) {
+
                 this._makeBbox();
             }
 

--- a/src/app/geo/locate.service.js
+++ b/src/app/geo/locate.service.js
@@ -42,7 +42,7 @@ function locateService($http, $translate, gapiService, configService, errorServi
         const lods = configService.getSync.map.selectedBasemap.lods;
 
         // get reprojected point and zoom to it
-        const geoPt = gapiService.gapi.proj.localProjectPoint(4326, map.spatialReference.wkid,
+        const geoPt = gapiService.gapi.proj.localProjectPoint(4326, map.spatialReference,
             [parseFloat(location.longitude), parseFloat(location.latitude)]);
         const zoomPt = gapiService.gapi.proj.Point(geoPt[0], geoPt[1], map.spatialReference);
 

--- a/src/app/geo/map-tools.service.js
+++ b/src/app/geo/map-tools.service.js
@@ -108,6 +108,28 @@ function mapToolService(configService, geoService, gapiService, $translate, Geo)
         };
     }
 
+    function loadCardinality() {
+        // separate function to reduce number of lines in mapCoordinates function.
+        // get values once to reuse in private functions (cardinal points and degree symbol)
+        if (typeof cardinal.east === 'undefined') {
+            cardinal.east = $translate.instant('geo.coord.east');
+            cardinal.west = $translate.instant('geo.coord.west');
+            cardinal.north = $translate.instant('geo.coord.north');
+            cardinal.south = $translate.instant('geo.coord.south');
+        }
+    }
+
+    function ddFormatting(point) {
+        // separate function to reduce number of lines in mapCoordinates function.
+        // does rounding and negative snipping for decimal degree display
+        const coord = {};
+        coord.y = point.y.toFixed(5);
+        coord.x = point.x.toFixed(5);
+        coord.y = coord.y > 0 ? coord.y : Math.abs(coord.y);
+        coord.x = coord.x < 0 ? Math.abs(coord.x) : coord.x;
+        return coord;
+    }
+
     /**
     * Provides data needed for the display of a map coordinates on the map in latitude/longitude (degree, minute, second and decimal degree) if
     * spatial reference is wkid 4326 or only show coordinates if spatial reference is different
@@ -130,39 +152,55 @@ function mapToolService(configService, geoService, gapiService, $translate, Geo)
         //       but since it's part of the legacy api, we need to continue to support the old
         //       interface of integer wkid's as well.
         const latLong = 4326;
+        const fixedOutMouseSR = isNaN(outMouseSR) ? outMouseSR : { wkid: outMouseSR };
+        let yLabel = '';
+        let xLabel = '';
+        const coordArray = [];
+        let failParty = false;
+        let coord;
 
         // project point in lat/long
-        const coord = gapiService.gapi.proj.localProjectGeometry(latLong, point);
+        // this is to get the direction (NESW), and we can use the result if our output is also lat/long
+        try {
+            const coordLL = gapiService.gapi.proj.localProjectPoint(point.spatialReference, latLong, [point.x, point.y]);
 
-        // get values once to reuse in private functions (cardinal points and degree symbol)
-        if (typeof cardinal.east === 'undefined') {
-            cardinal.east = $translate.instant('geo.coord.east');
-            cardinal.west = $translate.instant('geo.coord.west');
-            cardinal.north = $translate.instant('geo.coord.north');
-            cardinal.south = $translate.instant('geo.coord.south');
+            // this just messages back to older format, makes code more readable
+            coord = {
+                x: coordLL[0],
+                y: coordLL[1]
+            };
+
+            loadCardinality();
+
+            // get cardinality
+            yLabel = (coord.y > 0) ? cardinal.north : cardinal.south;
+            xLabel = (coord.x < 0) ? cardinal.west : cardinal.east;
+        } catch(error) {
+            failParty = true;
+            if (fixedOutMouseSR.wkid === latLong) {
+                // could not calculate point to show
+                coordArray.push('');
+                coordArray.push('');
+            }
         }
 
-        // get cardinality
-        const yLabel = (coord.y > 0) ? cardinal.north : cardinal.south;
-        const xLabel = (coord.x < 0) ? cardinal.west : cardinal.east;
-
-        const coordArray = [];
-        if (outMouseSR === latLong || outMouseSR.wkid === latLong) {
+        // format the result for display
+        if (fixedOutMouseSR.wkid === latLong && !failParty) {
             // degree, minute, second
             const dmsCoords = convertDDToDMS(coord.y, coord.x);
             coordArray.push(`${dmsCoords.y} ${yLabel} | ${dmsCoords.x} ${xLabel}`);
 
             // decimal
-            coord.y = coord.y.toFixed(5);
-            coord.x = coord.x.toFixed(5);
-            coord.y = `${(coord.y > 0) ? coord.y : Math.abs(coord.y)} ${yLabel}`;
-            coord.x = `${(coord.x < 0) ? Math.abs(coord.x) : coord.x} ${xLabel}`;
-            coordArray.push(`${coord.y} | ${coord.x}`);
+            coord = ddFormatting(coord);
+            coordArray.push(`${coord.y} ${yLabel} | ${coord.x} ${xLabel}`);
         } else {
-            // project point if wkid was different then 4326
-            const coordProj = gapiService.gapi.proj.localProjectGeometry(outMouseSR, point);
-            coordArray.push(`${coordProj.y.toFixed(5)} ${yLabel}`);
-            coordArray.push(`${coordProj.x.toFixed(5)} ${xLabel}`);
+            // project point if wkid was different then 4326, and different than mouse out projection
+            let coordProj = [point.x, point.y];
+            if (!gapiService.gapi.proj.isSpatialRefEqual(fixedOutMouseSR, point.spatialReference)) {
+                coordProj = gapiService.gapi.proj.localProjectPoint(point.spatialReference, fixedOutMouseSR, coordProj);
+            }
+            coordArray.push(`${coordProj[1].toFixed(5)} ${yLabel}`);
+            coordArray.push(`${coordProj[0].toFixed(5)} ${xLabel}`);
         }
 
         return coordArray;

--- a/src/app/geo/map.service.js
+++ b/src/app/geo/map.service.js
@@ -223,7 +223,7 @@ function mapServiceFactory(
 
         // avoid private variable
         const res = gapiService.gapi.layer.makeGeoJsonLayer(fakeGeoJSON, {
-            targetWkid: mapInstance._map.extent.spatialReference.wkid
+            targetSR: mapInstance._map.extent.spatialReference
         });
         res.then(esriLayer => {
             firstBasemapFlag = true;

--- a/src/app/layout/shell.directive.js
+++ b/src/app/layout/shell.directive.js
@@ -55,7 +55,7 @@ function rvShell($rootElement, events, stateManager, configService, layoutServic
                     // set ouput spatial reference for mouse coordinates. If spatial reference is defined in configuration file
                     // use it. If not, use the basemap spatial reference
                     const sr = mapConfig.mouseInfo.spatialReference;
-                    outMouseSR = (typeof sr !== 'undefined') ? sr.wkid : geoService.mapObject.spatialReference;
+                    outMouseSR = (typeof sr !== 'undefined') ? sr : geoService.mapObject.spatialReference;
 
                     // set map coordinates
                     events.$on('rvMouseMove',

--- a/src/app/ui/basemap/basemap.directive.js
+++ b/src/app/ui/basemap/basemap.directive.js
@@ -40,6 +40,8 @@ function Controller(geoService, mapService, basemapService, configService, event
 
     self.notifyApiClick = notifyApiClick;
 
+    self.selectedTileSchemaId = '';
+
     let mApi = null;
     events.$on(events.rvApiMapAdded, (_, api) => { mApi = api});
 
@@ -48,6 +50,7 @@ function Controller(geoService, mapService, basemapService, configService, event
     events.$on(events.rvMapLoaded, () => {
         const mapConfig = configService.getSync.map;
         const allBasemaps = mapConfig.basemaps;
+        self.selectedTileSchemaId = mapConfig.selectedBasemap.tileSchemaId;
 
         mapConfig.instance.changeBasemap = id => {
             const newBasemap = allBasemaps.find(basemap => basemap.id === id);
@@ -59,7 +62,7 @@ function Controller(geoService, mapService, basemapService, configService, event
             const index = allBasemaps.findIndex(basemap => basemap.id === id);
             const basemapToDelete = allBasemaps[index];
             if (apiBasemap.isActive) {
-                let newBasemap = allBasemaps.find(basemap => basemap.id !== id && basemap.wkid === basemapToDelete.wkid);
+                let newBasemap = allBasemaps.find(basemap => basemap.id !== id && basemap.tileSchemaId === basemapToDelete.tileSchemaId);
                 if (!newBasemap) {
                     newBasemap = allBasemaps.find(basemap => basemap.id !== id);
                 }
@@ -92,6 +95,8 @@ function Controller(geoService, mapService, basemapService, configService, event
      * @param {Basemap} newBasemap a Basemap object from the config
      */
     function selectBasemap(newBasemap) {
+
+        self.selectedTileSchemaId = newBasemap.tileSchemaId;
         const oldBasemap = configService.getSync.map.selectedBasemap;
 
         oldBasemap.deselect();
@@ -101,7 +106,7 @@ function Controller(geoService, mapService, basemapService, configService, event
         oldApiBasemap._isActive = false;
         oldApiBasemap._activeChanged.next(false);
 
-        if (newBasemap.wkid !== oldBasemap.wkid) {
+        if (newBasemap.tileSchemaId !== oldBasemap.tileSchemaId) {
             // cast the current center point into the new projection
             // it will be encoded in the bookmark, so there is no need to do the calculation when the bookmark is loaded
             const startPoint = mapService.getCenterPointInTargetBasemap(

--- a/src/app/ui/basemap/basemap.html
+++ b/src/app/ui/basemap/basemap.html
@@ -18,7 +18,7 @@
                         <h3 class="md-title">{{ tileSchema.name }}
                             <md-tooltip>{{ tileSchema.name }}</md-tooltip>
                         </h3>
-                        <div class="rv-icon-16" ng-show="self.selectedWkid != projection.wkid">
+                        <div class="rv-icon-16" ng-show="self.selectedTileSchemaId != tileSchema.id">
                             <md-icon md-svg-src="action:info" class="rv-basemap-warning"></md-icon>
                             <span class="md-catpion" >{{ 'basemap.refresh.req' | translate }}</span>
                         </div>

--- a/src/app/ui/geosearch/geosearch.service.js
+++ b/src/app/ui/geosearch/geosearch.service.js
@@ -408,7 +408,7 @@ function geosearchService(
         // zoom to location (expand the bbox to include all the area)
         geoService.setExtent(zoomExtent.expand(1.5)).then(() => {
             // get reprojected point and create point
-            const geoPt = gapi.proj.localProjectPoint(4326, mapSR.wkid, [
+            const geoPt = gapi.proj.localProjectPoint(4326, mapSR, [
                 parseFloat(position[0]),
                 parseFloat(position[1])
             ]);

--- a/src/app/ui/loader/layer-source.service.js
+++ b/src/app/ui/loader/layer-source.service.js
@@ -49,8 +49,6 @@ function layerSource($q, gapiService, Geo, LayerBlueprint, ConfigObject, configS
             [geoServiceTypes.TileService]: () => [_parseAsTile]
         };
 
-        const urlWrapper = new LayerBlueprint.UrlWrapper(serviceUrl);
-
         let fetchPromise;
 
         // check if it's a WMS first
@@ -198,10 +196,9 @@ function layerSource($q, gapiService, Geo, LayerBlueprint, ConfigObject, configS
          * @function _parseAsWfs
          * @private
          * @param {String} url a service url to be used
-         * @param {Object} data service info data from the geoApi predition call
          * @return {Promise} a promsie resolving with a LayerBlueprint.WFSServiceInfo object
          */
-        function _parseAsWfs(url, data) {
+        function _parseAsWfs(url) {
             const splitUrl = url.split('/');
             const indexOfItems = splitUrl.findIndex(item => item.startsWith('items'));
 
@@ -215,7 +212,6 @@ function layerSource($q, gapiService, Geo, LayerBlueprint, ConfigObject, configS
                 }
             };
 
-            const targetWkid = configService.getSync.map.instance.spatialReference.wkid;
             const layerInfo = new LayerBlueprint.WFSServiceSource(layerRawConfig);
 
             return layerInfo;
@@ -396,8 +392,6 @@ function layerSource($q, gapiService, Geo, LayerBlueprint, ConfigObject, configS
                     userAdded: true
                 }
             };
-
-            const targetWkid = configService.getSync.map.instance.spatialReference.wkid;
 
             // upfront validation is expensive and time consuming - create all file options and let the user decide, then validate
             const blueprintOptions = [

--- a/src/app/ui/tooltip/tooltip.service.js
+++ b/src/app/ui/tooltip/tooltip.service.js
@@ -373,7 +373,7 @@ function tooltipService($rootScope, $compile, $q, configService, referenceServic
 
                 removeHoverTooltip();
 
-                console.log('tooltipService', `movementOffset is ${movementOffset}`);
+                // console.log('tooltipService', `movementOffset is ${movementOffset}`);
             });
         }
     }

--- a/src/content/samples/config/config-sample-92.json
+++ b/src/content/samples/config/config-sample-92.json
@@ -1,0 +1,597 @@
+{
+  "ui": {
+    "title": "Fancy Basemaps",
+    "navBar": {
+      "zoom": "buttons",
+      "extra": [
+        "fullscreen",
+        "geoLocator",
+        "home",
+        "help"
+      ]
+    },
+    "sideMenu": {
+      "logo": true
+    },
+    "help": {
+      "folderName": "default"
+    },
+    "legend": {
+      "isOpen": {
+        "large": true,
+        "medium": true,
+        "small": false
+      }
+    }
+  },
+  "version": "2.0",
+  "language": "en",
+  "services": {
+    "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+    "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+    "export": {
+      "title": {
+        "value": "Title"
+      },
+      "map": {},
+      "mapElements": {},
+      "legend": {},
+      "footnote": {
+        "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+      }
+    },
+    "search": {
+      "serviceUrls": {
+        "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
+        "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
+        "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+        "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
+        "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+      }
+    }
+  },
+  "map": {
+    "initialBasemapId": "baseNrCan",
+    "components": {
+      "geoSearch": {
+        "enabled": true,
+        "showGraphic": true,
+        "showInfo": true
+      },
+      "mouseInfo": {
+        "enabled": true,
+        "spatialReference": {
+          "wkt": "PROJCS[\"Sphere_ARC_INFO_Azimuthal_Equidistant\",GEOGCS[\"GCS_Sphere_ARC_INFO\",DATUM[\"D_Sphere_ARC_INFO\",SPHEROID[\"Sphere_ARC_INFO\",6370997.0,0.0]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Azimuthal_Equidistant\"],PARAMETER[\"False_Easting\",0.0],PARAMETER[\"False_Northing\",0.0],PARAMETER[\"Central_Meridian\",-90.0],PARAMETER[\"Latitude_Of_Origin\",90.0],UNIT[\"Meter\",1.0]]"
+        }
+      },
+      "northArrow": {
+        "enabled": true
+      },
+      "basemap": {
+        "enabled": true
+      },
+      "overviewMap": {
+        "enabled": true,
+        "layerType": "imagery",
+        "initiallyExpanded": false
+      },
+      "scaleBar": {
+        "enabled": true
+      }
+    },
+    "legend": {
+      "type": "structured",
+      "root": {
+        "name": "root",
+        "children": [
+          {
+            "infoType": "title",
+            "content": "Fancy Basemap Sample"
+          },
+          {
+            "infoType": "text",
+            "content": "This sample has a 3rd projection. The mouse info is in Azamuth units"
+          },
+          {
+            "layerId": "fancyplantsFeat"
+          },
+          {
+            "layerId": "fancywindDyn"
+          }
+        ]
+      }
+    },
+    "layers": [
+      {
+        "id": "fancyplantsFeat",
+        "name": "Fancy Plants",
+        "layerType": "esriFeature",
+        "url": "https://maps-cartes.ec.gc.ca/arcgis/rest/services/EcoGeo/EcoGeo/MapServer/6"
+      },
+      {
+        "id": "fancywindDyn",
+        "name": "Fancy Wind",
+        "layerType": "esriDynamic",
+        "url": "https://maps-cartes.ec.gc.ca/arcgis/rest/services/EcoGeo/EcoGeo/MapServer/",
+        "layerEntries": [
+          {
+            "index": 9
+          }
+        ]
+      }
+    ],
+    "extentSets": [
+      {
+        "id": "EXT_NRCAN_Lambert_3978",
+        "default": {
+          "xmax": 3549492,
+          "xmin": -2681457,
+          "ymax": 3482193,
+          "ymin": -883440
+        },
+        "spatialReference": {
+          "wkid": 3978
+        }
+      },
+      {
+        "id": "EXT_ESRI_World_AuxMerc_3857",
+        "default": {
+          "xmax": -5007771.626060756,
+          "xmin": -16632697.354854,
+          "ymax": 10015875.184845109,
+          "ymin": 5022907.964742964
+        },
+        "spatialReference": {
+          "wkid": 102100,
+          "latestWkid": 3857
+        }
+      },
+      {
+        "id": "EXT_Azimuthal_Equidistant",
+        "default": {
+          "xmax": 5819079.101785716,
+          "xmin": -5819079.101785716,
+          "ymax": 4075601.7875,
+          "ymin": -62410.018214286305
+        },
+        "spatialReference": {
+          "wkt": "PROJCS[\"Sphere_ARC_INFO_Azimuthal_Equidistant\",GEOGCS[\"GCS_Sphere_ARC_INFO\",DATUM[\"D_Sphere_ARC_INFO\",SPHEROID[\"Sphere_ARC_INFO\",6370997.0,0.0]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Azimuthal_Equidistant\"],PARAMETER[\"False_Easting\",0.0],PARAMETER[\"False_Northing\",0.0],PARAMETER[\"Central_Meridian\",-90.0],PARAMETER[\"Latitude_Of_Origin\",90.0],UNIT[\"Meter\",1.0]]"
+        }
+      }
+    ],
+    "lodSets": [
+      {
+        "id": "LOD_NRCAN_Lambert_3978",
+        "lods": [
+          {
+            "level": 0,
+            "resolution": 38364.660062653464,
+            "scale": 145000000
+          },
+          {
+            "level": 1,
+            "resolution": 22489.62831258996,
+            "scale": 85000000
+          },
+          {
+            "level": 2,
+            "resolution": 13229.193125052918,
+            "scale": 50000000
+          },
+          {
+            "level": 3,
+            "resolution": 7937.5158750317505,
+            "scale": 30000000
+          },
+          {
+            "level": 4,
+            "resolution": 4630.2175937685215,
+            "scale": 17500000
+          },
+          {
+            "level": 5,
+            "resolution": 2645.8386250105837,
+            "scale": 10000000
+          },
+          {
+            "level": 6,
+            "resolution": 1587.5031750063501,
+            "scale": 6000000
+          },
+          {
+            "level": 7,
+            "resolution": 926.0435187537042,
+            "scale": 3500000
+          },
+          {
+            "level": 8,
+            "resolution": 529.1677250021168,
+            "scale": 2000000
+          },
+          {
+            "level": 9,
+            "resolution": 317.50063500127004,
+            "scale": 1200000
+          },
+          {
+            "level": 10,
+            "resolution": 185.20870375074085,
+            "scale": 700000
+          },
+          {
+            "level": 11,
+            "resolution": 111.12522225044451,
+            "scale": 420000
+          },
+          {
+            "level": 12,
+            "resolution": 66.1459656252646,
+            "scale": 250000
+          },
+          {
+            "level": 13,
+            "resolution": 38.36466006265346,
+            "scale": 145000
+          },
+          {
+            "level": 14,
+            "resolution": 22.48962831258996,
+            "scale": 85000
+          },
+          {
+            "level": 15,
+            "resolution": 13.229193125052918,
+            "scale": 50000
+          },
+          {
+            "level": 16,
+            "resolution": 7.9375158750317505,
+            "scale": 30000
+          },
+          {
+            "level": 17,
+            "resolution": 4.6302175937685215,
+            "scale": 17500
+          }
+        ]
+      },
+      {
+        "id": "LOD_ESRI_World_AuxMerc_3857",
+        "lods": [
+          {
+            "level": 0,
+            "resolution": 19567.87924099992,
+            "scale": 73957190.948944
+          },
+          {
+            "level": 1,
+            "resolution": 9783.93962049996,
+            "scale": 36978595.474472
+          },
+          {
+            "level": 2,
+            "resolution": 4891.96981024998,
+            "scale": 18489297.737236
+          },
+          {
+            "level": 3,
+            "resolution": 2445.98490512499,
+            "scale": 9244648.868618
+          },
+          {
+            "level": 4,
+            "resolution": 1222.992452562495,
+            "scale": 4622324.434309
+          },
+          {
+            "level": 5,
+            "resolution": 611.4962262813797,
+            "scale": 2311162.217155
+          },
+          {
+            "level": 6,
+            "resolution": 305.74811314055756,
+            "scale": 1155581.108577
+          },
+          {
+            "level": 7,
+            "resolution": 152.87405657041106,
+            "scale": 577790.554289
+          },
+          {
+            "level": 8,
+            "resolution": 76.43702828507324,
+            "scale": 288895.277144
+          },
+          {
+            "level": 9,
+            "resolution": 38.21851414253662,
+            "scale": 144447.638572
+          },
+          {
+            "level": 10,
+            "resolution": 19.10925707126831,
+            "scale": 72223.819286
+          },
+          {
+            "level": 11,
+            "resolution": 9.554628535634155,
+            "scale": 36111.909643
+          },
+          {
+            "level": 12,
+            "resolution": 4.77731426794937,
+            "scale": 18055.954822
+          },
+          {
+            "level": 13,
+            "resolution": 2.388657133974685,
+            "scale": 9027.977411
+          },
+          {
+            "level": 14,
+            "resolution": 1.1943285668550503,
+            "scale": 4513.988705
+          },
+          {
+            "level": 15,
+            "resolution": 0.5971642835598172,
+            "scale": 2256.994353
+          },
+          {
+            "level": 16,
+            "resolution": 0.29858214164761665,
+            "scale": 1128.497176
+          },
+          {
+            "level": 17,
+            "resolution": 0.14929107082380833,
+            "scale": 564.248588
+          },
+          {
+            "level": 18,
+            "resolution": 0.07464553541190416,
+            "scale": 282.124294
+          },
+          {
+            "level": 19,
+            "resolution": 0.03732276770595208,
+            "scale": 141.062147
+          },
+          {
+            "level": 20,
+            "resolution": 0.01866138385297604,
+            "scale": 70.5310735
+          }
+        ]
+      },
+      {
+        "id": "LOD_Azimuthal_Equidistant",
+        "lods": [
+          {
+            "level": 0,
+            "resolution": 33072.9828126323,
+            "scale": 125000000
+           },
+           {
+            "level": 1,
+            "resolution": 16536.49140631615,
+            "scale": 62500000
+           },
+           {
+            "level": 2,
+            "resolution": 8268.245703158074,
+            "scale": 31250000
+           },
+           {
+            "level": 3,
+            "resolution": 4134.122851579037,
+            "scale": 15625000
+           },
+           {
+            "level": 4,
+            "resolution": 2067.0614257895186,
+            "scale": 7812500
+           },
+           {
+            "level": 5,
+            "resolution": 1033.5307128947593,
+            "scale": 3906250
+           },
+           {
+            "level": 6,
+            "resolution": 516.7653564473796,
+            "scale": 1953125
+           }
+        ]
+      }
+    ],
+    "tileSchemas": [
+      {
+        "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+        "name": "Lambert Maps",
+        "extentSetId": "EXT_NRCAN_Lambert_3978",
+        "lodSetId": "LOD_NRCAN_Lambert_3978",
+        "hasNorthPole": true
+      },
+      {
+        "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+        "name": "Web Mercator Maps",
+        "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+        "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "EXT_Azimuthal_Equidistant#LOD_Azimuthal_Equidistant",
+        "name": "Azimuthal Equidistant Maps",
+        "extentSetId": "EXT_Azimuthal_Equidistant",
+        "lodSetId": "LOD_Azimuthal_Equidistant",
+        "hasNorthPole": true
+      }
+    ],
+    "baseMaps": [
+      {
+        "id": "baseNrCan",
+        "name": "Canada Base Map - Transportation (CBMT)",
+        "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+        "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+        "layers": [
+          {
+            "id": "CBMT",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+        "attribution": {
+          "text": {
+            "enabled": true,
+            "value": "Custom Attribution"
+          },
+          "logo": {
+            "enabled": true
+          }
+        }
+      },
+      {
+        "id": "baseSimple",
+        "name": "Canada Base Map - Simple",
+        "description": "Canada Base Map - Simple",
+        "altText": "altText - Canada base map - Simple",
+        "layers": [
+          {
+            "id": "SMR",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseCBME_CBCE_HS_RO_3978",
+        "name": "Canada Base Map - Elevation (CBME)",
+        "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+        "altText": "altText - Canada Base Map - Elevation (CBME)",
+        "layers": [
+          {
+            "id": "CBME_CBCE_HS_RO_3978",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseCBMT_CBCT_GEOM_3978",
+        "name": "Canada Base Map - Transportation (CBMT)",
+        "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+        "altText": "altText - Canada Base Map - Transportation (CBMT)",
+        "layers": [
+          {
+            "id": "CBMT_CBCT_GEOM_3978",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+      },
+      {
+        "id": "baseEsriWorld",
+        "name": "World Imagery",
+        "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+        "altText": "altText - World Imagery",
+        "layers": [
+          {
+            "id": "World_Imagery",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriPhysical",
+        "name": "World Physical Map",
+        "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+        "altText": "altText - World Physical Map",
+        "layers": [
+          {
+            "id": "World_Physical_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriRelief",
+        "name": "World Shaded Relief",
+        "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+        "altText": "altText - World Shaded Relief",
+        "layers": [
+          {
+            "id": "World_Shaded_Relief",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriStreet",
+        "name": "World Street Map",
+        "description": "This worldwide street map presents highway-level data for the world.",
+        "altText": "altText - ESWorld Street Map",
+        "layers": [
+          {
+            "id": "World_Street_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriTerrain",
+        "name": "World Terrain Base",
+        "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+        "altText": "altText - World Terrain Base",
+        "layers": [
+          {
+            "id": "World_Terrain_Base",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseEsriTopo",
+        "name": "World Topographic Map",
+        "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+        "altText": "altText - World Topographic Map",
+        "layers": [
+          {
+            "id": "World_Topo_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+      },
+      {
+        "id": "baseAzEqImage",
+        "name": "Northern Circumpolar Map",
+        "description": "This map shows geography of the northern circumpolar region.",
+        "altText": "Northern Circumpolar Map",
+        "layers": [
+          {
+            "id": "NCR_RCN",
+            "layerType": "esriFeature",
+            "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/FGP/NCR_RCN/MapServer"
+          }
+        ],
+        "tileSchemaId": "EXT_Azimuthal_Equidistant#LOD_Azimuthal_Equidistant"
+      }
+    ]
+  }
+}

--- a/src/content/samples/index-samples.tpl
+++ b/src/content/samples/index-samples.tpl
@@ -80,6 +80,7 @@
         }
 
     </style>
+    <script src="./plugins/coordInfo/coordInfo.js"></script>
 
     <% for (var index in htmlWebpackPlugin.files.css) { %>
         <% if (webpackConfig.output.crossOriginLoading) { %>
@@ -188,6 +189,7 @@
                 <option value="config/config-sample-89.json">89. Custom Geosearch sorted results</option>
                 <option value="config/config-sample-90.json">90. Layer with custom field alias</option>
                 <option value="config/config-sample-91.json">91. Custom Symbology Stacks</option>
+                <option value="config/config-sample-92.json">92. Third Basemap Schema using WKT</option>
             </select>
         </div>
 
@@ -206,6 +208,7 @@
         rv-config="config/config-sample-01.json"
         rv-langs='["en-CA", "fr-CA"]'
         rv-restore-bookmark="bookmark"
+        rv-plugins="coordInfo"
         rv-service-endpoint="http://section917.cloudapp.net:8000/">
          <noscript>
             <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Adds support for WKT projections, and fixes code that previously demanded WKID only.
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3442

Also fixes some related bugs discovered along the way
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3744
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3745
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3746

GeoAPI best buddy PR https://github.com/fgpv-vpgf/geoApi/pull/360

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

Sample 92 contains a 3rd basemap section Azimuth, and that projection is WKT type.  It also has the cursor info set to show points in Azimuth projection.

### Tests to cover all items that were updated

Unless specified, all tests are against both wkid and wkt basemaps

- [x] Make a config file with new schema item in it
- [x] Map Reload warning appears on basemap group headers that are not the current one
- [x] Identify works for feature, file, and dynamic layer types
- [x] Overview map works, can drag-pan
- [x] CSV Layer can be created
- [x] Shapefile Layer can be created
- [x] GeoJSON Layer can be created
- [x] GeoJSON Layer in alternate projection can be created
- [x] Map can reproject to and from wkt type basemaps
- [x] Check the results of the API `centerChanged` observable spits out correct lat-long points
- [x] Check the results of the API `zoomChanged` observable spits out correct level
- [x] API driven identify request works 
- [x] Bounding boxes work, and appear orthogonal.
- [x] Geolocation works
- [x] North arrow works (in particular, test web mercator basemap)
- [x] North pole flag works
- [x] Legacy api `mapCoordinates` function still works
- [x] Mouse co-ords display is working, can output in wkt co-ords
- [x] Location info plugin is working
- [x] Auto-gen thumbnails for Lambert and Mercator basemaps appear in the basemap selector
- [x] API `removeBasemap` is working
- [x] Wizard can still add [WFS](https://geo.weather.gc.ca/geomet/features/collections/ahccd-trends/items?measurement_type__type_mesure=temp_max&period__periode=Jun) and file based layers
- [x] Check results of API map `click` observable have correct points
- [x] API `XY` class `projectToPoint` works
- [x] API `XY` class `projectFromPoint` works
- [x] API `Map` class `setCenter` works
- [x] Point highlighting works
- [x] Polygon highlighting works
- [x] General check that filters still go to and from the grid (e.g. symbol filter, extent filter, grid filter to map)
- [x] Weak test of WMS against wkt. Will likely fail, check that helpful warning appears on console.
- [x] When changing projection, map extent is reasonably preserved
- [x] Legacy api `projectGeometry` function still works
- [x] Layer draw on map in appropriate places

### General Reference Point

![BayCorner](https://user-images.githubusercontent.com/7585245/64810805-12319600-d56a-11e9-9a5e-6b4ae5715745.jpg)
This corner of James and Hudson bays is `[-82.438345, 55.012662]` in lat-long and `[511951, -3856581]` in the Azimuth WKT projection.

Note there can be some difference in calculation between the `proj4` library and the ESRI Projection server when using WKT.

### API Snippets

```text
// center changed test
var mapInstance = RAMP.mapById('sample-map');
mapInstance.centerChanged.subscribe(function (xy) {
    console.log('center changed', xy);
});
```

```text
// zoom changed test
var mapInstance = RAMP.mapById('sample-map');
mapInstance.zoomChanged.subscribe(function (newLevel) {
    console.log('zoom changed', newLevel);
});
```

```text
// api identify test
var mapInstance = RAMP.mapById('sample-map');

// for feature and dynamic
// should return "Developing an appreciation...", "Activating the Energy Transition...", and other plant layer items (differs by projection due to bounding box shape)
var esriXY = new RAMP.GEO.XY(-65.207633, 44.153478);
mapInstance.identify(esriXY);

// for happy.json
// should return Right Eye
var happyXY = new RAMP.GEO.XY(-89.890472, 52.914845);
mapInstance.identify(happyXY);
```

```text
// remove basemap test
var mapInstance = RAMP.mapById('sample-map');

// World Physical Map under Mercator section should disappear
mapInstance.ui.basemaps.removeBasemap('baseEsriPhysical');
```

```text
// click test
var mapInstance = RAMP.mapById('sample-map');
mapInstance.click.subscribe(function (mouseEvent) {
    console.log('i clicked', mouseEvent);
});
```

```text
// XY method tests
var testXY = new RAMP.GEO.XY(-82.438345, 55.012662);

// should output 783268, 739781
console.log('project to lambert test', testXY.projectToPoint(3978));

// should output 514599, -3876531 (511951, -3856581 if using esri server projection engine)
console.log('project to azimuth test', testXY.projectToPoint('PROJCS["Sphere_ARC_INFO_Azimuthal_Equidistant",GEOGCS["GCS_Sphere_ARC_INFO",DATUM["D_Sphere_ARC_INFO",SPHEROID["Sphere_ARC_INFO",6370997.0,0.0]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Azimuthal_Equidistant"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-90.0],PARAMETER["Latitude_Of_Origin",90.0],UNIT["Meter",1.0]]'));

// should output -82.4, 55.0
console.log('project from lambert test', testXY.projectFromPoint(3978, 783268, 739781));

// should output -82.4, 55.0
console.log('project from azimuth test', testXY.projectFromPoint('PROJCS["Sphere_ARC_INFO_Azimuthal_Equidistant",GEOGCS["GCS_Sphere_ARC_INFO",DATUM["D_Sphere_ARC_INFO",SPHEROID["Sphere_ARC_INFO",6370997.0,0.0]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Azimuthal_Equidistant"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-90.0],PARAMETER["Latitude_Of_Origin",90.0],UNIT["Meter",1.0]]', 514599, -3876531));
```

```text
// set center test. zoom in lower so it's clear where the map center is.
var testXY = new RAMP.GEO.XY(-82.438345, 55.012662);
var mapInstance = RAMP.mapById('sample-map');
mapInstance.setCenter(testXY);
```

```text
// legacy tests. needs legacy api script added to run.
// trust me, works a charm.
var mapInstance = RAMP.mapById('sample-map');
var oldMap = RV.getMap('sample-map');

// test map co-ordinates. grab a point from a feature layer. project to 3 different flavours of parameter
// validate results using projection calculator
var featLayer = mapInstance.fgpMapObj._map._layers["fancyplantsFeat"];
var pointy = featLayer.graphics[0].geometry;

var projPointMerc = oldMap.mapCoordinates(pointy, 102100);
var projPointLL = oldMap.mapCoordinates(pointy, {wkid:4326});
var projPointAzimuth = oldMap.mapCoordinates(pointy, 'PROJCS["Sphere_ARC_INFO_Azimuthal_Equidistant",GEOGCS["GCS_Sphere_ARC_INFO",DATUM["D_Sphere_ARC_INFO",SPHEROID["Sphere_ARC_INFO",6370997.0,0.0]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Azimuthal_Equidistant"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-90.0],PARAMETER["Latitude_Of_Origin",90.0],UNIT["Meter",1.0]]');

// test projectGeometry. load happy json and project the eyeball. spot check a point
var happyLayer = mapInstance.fgpMapObj._map._layers["42e60115-1337-4b65-92fc-5ffc34ba63de"]; // guid will likely change, scrape off console after loading happy
var eyeball = happyLayer.graphics[0].geometry;
var projPolyMerc = oldMap.projectGeometry(eyeball, 102100);
var projPolyLL = oldMap.projectGeometry(eyeball, {wkid:4326});
var projPolyAzimuth = oldMap.projectGeometry(eyeball, 'PROJCS["Sphere_ARC_INFO_Azimuthal_Equidistant",GEOGCS["GCS_Sphere_ARC_INFO",DATUM["D_Sphere_ARC_INFO",SPHEROID["Sphere_ARC_INFO",6370997.0,0.0]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Azimuthal_Equidistant"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-90.0],PARAMETER["Latitude_Of_Origin",90.0],UNIT["Meter",1.0]]');
```

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [x] works in IE11
- [x] works in Edge
- [x] works with projection change
- [ ] works with language change
- [x] works via config file
- [x] works via wizard
- [x] works via API
- [ ] works via RCS
- [x] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [x] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [ ] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3748)
<!-- Reviewable:end -->
