### PR TITLE
Add focus ring around interactive elements to improve contrast

### DIFF
--- a/packages/ramp-core/src/content/styles/modules/_buttons.scss
+++ b/packages/ramp-core/src/content/styles/modules/_buttons.scss
@@ -67,6 +67,8 @@
         &.primary {
             @include icon($primary-color);
         }
+
+        @include button-size(rem(4));
     }
 }
 
@@ -120,6 +122,7 @@
                 position: absolute;
                 background: rgba(158, 158, 158, 0.2);
                 border-radius: 50%;
+                box-shadow: inset 0 0 0 1px black !important;
                 @include icon-ripple-shape($size);
             }
         }
@@ -255,6 +258,7 @@
 
     // for plugin button, they do not get md-focused when keyboard focus
     .rv-body-button:focus {
+        box-shadow: inset 0 0 0 1px black !important;
         background: rgba(158, 158, 158, 0.2);
     }
 }

--- a/packages/ramp-core/src/content/styles/modules/_lists.scss
+++ b/packages/ramp-core/src/content/styles/modules/_lists.scss
@@ -104,6 +104,10 @@
             left: 0;
             width: 100%;
             z-index: 1; // this is needed to place the button over the rotating icon as it's creating a new stacking content when transformed
+
+            &:focus {
+                box-shadow: inset 0 0 0 1px black !important;
+            }
         }
 
         .rv-group-name {

--- a/packages/ramp-core/src/content/styles/modules/_mapnav.scss
+++ b/packages/ramp-core/src/content/styles/modules/_mapnav.scss
@@ -59,7 +59,6 @@
 
         rv-mapnav-button {
             display: flex;
-            overflow: hidden;
             width: rem(3.2);
             text-align: center;
 

--- a/packages/ramp-core/src/content/styles/modules/_setting-controls.scss
+++ b/packages/ramp-core/src/content/styles/modules/_setting-controls.scss
@@ -103,6 +103,10 @@
                     padding: 0 rem(0.4);
                     height: rem(2);
 
+                    &.md-focused {
+                        border: 1px solid;
+                    }
+
                     span {
                         text-align: left;
                         width: 250px;
@@ -207,6 +211,11 @@
                     margin: 0;
                     padding: 0 rem(0.4);
                     height: rem(2);
+
+                    &.md-focused {
+                        border: 1px solid;
+                    }
+
                     span {
                         text-align: left;
                         width: 250px;

--- a/packages/ramp-core/src/material/angular-material.scss
+++ b/packages/ramp-core/src/material/angular-material.scss
@@ -6458,6 +6458,12 @@ md-switch {
         }
     }
 
+    &.md-focused {
+        .md-container {
+            box-shadow: inset 0 0 0 1px black !important;
+        }
+    }
+
     .md-container {
         cursor: grab;
         width: $switch-width;
@@ -6519,6 +6525,7 @@ md-switch {
         transform: translate3d(0, 0, 0);
         z-index: 1;
     }
+
     &.md-checked .md-thumb-container {
         transform: translate3d(100%, 0, 0);
     }


### PR DESCRIPTION
Adds a solid border around focused buttons to improve contrast. This border also applies to focused legend items and other interactive information sections such as the help content. 

[Demo](http://ramp4-app.azureedge.net/legacy/users/milespetrov/3916-focus-ring/samples/index-samples.html)
Closes #3916

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3930)
<!-- Reviewable:end -->
