### PR TITLE
Revert plugin resources to use public names

### DIFF
--- a/packages/ramp-core/api/src/schema.d.ts
+++ b/packages/ramp-core/api/src/schema.d.ts
@@ -712,6 +712,10 @@ export interface TileSchemaNode {
       | "data"
       | "styles"
     )[];
+    /**
+     * Allows Remove menu control on any layer in a structured legend. Caution: may allow users to delete layers and break legend
+     */
+    enableStructuredDelete?: boolean;
     state?: InitialLayerSettings;
     details?: {
       /**
@@ -883,6 +887,10 @@ export interface BasicLayerNode {
     | "data"
     | "styles"
   )[];
+  /**
+   * Allows Remove menu control on any layer in a structured legend. Caution: may allow users to delete layers and break legend
+   */
+  enableStructuredDelete?: boolean;
   state?: InitialLayerSettings;
   details?: {
     /**
@@ -912,6 +920,10 @@ export interface FeatureLayerNode {
    * The field to be used for tooltips.  If it is not present the viewer will use nameField (if provided).
    */
   tooltipField?: string;
+  /**
+   * A comma separated list of attribute names that should be requested on query.
+   */
+  outfields?: string;
   /**
    * The service endpoint of the layer.  It should match the type provided in layerType.
    */
@@ -961,6 +973,10 @@ export interface FeatureLayerNode {
     | "data"
     | "styles"
   )[];
+  /**
+   * Allows Remove menu control on any layer in a structured legend. Caution: may allow users to delete layers and break legend
+   */
+  enableStructuredDelete?: boolean;
   state?: InitialLayerSettings;
   /**
    * Settings for the table
@@ -1412,6 +1428,10 @@ export interface WmsLayerNode {
     | "data"
     | "styles"
   )[];
+  /**
+   * Allows Remove menu control on any layer in a structured legend. Caution: may allow users to delete layers and break legend
+   */
+  enableStructuredDelete?: boolean;
   state?: InitialLayerSettings;
   details?: {
     /**
@@ -1507,6 +1527,10 @@ export interface DynamicLayerNode {
     | "data"
     | "styles"
   )[];
+  /**
+   * Allows Remove menu control on any layer in a structured legend. Caution: may allow users to delete layers and break legend
+   */
+  enableStructuredDelete?: boolean;
   state?: InitialLayerSettings;
   /**
    * The format of the layer image output. It should only be in one of png, png8, png28, png32, jpg, pdf, bmp, gif, svg.  Defaults to png32 if not provided

--- a/packages/ramp-core/docs/mapauthor/migration.md
+++ b/packages/ramp-core/docs/mapauthor/migration.md
@@ -29,7 +29,7 @@ To continue to use the deprecated v2 API you'll need to add a script called **le
 
 ## Plugins
 
-The deprecated v2 API `registerPlugin` function has been removed, so you'll need to perform a few simple changes outlined below if you'd like to continue using the **BackToCart**, **CoorInfo**, or **AreaOfInterest** plugins.
+The deprecated v2 API `registerPlugin` function has been removed, so you'll need to perform a few simple changes outlined below if you'd like to continue using the **BackToCart**, **CoordInfo**, or **AreaOfInterest** plugins.
 
 ### Step 1: Add plugin script to host page header
 

--- a/packages/ramp-core/src/content/samples/plugins/areas-of-interest/aoi-no-pics-config.json
+++ b/packages/ramp-core/src/content/samples/plugins/areas-of-interest/aoi-no-pics-config.json
@@ -518,7 +518,7 @@
         ]
     },
     "plugins": {
-        "AreasOfInterest": {
+        "areasOfInterest": {
             "areas": [
                 {
                     "title-en-CA": "Reservoir Manicougan, Quebec, Canada",

--- a/packages/ramp-core/src/content/samples/plugins/areas-of-interest/aoi-no-pics-index.tpl
+++ b/packages/ramp-core/src/content/samples/plugins/areas-of-interest/aoi-no-pics-index.tpl
@@ -46,7 +46,7 @@
             is="rv-map"
             rv-config="aoi-no-pics-config.json"
             rv-langs='["en-CA", "fr-CA"]'
-            rv-plugins="AreasOfInterest" >
+            rv-plugins="areasOfInterest" >
          <noscript>
             <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
 

--- a/packages/ramp-core/src/content/samples/plugins/areas-of-interest/aoi-pics-config.json
+++ b/packages/ramp-core/src/content/samples/plugins/areas-of-interest/aoi-pics-config.json
@@ -518,7 +518,7 @@
         ]
     },
     "plugins": {
-        "AreasOfInterest": {
+        "areasOfInterest": {
             "areas": [
                 {
                     "title-en-CA": "Reservoir Manicougan, Quebec, Canada",

--- a/packages/ramp-core/src/content/samples/plugins/areas-of-interest/aoi-pics-index.tpl
+++ b/packages/ramp-core/src/content/samples/plugins/areas-of-interest/aoi-pics-index.tpl
@@ -48,7 +48,7 @@
             is="rv-map"
             rv-config="aoi-pics-config.json"
             rv-langs='["en-CA", "fr-CA"]'
-            rv-plugins="AreasOfInterest" >
+            rv-plugins="areasOfInterest" >
          <noscript>
             <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
 

--- a/packages/ramp-core/src/content/samples/plugins/back-to-cart/back-to-cart-index.tpl
+++ b/packages/ramp-core/src/content/samples/plugins/back-to-cart/back-to-cart-index.tpl
@@ -38,7 +38,7 @@
             data-rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/"
             data-rv-keys=""
             data-rv-wait="true"
-            rv-plugins="BackToCart" >
+            rv-plugins="backToCart" >
          <noscript>
             <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
 

--- a/packages/ramp-core/src/content/samples/plugins/coordinate-info/coordinate-info-index.tpl
+++ b/packages/ramp-core/src/content/samples/plugins/coordinate-info/coordinate-info-index.tpl
@@ -33,7 +33,7 @@
             is="rv-map"
             rv-config="coordinate-info-config.json"
             rv-langs='["en-CA", "fr-CA"]'
-            rv-plugins="CoordinateInfo" >
+            rv-plugins="coordInfo" >
          <noscript>
             <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
 

--- a/packages/ramp-plugin-areas-of-interest/src/html-assets.ts
+++ b/packages/ramp-plugin-areas-of-interest/src/html-assets.ts
@@ -5,7 +5,7 @@ export const noPic = `<li class="rv-basemap-list-item" style="height: 50px;">
                             <div style="max-height: 50px; max-width: 350px; text-align: center;">
                                 <button class="rv-body-button rv-button-square md-button" type="button">
                                     <div class="rv-basemap-footer">
-                                        <span style="text-overflow:ellipses; text-transform:none; font-weight:normal">{{ 'plugins.AreasOfInterest.areaTitles.{areaIndex}' | translate }}</span>
+                                        <span style="text-overflow:ellipses; text-transform:none; font-weight:normal">{{ 'plugins.areasOfInterest.areaTitles.{areaIndex}' | translate }}</span>
                                     </div>
                                 </button>
                             </div>
@@ -17,7 +17,7 @@ export const hasPic = `<li class="rv-basemap-list-item" style="height: 175px;">
                                 <div style="max-height:175px; max-width:350px; text-align:center;"><img alt="" src="{imgSrc}"/>
                                 <button class="rv-body-button rv-button-square md-button" type="button">
                                     <div class="rv-basemap-footer">
-                                        <span style="text-overflow:ellipses; text-transform:none; font-weight:normal">{{ 'plugins.AreasOfInterest.areaTitles.{areaIndex}' | translate }}</span>
+                                        <span style="text-overflow:ellipses; text-transform:none; font-weight:normal">{{ 'plugins.areasOfInterest.areaTitles.{areaIndex}' | translate }}</span>
                                     </div>
                                 </button>
                             </div>

--- a/packages/ramp-plugin-areas-of-interest/src/index.ts
+++ b/packages/ramp-plugin-areas-of-interest/src/index.ts
@@ -90,7 +90,7 @@ export default class AreasOfInterest {
         });
 
         let closeBtn = this.panel.header.closeButton;
-        this.panel.header.title = 'plugins.AreasOfInterest.title';
+        this.panel.header.title = 'plugins.areasOfInterest.title';
 
         this.panel.body = bodyElement;
     }

--- a/packages/ramp-plugin-coordinate-info/src/html-assets.ts
+++ b/packages/ramp-plugin-coordinate-info/src/html-assets.ts
@@ -1,47 +1,47 @@
 export const template = `<div tabindex="-2"><ul class="rv-list">
     <li>
-        <strong>{{ 'plugins.CoordinateInfo.coordSection' | translate }}</strong>
+        <strong>{{ 'plugins.coordInfo.coordSection' | translate }}</strong>
         <div class="rv-subsection">
-            <div>{{ 'plugins.CoordinateInfo.coordDecimal' | translate }}</div>
+            <div>{{ 'plugins.coordInfo.coordDecimal' | translate }}</div>
             <div class="rv-subsection">
-            <div>{{ 'plugins.CoordinateInfo.coordLat' | translate }}{pt.y}</div>
-            <div>{{ 'plugins.CoordinateInfo.coordLong' | translate }}{pt.x}</div>
+            <div>{{ 'plugins.coordInfo.coordLat' | translate }}{pt.y}</div>
+            <div>{{ 'plugins.coordInfo.coordLong' | translate }}{pt.x}</div>
             </div>
-            <div>{{ 'plugins.CoordinateInfo.coordDMS' | translate }}</div>
+            <div>{{ 'plugins.coordInfo.coordDMS' | translate }}</div>
             <div class="rv-subsection">
-            <div>{{ 'plugins.CoordinateInfo.coordLat' | translate }}{dms.y}</div>
-            <div>{{ 'plugins.CoordinateInfo.coordLong' | translate}}{dms.x}</div>
+            <div>{{ 'plugins.coordInfo.coordLat' | translate }}{dms.y}</div>
+            <div>{{ 'plugins.coordInfo.coordLong' | translate}}{dms.x}</div>
             </div>
         </div>
     </li>
     <li>
-        <strong>{{ 'plugins.CoordinateInfo.utmSection' | translate }}</strong>
+        <strong>{{ 'plugins.coordInfo.utmSection' | translate }}</strong>
         <div class="rv-subsection">
-            <div>{{ 'plugins.CoordinateInfo.utmZone' | translate }}{zone}</div>
-            <div>{{ 'plugins.CoordinateInfo.utmEast' | translate }}{outPt.x}</div>
-            <div>{{ 'plugins.CoordinateInfo.utmNorth' | translate }}{outPt.y}</div>
+            <div>{{ 'plugins.coordInfo.utmZone' | translate }}{zone}</div>
+            <div>{{ 'plugins.coordInfo.utmEast' | translate }}{outPt.x}</div>
+            <div>{{ 'plugins.coordInfo.utmNorth' | translate }}{outPt.y}</div>
         </div>
     </li>
     <li>
-        <strong>{{ 'plugins.CoordinateInfo.ntsSection' | translate }}</strong>
+        <strong>{{ 'plugins.coordInfo.ntsSection' | translate }}</strong>
         <div class="rv-subsection">
             <div>{nts250}</div>
             <div>{nts50}</div>
         </div>
     </li>
     <li>
-        <strong>{{ 'plugins.CoordinateInfo.altiSection' | translate }}</strong>
+        <strong>{{ 'plugins.coordInfo.altiSection' | translate }}</strong>
         <div class="rv-subsection">{elevation} m</div>
     </li>
     {magSection}
 </ul></div>`;
 
 export const magSection = `<li>
-<strong>{{ 'plugins.CoordinateInfo.magSection' | translate }}</strong>
+<strong>{{ 'plugins.coordInfo.magSection' | translate }}</strong>
 <div class="rv-subsection">
-    <div>{{ 'plugins.CoordinateInfo.magDate' | translate }}{date}</div>
-    <div>{{ 'plugins.CoordinateInfo.magDecli' | translate }}{magnetic}</div>
-    <div>{{ 'plugins.CoordinateInfo.magChange' | translate }}{annChange}</div>
+    <div>{{ 'plugins.coordInfo.magDate' | translate }}{date}</div>
+    <div>{{ 'plugins.coordInfo.magDecli' | translate }}{magnetic}</div>
+    <div>{{ 'plugins.coordInfo.magChange' | translate }}{annChange}</div>
     <div>{compass}</div>
 </div>
 </li>`;

--- a/packages/ramp-plugin-coordinate-info/src/index.ts
+++ b/packages/ramp-plugin-coordinate-info/src/index.ts
@@ -217,7 +217,7 @@ export default class CoordInfo {
             this.panel.element.addClass('mobile-fullscreen');
 
             let closeBtn = this.panel.header.closeButton;
-            this.panel.header.title = `plugins.CoordinateInfo.coordButtonLabel`;
+            this.panel.header.title = `plugins.coordInfo.coordButtonLabel`;
         } else {
             this.panel.close();
         }

--- a/packages/ramp-plugin-custom-export/src/index.ts
+++ b/packages/ramp-plugin-custom-export/src/index.ts
@@ -12,7 +12,7 @@ interface ExportPluginOptions {
 export default class CustomExport {
     feature: string = 'export';
 
-    // A store of the instances of areasOfInterest, 1 per map
+    // A store of the instances of CustomExport, 1 per map
     static instances: { [id: string]: CustomExport } = {};
 
     preInit() {


### PR DESCRIPTION
Reverts resource keys and samples for ramp-supplied plugins.

A change during the migration to monorepo caused the plugin webpack package names to be used as the identifier in some spots.

Closes https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3826

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3827)
<!-- Reviewable:end -->
