### PR TITLE
Correct french translation

### DIFF
--- a/packages/ramp-core/src/locales/translations.csv
+++ b/packages/ramp-core/src/locales/translations.csv
@@ -141,7 +141,7 @@ Map Navigation basemap tooltip,nav.tooltip.basemap,Basemap,1,Carte de base,1
 Metadata pane title,metadata.title,Metadata,1,Métadonnées,1
 Metadata pane expand,metadata.expand.tooltip,Expand metadata,1,Agrandir les métadonnées,1
 Hovertip loading text,maptip.hover.label.loading,Loading...,1,Chargement en cours...,1
-,settings.change.at,Change <span class="rv-control-name" translate="settings.label.{{controlName}}"></span> at:,1,Changement {{settingName}} à:,0
+,settings.change.at,Change <span class="rv-control-name" translate="settings.label.{{controlName}}"></span> at:,1,Changement <span class="rv-control-name" translate="settings.label.{{controlName}}"></span> à:,0
 Settings main title,settings.title,Settings,1,Paramètres,1
 Settings visibility header label,settings.label.display,Display,1,Affichage,1
 Settings bounding box visibility label,settings.label.boundingBox,Bounding box,1,Zone de délimitation,1


### PR DESCRIPTION
The French version contains `{{settingName}}` which doesn't print anything to the page. The English version contains a `span` translation element which is dynamically rendered based on the components value for `controlName`. 

Removing the `span` does not change the visible layout. Therefore I've replaced `{{settingName}}` with the working `span` from the English translation. 

## Before update
![Screenshot from 2021-04-26 07-24-51](https://user-images.githubusercontent.com/10187181/116284242-b49f8c80-a741-11eb-9cab-0b27f8399935.png)

## After update
![Screenshot from 2021-04-26 07-23-10](https://user-images.githubusercontent.com/10187181/116284284-c2551200-a741-11eb-8df3-47c809bfb15f.png)

Closes #3886 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3891)
<!-- Reviewable:end -->
