### PR TITLE
API Layer race condition

### DIFF
--- a/packages/ramp-core/src/app/geo/layer-registry.service.js
+++ b/packages/ramp-core/src/app/geo/layer-registry.service.js
@@ -979,6 +979,18 @@ function layerRegistryFactory(
      * @param {LayerRecord} layerRecord a layer record to use when creating ConfigLayer
      */
     function _createApiLayer(layerRecord) {
+        // there is a race condition where a fast layer can requst the api wrapper
+        // before the mapapi variable has been set. this avoids that.
+        const raceChecker = setInterval(() => {
+            if (mapApi) {
+                clearInterval(raceChecker);
+                _createApiLayerAction(layerRecord);
+            }
+        }, 50);
+    }
+
+    // the guts of _createApiLayer that happen after the race condition is resolved.
+    function _createApiLayerAction(layerRecord) {
         let apiLayer;
         const createdLayers = [];
 


### PR DESCRIPTION
Donethankses https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3864

Puts an interval in front of the code that generates the API layer. Interval spins until the map api variable is populated, avoiding the race condition error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3866)
<!-- Reviewable:end -->
