### PR TITLE
Fix offset point highlighting

### DIFF
--- a/packages/ramp-core/src/app/core/config.service.js
+++ b/packages/ramp-core/src/app/core/config.service.js
@@ -349,7 +349,7 @@ function configService($q, $rootElement, $http, $translate, events, gapiService,
 
         // load first config, other configs will be loaded as needed
         configList[0].promise.then(config => {
-            let dojoUrl = (location.protocol === 'https:' ? 'https:' : 'http:') + '//js.arcgis.com/3.31/init.js';
+            let dojoUrl = (location.protocol === 'https:' ? 'https:' : 'http:') + '//js.arcgis.com/3.35/init.js';
             // initialize gapi and store a return promise
             if (typeof config.services._esriLibUrl !== 'undefined' && config.services._esriLibUrl !== "") {
                 dojoUrl = config.services._esriLibUrl;

--- a/packages/ramp-core/src/app/global-registry.js
+++ b/packages/ramp-core/src/app/global-registry.js
@@ -5,7 +5,7 @@
  */
 const rvDefaults = {
     // NOTE is appears this URL def is no longer being used. The `dojoUrl` var in config.service.js is what gets loaded
-    dojoURL: (location.protocol === 'https:' ? 'https:' : 'http:') + '//js.arcgis.com/3.31/init.js'
+    dojoURL: (location.protocol === 'https:' ? 'https:' : 'http:') + '//js.arcgis.com/3.35/init.js'
 };
 
 /**

--- a/packages/ramp-geoapi/src/layer/layerRec/attribFC.js
+++ b/packages/ramp-geoapi/src/layer/layerRec/attribFC.js
@@ -429,9 +429,17 @@ class AttribFC extends basicFC.BasicFC {
             // attempt to get geometry from fastest source.
             if (gCache[objectId]) {
                 resultFeat.geometry = gCache[objectId];
-            } else if (layerObj.graphics) {
+            } else if (layerObj.graphics && nonPoint) {
                 // it is a feature layer. we can attempt to extract info from it.
                 // but remember the feature may not exist on the client currently
+                // NOTE: sometime after v3.22 of the ESRI API, point layers began showing a degradation
+                //       in accuracy when rendered locally at world-level scales. Unsure why (pixel alignment?)
+                //       but the result meant a point cached at world-level would not be in the correct spot
+                //       when drawn at ground-level.
+                //       Attempted to add an LOD cache for points (similar to lines & polys) but the zoom
+                //       was also impacted; the map would zoom and center on the inaccurate location.
+                //       So we are just not doing local graphic hunting for point layers. Will grab from the server
+                //       and cache that geometry.
                 if (!localGraphic) {
                     // wasn't fetched during attribute section. do it now
                     localGraphic = huntLocalGraphic(objectId);


### PR DESCRIPTION
Donethankses https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3873

- Boosted ESRI API to `v3.35`
- Removed the "take geometry from local layer" optimization for Point-based feature layers. First access will now always get full precision from the server, then use that as the cached value.

[Demo](http://fgpv-app.azureedge.net/demo/users/james-rae/hilight/dist/samples/index-fgp-en.html). To test, add feature layers via the `+` wizard, and attempt to zoom to points from Canada view (via grid zoomies or details zoomies buttons). After zoom, do a minute pan and ensure the layer point remains where the highlight was drawn.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3875)
<!-- Reviewable:end -->
