### PR TITLE
fix(panels): implement open panel history + close in order

### DIFF
--- a/packages/ramp-core/api/src/panel-registry.ts
+++ b/packages/ramp-core/api/src/panel-registry.ts
@@ -10,6 +10,7 @@ import { Subject } from 'rxjs';
 export class PanelRegistry {
     private _mapI: Map;
     private _panels: Panel[] = [];
+    private _openPanels: Panel[] = [];
     private _reopenList: Panel[] = [];
     private _panelOpening = new Subject();
     private _panelClosing = new Subject();
@@ -64,6 +65,18 @@ export class PanelRegistry {
         return this._panels;
     }
 
+    /* Returns the list of Panels that are opened, in the order of which
+     * they were opened.
+     * @return {Panel[]} list of open panels in the order of which they were opened.
+     */
+    get open(): Panel[] {
+        return this._openPanels;
+    }
+
+    /* Returns a list of open panels. The order of the panels in the list do not necessarily
+     * match the order in which they were opened.
+     * @return {Panel[]} list of open panels
+     */
     get opened() {
         return this.all.filter(p => p.isOpen);
     }

--- a/packages/ramp-core/src/app/layout/shell.directive.js
+++ b/packages/ramp-core/src/app/layout/shell.directive.js
@@ -74,11 +74,10 @@ function rvShell($rootElement, events, stateManager, configService, layoutServic
 
             if (event.which === 27 && !mdSidePanelOpen) {
                 scope.$apply(() => {
-                    let panels = scope.self.api.panels.opened;
-
+                    let panels = scope.self.api.panels.open;
                     // on press of the escape key, close the most recently opened panel.
                     if(panels.length > 0) {
-                        panels[0].close();
+                        panels[panels.length - 1].close();
                     }
                 });
             } else if (navigationKeys.find(x => x === event.which)) {


### PR DESCRIPTION
## Description
Adds a panel history array that stores the opened panels in the order they were opened. When pressing Esc, the panels are closed in the opposite order of which they were opened.

## Testing
<!-- Have you added unit tests for this code?  If not explain why. -->
[Test Link](http://fgpv-app.azureedge.net/demo/users/RyanCoulsonCA/fix-panel-history/dist/samples/index-samples.html)

### Checklist
<!-- check all that apply (some items wont apply to all PRs) -->
- [ ] works in IE11
- [ ] works in Edge
- [ ] works with projection change
- [ ] works with language change
- [ ] works via config file
- [ ] works via wizard
- [ ] works via API
- [ ] works via RCS
- [ ] works via bookmark load
- [ ] works in auto-legend
- [ ] works in structured legend
- [ ] works on layer reload
- [ ] datagrid works
- [ ] identify works
- [ ] the [accessibility guidelines](http://fgpv-vpgf.github.io/fgpv-vpgf/master/#/developer/accessibility_guidelines) have been respected

## Documentation
<!-- Which areas of documentation have been changed: jsdoc, tutorials, samples, wiki -->

## Checklist
<!-- Quick checklist for items that are easy to miss -->

- [ ] Commit messages follow [the guidelines](https://github.com/fgpv-vpgf/fgpv-vpgf/blob/master/CONTRIBUTING.md#-git-commit-guidelines)
- [ ] Release notes have been updated
- [ ] PR targets the correct release version
- [ ] Help files and documentation have been updated
- [ ] original issue has been reviewed & updated to reflect the PR content

Remember, it is a *muffin offence* to open a PR with any of the above checklist items incomplete.

Please keep the original issue up to date with the final solution, expected behaviour, and any additional notes for testers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3809)
<!-- Reviewable:end -->
