### PR TITLE
Redo LayerId Observables Params and Identify Race Fix

### DIFF
--- a/packages/ramp-core/package-lock.json
+++ b/packages/ramp-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "RAMP2",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ramp-core",
     "private": true,
-    "version": "3.3.0",
+    "version": "3.3.1",
     "description": "RAMP2 Viewer",
     "repository": "https://github.com/fgpv-vpgf/fgpv-vpgf",
     "license": "MIT",

--- a/packages/ramp-core/src/app/geo/identify.service.js
+++ b/packages/ramp-core/src/app/geo/identify.service.js
@@ -122,7 +122,11 @@ function identifyService($q, configService, gapiService, referenceService, state
                 identifyResults.forEach(idResult => {
                     const featureList = idResult.data || [];
                     featureList.forEach(feat => {
-                        mapClickEvent._featureSubject.next(feat);
+                        mapClickEvent._featureSubject.next({
+                            layerId: idResult.layerId,
+                            layerIdx: idResult.layerIdx,
+                            ...feat
+                        });
                     });
                 });
             });
@@ -144,6 +148,8 @@ function identifyService($q, configService, gapiService, referenceService, state
                 layer: "not yet implemented",
                 event: identifyMouseEvent,
                 sessionId,
+                layerId: r.layerId,
+                layerIdx: r.layerIdx,
                 features: identifyPromise.then(() => r.data)
             }));
 

--- a/packages/ramp-geoapi/src/layer/layerRec/dynamicRecord.js
+++ b/packages/ramp-geoapi/src/layer/layerRec/dynamicRecord.js
@@ -704,6 +704,8 @@ class DynamicRecord extends attribRecord.AttribRecord {
             let childProxy = this.getChildProxy(leafIndex);
             opts.layerDefinitions[leafIndex] = childProxy.filter.getCombinedSql();
             const identifyResult = new shared.IdentifyResult(childProxy);
+            identifyResult.layerId = this.layerId;
+            identifyResult.layerIdx = leafIndex;
             identifyResults[leafIndex] = identifyResult;
         });
 
@@ -754,8 +756,6 @@ class DynamicRecord extends attribRecord.AttribRecord {
                         }
 
                         identifyResult.isLoading = false;
-                        identifyResult.layerId = this.layerId;
-                        identifyResult.layerIdx = ele.layerId;
                     });
                 });
 

--- a/packages/ramp-geoapi/src/layer/layerRec/featureRecord.js
+++ b/packages/ramp-geoapi/src/layer/layerRec/featureRecord.js
@@ -353,6 +353,8 @@ class FeatureRecord extends attribRecord.AttribRecord {
         }
 
         const identifyResult = new shared.IdentifyResult(this.getProxy());
+        identifyResult.layerId = this.layerId;
+        identifyResult.layerIdx = parseInt(this._defaultFC);
         const tolerance = opts.tolerance || this.clickTolerance;
 
         // run a spatial query
@@ -445,8 +447,6 @@ class FeatureRecord extends attribRecord.AttribRecord {
                 });
 
                 identifyResult.isLoading = false;
-                identifyResult.layerId = this.layerId;
-                identifyResult.layerIdx = parseInt(this._defaultFC);
             });
 
         return { identifyResults: [identifyResult], identifyPromise };

--- a/packages/ramp-geoapi/src/layer/layerRec/wmsRecord.js
+++ b/packages/ramp-geoapi/src/layer/layerRec/wmsRecord.js
@@ -125,6 +125,8 @@ class WmsRecord extends layerRecord.LayerRecord {
         }
 
         const identifyResult = new shared.IdentifyResult(this.getProxy());
+        identifyResult.layerId = this.layerId;
+        identifyResult.layerIdx = parseInt(this._defaultFC);
 
         const identifyPromise = this._apiRef.layer.ogc
             .getFeatureInfo(
@@ -134,8 +136,6 @@ class WmsRecord extends layerRecord.LayerRecord {
                 this.config.featureInfoMimeType)
             .then(data => {
                 identifyResult.isLoading = false;
-                identifyResult.layerId = this.layerId;
-                identifyResult.layerIdx = parseInt(this._defaultFC);
 
                 // TODO: check for French service
                 // check if a result is returned by the service. If not, do not add to the array of data


### PR DESCRIPTION
Enhances https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3781

Makes sure the new layer id properties make it onto the objects that get emitted by the observables.

Also found a race condition in the geoApi identify routines where the ids would not appear until after server results, and if slow the observables would emit `undefined` properties.

Easy console testing code (have a map with some layers)

```
var map = RAMP.mapInstances[0];

map.click.subscribe(c => {
     console.log('click result', c);
     c.features.subscribe(featureList => {console.log('features from click', featureList)});
});

map.layers.identify.subscribe(i => { console.log('identify result', i); });
```

[test link](http://fgpv-app.azureedge.net/demo/users/james-rae/layeridRedo/dist/samples/index-samples.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3824)
<!-- Reviewable:end -->
