### PR TITLE
fix(coordInfo): update magnetic declination service

### DIFF
--- a/packages/ramp-plugin-coordinate-info/src/html-assets.ts
+++ b/packages/ramp-plugin-coordinate-info/src/html-assets.ts
@@ -42,6 +42,5 @@ export const magSection = `<li>
     <div>{{ 'plugins.coordInfo.magDate' | translate }}{date}</div>
     <div>{{ 'plugins.coordInfo.magDecli' | translate }}{magnetic}</div>
     <div>{{ 'plugins.coordInfo.magChange' | translate }}{annChange}</div>
-    <div>{compass}</div>
 </div>
 </li>`;


### PR DESCRIPTION
Closes #3910. 

This PR replaces the deprecated magnetic declination service with a noaa geomag service: https://www.ngdc.noaa.gov/geomag/calculators/magcalc.shtml#declination 

To test, use [this link](http://ramp4-app.azureedge.net/legacy/users/yileifeng/3910-mag-declin-service/samples/plugins/coordinate-info/coordinate-info-index.html). Turn on the Coords Info on the side bar and then click on different points on the map. The magnetic declination section should display proper values that can be validated with the declination calculator linked above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3929)
<!-- Reviewable:end -->
