### PR TITLE
Update WFS query to comply with OGC API - Features spec

### DIFF
--- a/packages/ramp-core/src/app/geo/layer-blueprint.class.ts
+++ b/packages/ramp-core/src/app/geo/layer-blueprint.class.ts
@@ -611,9 +611,8 @@ function LayerBlueprint($http: any, $q: any, Geo: any, gapiService: any, ConfigO
             if (totalCount === -1) {
                 // get the total number of records
                 newQueryMap = {
-                    request: 'GetFeature',
-                    resultType: 'hits',
-                    limit: '0'
+                    f: 'json',
+                    resulttype: 'hits'
                 };
             }
 


### PR DESCRIPTION
Code change for #3857 

This covers the changes in the WFS3 spec now named OGC API - Features. The new query is backwards compatible from my testing. I also tested it in CCCS and layers following the new spec load there as well.

The new layer as mentioned in the issue (internal to ECCC): https://api.wxod-dev.cmc.ec.gc.ca/collections/ltce-stations/items
Old layer to test that its backwards compatible: https://geo.wxod-dev.cmc.ec.gc.ca/geomet/features/collections/hydrometric-stations/items

http://fgpv-app.azureedge.net/demo/users/spencerwahl/ogc-api-features/dist/samples/index-samples.html


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3858)
<!-- Reviewable:end -->
