### PR TITLE
fix(details): details shows correct attribs when using outfields

### DIFF
--- a/packages/ramp-geoapi/src/attribute.js
+++ b/packages/ramp-geoapi/src/attribute.js
@@ -306,7 +306,6 @@ function loadServerAttribsBuilder(esriBundle, geoApi) {
 
             defService.then(serviceResult => {
                 if (serviceResult && (typeof serviceResult.error === 'undefined')) {
-
                     // properties for all endpoints
                     layerData.layerType = serviceResult.type;
                     layerData.geometryType = serviceResult.geometryType || 'none'; // TODO need to decide what propert default is. Raster Layer has null gt.
@@ -317,7 +316,6 @@ function loadServerAttribsBuilder(esriBundle, geoApi) {
 
                     if (serviceResult.type === 'Feature Layer') {
                         layerData.supportsFeatures = true;
-                        layerData.fields = serviceResult.fields;
                         layerData.nameField = serviceResult.displayField;
 
                         // find object id field
@@ -338,11 +336,19 @@ function loadServerAttribsBuilder(esriBundle, geoApi) {
                                 console.error(`Encountered service with no OID defined: ${layerUrl}`);
                         }
 
-                        // ensure our attribute list contains the object id
+
                         if (attribs !== '*') {
+                            // only add fields specified in outfields to the fields array, if outfields is defined. Converts the attribute to
+                            // uppercase to avoid case-related problems.
+                            const attrs = attribs.toUpperCase().split(',');
+                            layerData.fields = serviceResult.fields.filter(f => attrs.includes(f.name.toUpperCase()));
+
+                            // ensure our attribute list contains the object id
                             if (attribs.split(',').indexOf(layerData.oidField) === -1) {
                                 attribs += (',' + layerData.oidField);
                             }
+                        } else {
+                            layerData.fields = serviceResult.fields;
                         }
 
                         // add renderer and legend


### PR DESCRIPTION
## Description
<!-- Link to an issue or include a description -->
Fixes an issue where the details panel would display all attributes even if `outfields` was defined on the layer.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
You can test this PR using [this sample](http://fgpv-app.azureedge.net/demo/users/RyanCoulsonCA/fix-outfields/dist/samples/index-samples.html?sample=90). Click on one of the `Electric Transmission Line` points on the map. Only the fields defined in `outfields` (`OBJECTID`, `COUNTRY`, `LATITUDE`, and `LONGITUDE`) should appear.

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [ ] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works
- [ ] the [accessibility guidelines](http://fgpv-vpgf.github.io/fgpv-vpgf/master/#/developer/accessibility_guidelines) have been respected

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [x] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [x] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3803)
<!-- Reviewable:end -->
