### PR TITLE
Focus fixes

### DIFF
--- a/packages/ramp-core/src/app/focus-manager.js
+++ b/packages/ramp-core/src/app/focus-manager.js
@@ -165,7 +165,7 @@ class Viewer {
      */
     clearTabindex() {
         this.rootElement
-            .find(focusSelector)
+            .find(focusSelector + ', [tabindex=0]')
             .not('.rv-esri-map')
             .not('[tabindex=-2]')
             .not('[tabindex=-3]')
@@ -957,13 +957,13 @@ bodyObserver.observe(document.body, {
 
 /**
  * Fix Firefox behaviour where a focused element which is subsequently hidden is not blurred.
- * 
- * In cases such as the side menu the close button remained focused when the panel was closed. 
+ *
+ * In cases such as the side menu the close button remained focused when the panel was closed.
  * Since this panel has a focus trap, the FM has no where to move focus and the keyboard navigation
  * locks up.
- * 
+ *
  * This fix blurs the active element if its not visible allowing the FM to recover from history.
- * 
+ *
  */
 if (navigator.userAgent.indexOf("Firefox") > -1) {
     $(document).on( "keyup", () => {

--- a/packages/ramp-core/src/app/ui/toc/legend-element-factory.class.js
+++ b/packages/ramp-core/src/app/ui/toc/legend-element-factory.class.js
@@ -12,6 +12,21 @@
  */
 angular.module('app.ui').factory('LegendElementFactory', LegendElementFactory);
 
+/**
+ * Adds a focus manager link between the currently focused element in the legend (data table button, setting button, etc.) and the first
+ * focusable element contained in the provided jQuery selector.
+ *
+ * Keyboard navigation is improved as the next tab press brings them to the action content. #WCAG
+ *
+ * @param { string } selector the jQuery string selector to set as the target link
+ */
+function setLink(selector) {
+    // in case selector is not yet available (async op or animation transition) we use a timeOut.
+    setTimeout(() => {
+        $.link($(selector));
+    }, 500);
+}
+
 // eslint-disable-next-line max-statements
 function LegendElementFactory(
     $translate,
@@ -301,6 +316,7 @@ function LegendElementFactory(
 
         action() {
             tocService.toggleMetadata(this.block);
+            setLink('#sideMetadata');
         }
     }
 
@@ -320,6 +336,7 @@ function LegendElementFactory(
 
         action() {
             tocService.toggleSettings(this.block);
+            setLink('#sideSettings');
         }
     }
 
@@ -418,6 +435,7 @@ function LegendElementFactory(
 
         _debouncedAction = debounceService.registerDebounce(() => {
             tocService.toggleLayerTablePanel(this.block);
+            setLink('#enhancedTable');
         }, 300);
     }
 


### PR DESCRIPTION
- Fixes an issue where focus incorrectly occurred within the map while trying to tab past the map. Elements with attributes `tabindex=0` were not being properly updated by the focus manager. 
- Adds focus links between some legend actions and the corresponding panels/content.
- Tested on chrome/edge/FF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3852)
<!-- Reviewable:end -->
