### PR TITLE
fix(enhancedTable): tooltip always shows up when cell text is cut off

### DIFF
--- a/packages/ramp-plugin-enhanced-table/src/panel-manager.ts
+++ b/packages/ramp-plugin-enhanced-table/src/panel-manager.ts
@@ -161,7 +161,8 @@ export class PanelManager {
                     const focusedCell = <HTMLElement>$(`[row-index=${cell.rowIndex}]`).find(`[col-id=${cell.column.colId}]`)[0];
                     const focusedCellText = <HTMLElement>focusedCell.children[0];
 
-                    if (focusedCellText.offsetWidth > focusedCell.offsetWidth) {
+                    // display the tooltip if the width of the text is larger than the cell width (excluding the padding), and it's not a button.
+                    if (focusedCellText.offsetWidth > focusedCell.offsetWidth - 48 && !focusedCellText.classList.contains('md-button')) {
 
                         const positionTooltip = () => {
                             const tooltip = $('.rv-render-tooltip')[0];


### PR DESCRIPTION
## Description
Closes #3775 
Plugins PR: https://github.com/fgpv-vpgf/plugins/pull/150

__Note__: had to re-PR this because I forced pushed 0 commits to the last one 🤦‍♂. You can find the old PR [here](https://github.com/fgpv-vpgf/fgpv-vpgf/pull/3777)

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
http://fgpv-app.azureedge.net/demo/users/RyanCoulsonCA/fix-3775/dev/samples/index-samples.html

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [ ] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [x] datagrid works
- [ ] identify works

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [x] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3789)
<!-- Reviewable:end -->
