### PR TITLE
fix(geosearch): prevent focus from getting stuck in geosearch

### DIFF
--- a/packages/ramp-core/src/app/layout/shell.directive.js
+++ b/packages/ramp-core/src/app/layout/shell.directive.js
@@ -40,6 +40,7 @@ function rvShell($rootElement, events, stateManager, configService, layoutServic
                     api.panels.legend.open();
                 }
                 scope.self.config = config;
+                scope.self.api = api;
             });
         })
 
@@ -73,7 +74,12 @@ function rvShell($rootElement, events, stateManager, configService, layoutServic
 
             if (event.which === 27 && !mdSidePanelOpen) {
                 scope.$apply(() => {
-                    stateManager.closePanelFromHistory();
+                    let panels = scope.self.api.panels.opened;
+
+                    // on press of the escape key, close the most recently opened panel.
+                    if(panels.length > 0) {
+                        panels[0].close();
+                    }
                 });
             } else if (navigationKeys.find(x => x === event.which)) {
                 $rootElement.addClass('rv-keyboard');


### PR DESCRIPTION
## Description
Closes #3784 

Pressing the `esc` key will act in a manner similar to how it did in RAMP 2.5.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [ ] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works
- [ ] the [accessibility guidelines](http://fgpv-vpgf.github.io/fgpv-vpgf/master/#/developer/accessibility_guidelines) have been respected

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3788)
<!-- Reviewable:end -->
