### PR TITLE
Fixes an issue with FM incorrect pressed key state

### DIFF
--- a/packages/ramp-core/src/app/focus-manager.js
+++ b/packages/ramp-core/src/app/focus-manager.js
@@ -663,6 +663,8 @@ function onKeydown(event) {
         // set viewer inactive but allow tab action to be handled by the browser
         if (event.which === 9 && keys[27]) { // escape + tab keydown
             viewerActive.setStatus(statuses.INACTIVE);
+            // Fixes an issue where keyup is not called in some cases causing focus manager to have an incorrect pressed key state
+            delete keys[27];
 
         } else if (event.which === 9 ||
             ((event.which === 37 || event.which === 39 || event.which === 13) &&


### PR DESCRIPTION
Fixes an issue where in some cases such as focus leaving the document the `keyup` event handler was not being invoked causing the focus manager to have an incorrect depressed key state.

The escape key is manually cleared after an `esc` + `tab` action. `tab` does not need to be cleared manually since it would be cleared by `keyup` on a subsequent `tab` press.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3853)
<!-- Reviewable:end -->
