### PR TITLE
WFS table bug

### DIFF
--- a/packages/ramp-core/api/src/layers.ts
+++ b/packages/ramp-core/api/src/layers.ts
@@ -394,6 +394,12 @@ export class BaseLayer {
 
     /** Removes the attributes with the given key, or all attributes if key is undefined. */
     removeAttributes(attributeKey?: number): void {
+        // If the layer is not ESRI do not delete the attributes.
+        // File based/WFS layers will not reload attributes so deleting them will break the layer.
+        if (this._viewerLayer.dataSource() !== 'esri') {
+            return;
+        }
+
         if (typeof attributeKey !== 'undefined') {
             if (this instanceof ConfigLayer) {
                 console.warn('Single key removal of attributes is not recommended for config layers due to the potential for synchronization issues');


### PR DESCRIPTION
Fixes an issue that showed up on CDV.

WFS and file based layers were having their attributes deleted by a delayed init. This was breaking the layer and causing datatables to not open. It now checks and only deletes attributes from ESRI layers since they can reload attribs.

Thanks @james-rae for the help debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3879)
<!-- Reviewable:end -->
