### PR TITLE
rollback doc links to 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Now that you have the required files on your page we should add the map element.
 
 A map should now load on your page. Theres much more you can do with RAMP, a good place to start (I'm mentioning it again!) is the [map author guide](#map-author-guide)
 
-#### [Some samples](http://fgpv-app.azureedge.net/?prefix=demo/tags/v3.2.0/prod/samples/)
+#### [Some samples](http://fgpv-app.azureedge.net/?prefix=demo/tags/v3.3.0/dist/samples/)
 
 ### Support
 

--- a/packages/ramp-core/README.md
+++ b/packages/ramp-core/README.md
@@ -15,24 +15,24 @@ For more information on this project, please see one of the sections below:
 * [Building the Project](#building-the-project)
 * [Support](#support)
 
-Also, please visit the [Documentation Site](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.3.0/#/home) for additional content on:
+Also, please visit the [Documentation Site](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.2.0/#/home) for additional content on:
 
-* [Map Author Guide](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.3.0/#/mapauthor/intro)
-* [Contributing to the RAMP Project](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.3.0/#/contribute/getting_started)
+* [Map Author Guide](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.2.0/#/mapauthor/intro)
+* [Contributing to the RAMP Project](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.2.0/#/contribute/getting_started)
 * [Interactive Schema Documentation](https://fgpv-vpgf.github.io/schema-to-docs/)
-* [Developer Guide](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.3.0/#/developer/intro)
-* [Technical Documentation](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.3.0/#/technical/architecture)
+* [Developer Guide](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.2.0/#/developer/intro)
+* [Technical Documentation](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.2.0/#/technical/architecture)
 
 ## Usage
 
 ### Quick guide
 
-We'll go through the simplest way to use RAMP, for more information see the [map author guide](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.3.0/#/mapauthor/intro)
+We'll go through the simplest way to use RAMP, for more information see the [map author guide](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.2.0/#/mapauthor/intro)
 
 First, grab the most recent release from the [github releases](https://github.com/fgpv-vpgf/fgpv-vpgf/releases)
 Place the files `rv-main.js` and `rv-styles.css` within your webpage's folder structure. We usually put our JavaScript files under a `js` folder and our stylesheets under a `css` folder.
 
-Then you want to include those files on your page, along with jQuery and the needed polyfills (again, more info at the [map author guide](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.3.0/#/mapauthor/intro)):
+Then you want to include those files on your page, along with jQuery and the needed polyfills (again, more info at the [map author guide](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.2.0/#/mapauthor/intro)):
 1. Within `head`
 ```html
 <link rel="stylesheet" href="../../../rv-styles.css" />
@@ -52,7 +52,7 @@ Now that you have the required files on your page we should add the map element.
 
 A map should now load on your page. Theres much more you can do with RAMP, a good place to start (I'm mentioning it again!) is the [map author guide](#map-author-guide)
 
-### [Some samples](http://fgpv-app.azureedge.net/?prefix=demo/tags/v3.3.0/prod/samples/)
+### [Some samples](http://fgpv-app.azureedge.net/?prefix=demo/tags/v3.3.0/dist/samples/)
 
 ## Building the project
 
@@ -67,7 +67,7 @@ Running a local build:
 3. Run `npm install` to install dependencies
 4. Run `npm run serve` to build and launch a dev server
 
-We use a fork and pull model for contributions, see our [contributing guidelines](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.3.0/#/contribute/getting_started) for more details.
+We use a fork and pull model for contributions, see our [contributing guidelines](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.2.0/#/contribute/getting_started) for more details.
 
 ### Generating Local Builds
 
@@ -135,4 +135,4 @@ Plugins: https://github.com/fgpv-vpgf/plugins
 
 GeoSearch: https://github.com/ramp-pcar/geosearch
 
-If you need help contributing, make sure to give the [contribution docs](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.3.0/#/contribute/getting_started) a read. If you still have questions let us know.
+If you need help contributing, make sure to give the [contribution docs](http://fgpv-vpgf.github.io/fgpv-vpgf/v3.2.0/#/contribute/getting_started) a read. If you still have questions let us know.


### PR DESCRIPTION
3.3 docs are broken, and not much has changed between 3.2 and 3.3.
rolling back readme links for now to avoid 404s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3818)
<!-- Reviewable:end -->
