### PR TITLE
fix(enhancedTable): change default search mode

### DIFF
--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -828,7 +828,7 @@
                 },
                 "lazyFilter": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Specifies if simple filtering is on. If true, we match any substring of text entered. If false, search field accepts regex expressions. Note: Only effects text fields"
                 },
                 "applyMap": {

--- a/packages/ramp-core/src/app/core/config.class.js
+++ b/packages/ramp-core/src/app/core/config.class.js
@@ -569,7 +569,7 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
             this._description = source.description;
             this._maximize = source.maximize || false;
             this._search = source.search || { enabled: true, value: null };
-            this._lazyFilter = source.lazyFilter || false;
+            this._lazyFilter = source.lazyFilter !== undefined ? source.lazyFilter : true;
             this._showFilter = source.showFilter !== undefined ? source.showFilter : true;
             this._filterByExtent = source.filterByExtent || false;
             this._applyMap = source.applyMap || false;

--- a/packages/ramp-core/src/content/samples/api/legendTests/test-legend-four.json
+++ b/packages/ramp-core/src/content/samples/api/legendTests/test-legend-four.json
@@ -101,7 +101,7 @@
                     "boundingBox": false
                 },
                 "table": {
-                    "lazyFilter": true
+                    "lazyFilter": false
                 },
                 "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
             },

--- a/packages/ramp-core/src/content/samples/api/legendTests/test-legend-three.json
+++ b/packages/ramp-core/src/content/samples/api/legendTests/test-legend-three.json
@@ -128,7 +128,7 @@
                     "boundingBox": false
                 },
                 "table": {
-                    "lazyFilter": true
+                    "lazyFilter": false
                 },
                 "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
             },

--- a/packages/ramp-core/src/content/samples/api/legendTests/test-legend-two.json
+++ b/packages/ramp-core/src/content/samples/api/legendTests/test-legend-two.json
@@ -131,7 +131,7 @@
                     "boundingBox": false
                 },
                 "table": {
-                    "lazyFilter": true
+                    "lazyFilter": false
                 },
                 "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
             },

--- a/packages/ramp-core/src/content/samples/config/config-sample-01.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-01.json
@@ -140,7 +140,7 @@
           "boundingBox": false
         },
         "table": {
-          "lazyFilter": true
+          "lazyFilter": false
         },
         "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
       },

--- a/packages/ramp-core/src/content/samples/config/config-sample-84.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-84.json
@@ -237,7 +237,7 @@
                     "boundingBox": false
                 },
                 "table": {
-                    "lazyFilter": true
+                    "lazyFilter": false
                 },
                 "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
             },

--- a/packages/ramp-core/src/content/samples/config/config-sample-86.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-86.json
@@ -119,7 +119,7 @@
             "boundingBox": false
           },
           "table": {
-            "lazyFilter": true
+            "lazyFilter": false
           },
           "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
         },

--- a/packages/ramp-core/src/content/samples/config/config-sample-87.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-87.json
@@ -149,7 +149,7 @@
           "boundingBox": false
         },
         "table": {
-          "lazyFilter": true
+          "lazyFilter": false
         },
         "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
       },

--- a/packages/ramp-core/src/content/samples/config/config-sample-88.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-88.json
@@ -101,7 +101,7 @@
                     "index": 0,
                     "name": "Keyword search",
                     "table": {
-                        "lazyFilter": true,
+                        "lazyFilter": false,
                         "search": {
                             "enabled": false
                         },
@@ -210,7 +210,7 @@
                             }
                         }
                     ],
-                    "lazyFilter": true
+                    "lazyFilter": false
                 },
                 "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
             }

--- a/packages/ramp-core/src/content/samples/config/config-sample-89.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-89.json
@@ -124,7 +124,7 @@
           "boundingBox": false
         },
         "table": {
-          "lazyFilter": true
+          "lazyFilter": false
         },
         "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
       },

--- a/packages/ramp-core/src/content/samples/plugins/coordinate-info/coordinate-info-config.json
+++ b/packages/ramp-core/src/content/samples/plugins/coordinate-info/coordinate-info-config.json
@@ -113,7 +113,7 @@
                             }
                         }
                     ],
-                    "lazyFilter": true
+                    "lazyFilter": false
                 },
                 "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
             },
@@ -184,7 +184,7 @@
                     "search": {
                         "enabled": false
                     },
-                    "lazyFilter": true,
+                    "lazyFilter": false,
                     "applyMap": true
                 }
             }

--- a/packages/ramp-core/src/content/samples/plugins/enhancedTable/enhanced-table-cam-config.json
+++ b/packages/ramp-core/src/content/samples/plugins/enhancedTable/enhanced-table-cam-config.json
@@ -101,7 +101,7 @@
                 "index": 0,
                 "name": "Keyword search",
                 "table": {
-                    "lazyFilter": true,
+                    "lazyFilter": false,
                     "search": {
                         "enabled": false
                     },
@@ -208,7 +208,7 @@
                         }
                     }
                 ],
-                "lazyFilter": true
+                "lazyFilter": false
             },
             "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
         }],

--- a/packages/ramp-core/src/content/samples/plugins/enhancedTable/enhanced-table-config.json
+++ b/packages/ramp-core/src/content/samples/plugins/enhancedTable/enhanced-table-config.json
@@ -127,7 +127,7 @@
                 "layerType": "esriFeature",
                 "table": {
                     "applyMap": true,
-                    "lazyFilter": true,
+                    "lazyFilter": false,
                     "searchStrictMatch": true,
                     "columns": [{
                         "data": "OBJECTID",
@@ -160,7 +160,7 @@
                             }
                         }
                     ],
-                    "lazyFilter": true
+                    "lazyFilter": false
                 },
                 "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/2"
             },
@@ -229,7 +229,7 @@
                     "search": {
                         "enabled": false
                     },
-                    "lazyFilter": true,
+                    "lazyFilter": false,
                     "applyMap": true,
                     "printEnabled": true
                 }


### PR DESCRIPTION
## Description
Part of #3771 

Changes default filter search mode of grid to lazy. 

## Testing
Flipped the `lazyFilter` value to `false` for all previous config files with it set to `true`, while all configs that did not specify a `lazyFilter` value should default to lazy search mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3795)
<!-- Reviewable:end -->
