### PR TITLE
Mobile css fix for Details

### DIFF
--- a/packages/ramp-core/src/content/styles/modules/_details.scss
+++ b/packages/ramp-core/src/content/styles/modules/_details.scss
@@ -8,12 +8,15 @@
     rv-details {
         @include include-size(rv-sm) {
             //position: fixed;
-            position: absolute;
-            left: 0;
             // top: $toolbar-height + 1;
-            top: 0;
-            right: 0;
-            bottom: 0;
+
+            // removing these five, as they were causing details body to cover details header in mobile view
+            // position: absolute;
+            // left: 0;
+            // top: 0;
+            // right: 0;
+            // bottom: 0;
+
             z-index: 3;
         }
     }


### PR DESCRIPTION
Donethankses #3862 

[Demo link](http://fgpv-app.azureedge.net/demo/users/james-rae/css/dist/samples/index-fgp-en.html). Note the normal samples page can't be resized small enough to go to mobile view, but this one can. Just add a layer via the `+` to get some details.

Pls give it a good kicking to test it out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3863)
<!-- Reviewable:end -->
