### PR TITLE
fix(legend): fix missing tooltip when navigating with tab

### DIFF
--- a/packages/ramp-core/src/app/ui/toc/legend-control.directive.js
+++ b/packages/ramp-core/src/app/ui/toc/legend-control.directive.js
@@ -40,6 +40,7 @@ function rvLegendControl(LegendElementFactory, Geo, LegendBlock, appInfo) {
         templateUrl: (elm, attr) => templateUrl[attr.template || 'button'],
         scope: {
             block: '=',
+            node: '=',
             valueParentBlock: '=',
             name: '@'
         },

--- a/packages/ramp-core/src/app/ui/toc/templates/legend-control-body.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/legend-control-body.html
@@ -5,6 +5,8 @@
     ng-disabled="self.uiControl.isDisabled"
     ng-click="self.uiControl.action(); self.notifyApiClick(self.block)">
 
+    <md-tooltip md-delay="self.node.getTooltipDelay()" md-direction="{{ self.node.getTooltipDirection() }}">{{ self.block.name }}</md-tooltip>
+
     {{ self.uiControl.label | translate }}
 
 </md-button>

--- a/packages/ramp-core/src/app/ui/toc/templates/legend-group.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/legend-group.html
@@ -1,13 +1,12 @@
 <div
     class="rv-list-item-body">
 
-    <md-tooltip md-delay="self.getTooltipDelay()" md-direction="{{ self.getTooltipDirection() }}">{{ self.block.name }}</md-tooltip>
-
     <md-button
         ng-if="!self.isReorder"
         class="rv-body-button rv-button-square"
         ng-click="self.block.expanded = !self.block.expanded"
         aria-label="{{ self.block.expanded ? 'toc.label.group.collapse' : 'toc.label.group.expand' | translate }}">
+        <md-tooltip md-delay="self.getTooltipDelay()" md-direction="{{ self.getTooltipDirection() }}">{{ self.block.name }}</md-tooltip>
     </md-button>
 </div>
 

--- a/packages/ramp-core/src/app/ui/toc/templates/legend-node.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/legend-node.html
@@ -3,9 +3,7 @@
     ng-mouseover="self.block.symbologyStack.fannedOut = true"
     ng-mouseleave="self.block.symbologyStack.fannedOut = false">
 
-    <md-tooltip md-delay="self.getTooltipDelay()" md-direction="{{ self.getTooltipDirection() }}">{{ self.block.name }}</md-tooltip>
-
-    <rv-legend-control block="self.block" template="body" name="data"></rv-legend-control>
+    <rv-legend-control block="self.block" template="body" node="self" name="data"></rv-legend-control>
 </div>
 
 <rv-symbology-stack


### PR DESCRIPTION
## Description
For #3819. There's still a problem with focusing for some layers (see [here](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3819#issuecomment-607343586)).

Fixes a legend problem where the tooltip does not appear when it is focused on using keyboard navigation.

## Testing
[Test Link](http://fgpv-app.azureedge.net/demo/users/RyanCoulsonCA/fix-3819/dist/samples/index-samples.html?sample=1)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3828)
<!-- Reviewable:end -->
