### PR TITLE
Update esri api to 3.31

### DIFF
--- a/packages/ramp-core/src/app/core/config.service.js
+++ b/packages/ramp-core/src/app/core/config.service.js
@@ -349,7 +349,7 @@ function configService($q, $rootElement, $http, $translate, events, gapiService,
 
         // load first config, other configs will be loaded as needed
         configList[0].promise.then(config => {
-            let dojoUrl = (location.protocol === 'https:' ? 'https:' : 'http:') + '//js.arcgis.com/3.22/init.js';
+            let dojoUrl = (location.protocol === 'https:' ? 'https:' : 'http:') + '//js.arcgis.com/3.31/init.js';
             // initialize gapi and store a return promise
             if (typeof config.services._esriLibUrl !== 'undefined' && config.services._esriLibUrl !== "") {
                 dojoUrl = config.services._esriLibUrl;

--- a/packages/ramp-core/src/app/global-registry.js
+++ b/packages/ramp-core/src/app/global-registry.js
@@ -4,7 +4,8 @@
  * These are global values defined in the RV registry. They can be overridden by creating a global `RV` object with the same properties __before__ `injector.js` is executed.
  */
 const rvDefaults = {
-    dojoURL: (location.protocol === 'https:' ? 'https:' : 'http:') + '//js.arcgis.com/3.29/init.js'
+    // NOTE is appears this URL def is no longer being used. The `dojoUrl` var in config.service.js is what gets loaded
+    dojoURL: (location.protocol === 'https:' ? 'https:' : 'http:') + '//js.arcgis.com/3.31/init.js'
 };
 
 /**


### PR DESCRIPTION
Updates from 3.22 (for real this time) to 3.31.

Testing the basics like maps load, layers load, layer load indicators turn off appropriately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3793)
<!-- Reviewable:end -->
