### PR TITLE
Multiple RAMP Instance Fix

### DIFF
--- a/packages/ramp-core/api/src/panel-registry.ts
+++ b/packages/ramp-core/api/src/panel-registry.ts
@@ -54,7 +54,7 @@ export class PanelRegistry {
      * @return {Panel | undefined} the matching panel, or if there is none; `undefined`
      */
     getById(id: string): Panel | undefined {
-        return this._panels.find(panel => panel.id === id);
+        return this._panels.find(panel => panel.id === `${id}-${this._mapI.id}`);
     }
 
     /**
@@ -89,11 +89,14 @@ export class PanelRegistry {
      */
     create(id: string, panelType: PanelTypes = PanelTypes.Panel) {
 
+        const cssClass = id;
+        id += `-${this._mapI.id}`;
+
         if ($(`#${id}`).length >= 1) {
             throw new Error(`API(panels): an element with ID ${id} already exists. A panel ID must be unique to the page.`);
         }
 
-        const panel = new Panel(id, this._mapI, panelType);
+        const panel = new Panel(id, this._mapI, panelType, cssClass);
 
         panel.opening.subscribe(p => {
             this._panelOpening.next(p);

--- a/packages/ramp-core/api/src/panel/index.ts
+++ b/packages/ramp-core/api/src/panel/index.ts
@@ -342,9 +342,9 @@ export class Panel {
      *
      * @param id A unique ID for the panel (and the DOM)
      */
-    private _initElements(id: string): void {
+    private _initElements(id: string, cssClass: string): void {
         this._element = $(document.createElement('div'));
-        this.element.addClass('rv-content-pane layout-padding panel-contents');
+        this.element.addClass(`rv-content-pane layout-padding panel-contents ${cssClass}`);
 
         this._body = $(document.createElement('div'));
         this.body.addClass(['panel-body']);
@@ -443,7 +443,7 @@ export class Panel {
      *
      * @param id - the user defined ID name for this Panel
      */
-    constructor(id: string, api: ViewerAPI, panelType: PanelTypes) {
+    constructor(id: string, api: ViewerAPI, panelType: PanelTypes, cssClass: string = id) {
         this.api = api;
 
         this.appBar = new appBar(this);
@@ -455,7 +455,7 @@ export class Panel {
 
         this._style = {};
         this._initRXJS();
-        this._initElements(id);
+        this._initElements(id, cssClass);
 
         $(window).resize(() => {
             this.offScreenRuleCheck();

--- a/packages/ramp-core/features/table/PanelManager.ts
+++ b/packages/ramp-core/features/table/PanelManager.ts
@@ -6,7 +6,7 @@ import { Panel, PanelTypes } from 'api/panel';
  */
 export class PanelManager extends Panel {
     constructor(table: Table) {
-        super('tblID', table.mapApi, PanelTypes.Panel);
+        super(`tblID-${table.mapApi.id}`, table.mapApi, PanelTypes.Panel, 'tblID');
         this.tableContent = $(`<div></div>`);
         this.element.css({
             top: '0px',

--- a/packages/ramp-core/src/app/ui/loader/loader-menu.directive.js
+++ b/packages/ramp-core/src/app/ui/loader/loader-menu.directive.js
@@ -61,12 +61,12 @@ function Controller(stateManager, appInfo, $timeout, $rootElement) {
 
     function openFileLoader() {
         mApi.panels.fileLoader.open();
-        setFocus('#fileLoader');
+        setFocus(`#${mApi.id} .fileLoader`);
     }
 
     function openServiceLoader() {
         mApi.panels.serviceLoader.open();
-        setFocus('#serviceLoader');
+        setFocus(`#${mApi.id} .serviceLoader`);
     }
 
     /**

--- a/packages/ramp-core/src/app/ui/metadata/metadata.run.js
+++ b/packages/ramp-core/src/app/ui/metadata/metadata.run.js
@@ -47,7 +47,8 @@ function metadataBlock(events) {
         function expandPanel() {
             let panel = mApi.panels.getById('expandMetadata')
             if (panel === undefined) {
-                $('#expandMetadata').remove();
+                // It doesn't look like this line should do anything but it was here so I'm keeping it.
+                $(`#${mApi.id} .expandMetadata`).remove();
                 panel = mApi.panels.create('expandMetadata', 1);
                 const closeButton = panel.header.closeButton;
                 panel.header.title = metadataPanel.header.elements.title[0].innerHTML;

--- a/packages/ramp-core/src/app/ui/toc/legend-element-factory.class.js
+++ b/packages/ramp-core/src/app/ui/toc/legend-element-factory.class.js
@@ -29,6 +29,7 @@ function setLink(selector) {
 
 // eslint-disable-next-line max-statements
 function LegendElementFactory(
+    $rootElement,
     $translate,
     Geo,
     ConfigObject,
@@ -316,7 +317,7 @@ function LegendElementFactory(
 
         action() {
             tocService.toggleMetadata(this.block);
-            setLink('#sideMetadata');
+            setLink(`#${$rootElement[0].id} .sideMetadata`);
         }
     }
 
@@ -336,7 +337,7 @@ function LegendElementFactory(
 
         action() {
             tocService.toggleSettings(this.block);
-            setLink('#sideSettings');
+            setLink(`#${$rootElement[0].id} .sideSettings`);
         }
     }
 
@@ -435,7 +436,7 @@ function LegendElementFactory(
 
         _debouncedAction = debounceService.registerDebounce(() => {
             tocService.toggleLayerTablePanel(this.block);
-            setLink('#enhancedTable');
+            setLink(`#${$rootElement[0].id} .enhancedTable`);
         }, 300);
     }
 

--- a/packages/ramp-core/src/app/ui/toc/toc.service.js
+++ b/packages/ramp-core/src/app/ui/toc/toc.service.js
@@ -270,7 +270,7 @@ function tocService($q, $rootScope, $mdToast, $translate, referenceService, stat
         const undoToast = $mdToast.simple()
             .textContent($translate.instant('toc.label.state.remove'))
             .action($translate.instant('toc.label.action.remove'))
-            .parent($('#mainToc'))
+            .parent($rootElement.find('.mainToc').first())
             .position('bottom rv-flex');
 
         if (showToast) {

--- a/packages/ramp-core/src/content/samples/index-many.tpl
+++ b/packages/ramp-core/src/content/samples/index-many.tpl
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <title>Test Samples - RAMP2 Viewer</title>
+
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;  
+        }
+
+        .myMap {
+            height: 100%;
+            border: 1px black solid;
+        }
+
+        .flexMap {
+            flex: 1;
+        }
+
+        #hideShow {
+            position: absolute;
+            width: 10%;
+            right: 45%;
+            z-index: 100;
+            top: 80px;
+            padding: 0;
+        }
+
+        .row {
+            height: 650px;
+            display: flex;
+        }
+    </style>
+    <script src="./plugins/coordInfo/coordInfo.js"></script>
+
+    <% for (var index in htmlWebpackPlugin.files.css) { %>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+        <% } else { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" />
+        <% } %>
+    <% } %>
+
+</head>
+
+<!-- rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/" rv-keys='["Airports"]' -->
+
+<body>
+    <div class="myMap" id="sample-map" is="rv-map" ramp-gtm
+        rv-config="config/config-sample-01.json"
+        rv-langs='["en-CA", "fr-CA"]'
+        rv-restore-bookmark="bookmark"
+        rv-plugins="coordInfo"
+        rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/">
+         <noscript>
+            <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
+
+            <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
+        </noscript>
+    </div>
+    <div class="row">
+        <div class="myMap flexMap" id="second-map" is="rv-map" ramp-gtm
+            rv-config="config/config-sample-01.json"
+            rv-langs='["en-CA", "fr-CA"]'
+            rv-restore-bookmark="bookmark"
+            rv-plugins="coordInfo"
+            rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/">
+            <noscript>
+                <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
+
+                <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
+            </noscript>
+        </div>
+        <div class="myMap flexMap" id="third-map" is="rv-map" ramp-gtm
+            rv-config="config/config-sample-01.json"
+            rv-langs='["en-CA", "fr-CA"]'
+            rv-restore-bookmark="bookmark"
+            rv-plugins="coordInfo"
+            rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/">
+            <noscript>
+                <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
+
+                <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
+            </noscript>
+        </div>
+    </div>
+
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Object.entries,Object.values,Array.prototype.find,Array.prototype.findIndex,Array.prototype.values,Array.prototype.includes,HTMLCanvasElement.prototype.toBlob,String.prototype.repeat,String.prototype.codePointAt,String.fromCodePoint,NodeList.prototype.@@iterator,Promise,Promise.prototype.finally"></script>
+
+    <% for (var index in htmlWebpackPlugin.files.js) { %>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+        <% } else { %>
+            <script src="<%= htmlWebpackPlugin.files.js[index] %>"></script>
+        <% } %>
+    <% } %>
+</body>
+
+</html>

--- a/packages/ramp-core/src/content/styles/api/panel.scss
+++ b/packages/ramp-core/src/content/styles/api/panel.scss
@@ -37,8 +37,8 @@
     z-index: 1000;
 }
 
-#sideMetadata,
-#sideSettings {
+.sideMetadata,
+.sideSettings {
     .rv-header-controls {
         padding: 0 0 0 0;
 
@@ -86,16 +86,16 @@
     padding: 0 !important;
     margin-left: 0 !important;
     top: 0px;
-    left: 411px;
+    left: 411px !important;
     width: 350px;
 }
 
-#expandMetadata {
+.expandMetadata {
     width: 70%;
     height: 80%;
-    overflow: auto;
-    left: 15%;
-    top: 10%;
+    overflow: auto !important;
+    left: 15% !important;
+    top: 10% !important;
 
     .rv-header {
         padding-left: 10px;

--- a/packages/ramp-core/src/content/styles/modules/_details.scss
+++ b/packages/ramp-core/src/content/styles/modules/_details.scss
@@ -56,8 +56,8 @@
         }
     }
 
-    #mainDetails {
-        top: 49px;
+    .mainDetails {
+        top: 49px !important;
         width: 400px;
 
         @include include-size(rv-sm) {

--- a/packages/ramp-core/src/content/styles/modules/_geosearch.scss
+++ b/packages/ramp-core/src/content/styles/modules/_geosearch.scss
@@ -46,9 +46,9 @@ $result-item-height-touch: rem(4.8);
         }
     }
 
-    #mainGeosearch {
+    .mainGeosearch {
         width: 400px;
-        top: 65px;
+        top: 65px !important;
         opacity: 0;
         box-shadow: none !important;
         bottom: 0;

--- a/packages/ramp-core/src/content/styles/modules/_loader.scss
+++ b/packages/ramp-core/src/content/styles/modules/_loader.scss
@@ -1,11 +1,11 @@
 @mixin loader {
-    #fileLoader, #serviceLoader {
-        top: 49px;
+    .fileLoader, .serviceLoader {
+        top: 49px !important;
         left: 0px;
         width: 400px;
 
         @include include-size(rv-sm) {
-            top: 49px;
+            top: 49px !important;
             left: 0px;
             margin: 0;
             width: 100%;

--- a/packages/ramp-core/src/content/styles/modules/_toc.scss
+++ b/packages/ramp-core/src/content/styles/modules/_toc.scss
@@ -8,8 +8,8 @@ $layer-item-height-touch: rem(7.2);
 
 
 @mixin toc {
-    #mainToc {
-        top: 49px;
+    .mainToc {
+        top: 49px !important;
         left: 0px;
         width: 400px;
 

--- a/packages/ramp-plugin-enhanced-table/src/index.ts
+++ b/packages/ramp-plugin-enhanced-table/src/index.ts
@@ -127,8 +127,8 @@ export default class TableBuilder {
                 this.legendBlock.loadingPanel = undefined;
             }
         }
-        if ($('#enhancedTableLoader') !== undefined) {
-            $('#enhancedTableLoader').remove();
+        if ($(`#${this.mapApi.id} .enhancedTableLoader`) !== undefined) {
+            $(`#${this.mapApi.id} .enhancedTableLoader`).remove();
         }
     }
 

--- a/packages/ramp-plugin-enhanced-table/src/panel-status-manager.ts
+++ b/packages/ramp-plugin-enhanced-table/src/panel-status-manager.ts
@@ -87,6 +87,9 @@ export class PanelStatusManager {
             if ((firstRow === undefined && lastRow === undefined) || topPixel === bottomPixel) {
                 firstRow = 0;
                 lastRow = 0;
+            } else if (firstRow !== undefined && lastRow === undefined) {
+                // This only happens when the table is so small it only shows one row, the calculation above doesn't see the "last" row correctly
+                lastRow = firstRow;
             }
             rowRange = firstRow.toString() + " - " + lastRow.toString();
         }


### PR DESCRIPTION
https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3893

This fixes the long-broken multiple ramp instances on one page. The map ID is now appended to every panel ID to make them unique while also letting multiple ramps have a legend, details, etc.

Styling is now done via classes, as it should be. This may break styling on sites that were using ramp, if people were styling on panel IDs... I'm not sure if that makes this a proper breaking change or not. Versioning can be decided when this is ok to merge.

This needs A LOT of testing, it seems like everythings working to me, but I've almost definitely missed something somewhere. I would recommend this doesn't get merged urgently and has some tinkering done with it before we possibly ruin the main branch.

Some bonus stuff;
- we have an index-many again
- making index-many found a bug where the table wouldn't load if it was too small, that is now fixed