### PR TITLE
fix(legend): layers with stateOnly correctly appear on map

### DIFF
--- a/packages/ramp-core/src/app/geo/legend.service.js
+++ b/packages/ramp-core/src/app/geo/legend.service.js
@@ -579,6 +579,23 @@ function legendServiceFactory(
                 } else {
                     _updateApiReloadedBlock(legendBlockGroup); //update Dynamic Group in the Legend API
                 }
+
+                // Hide each entry from the legend if has `stateOnly` set.
+                legendBlockGroup.entries.forEach(entry => {
+                    let config = entry.proxyWrapper.layerConfig;
+                    entry.hidden = config.stateOnly ? config.stateOnly : false;
+                });
+
+                let isStateOnly = (entry) => {
+                    return entry.proxyWrapper.layerConfig.stateOnly;
+                }
+
+                // If all entries have `stateOnly` set, then hide the entire group
+                // from the legend.
+                if(legendBlockGroup.entries.every(isStateOnly)) {
+                    legendBlockGroup.hidden = true;
+                }
+
                 legendBlockGroup.synchronizeControlledEntries();
             });
 

--- a/packages/ramp-core/src/content/samples/config/config-sample-93.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-93.json
@@ -1,0 +1,485 @@
+{
+    "ui": {
+      "navBar": {
+        "zoom": "buttons",
+        "extra": [
+          "fullscreen",
+          "geoLocator",
+          "home",
+          "help"
+        ]
+      },
+      "sideMenu": {
+        "logo": true
+      },
+      "legend": {
+        "isOpen": {
+          "large": true,
+          "medium": true,
+          "small": false
+        }
+      }
+    },
+    "version": "2.0",
+    "language": "en",
+    "services": {
+      "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+      "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+      "export": {
+        "title": {
+          "value": "Title"
+        },
+        "map": {},
+        "mapElements": {},
+        "legend": {},
+        "footnote": {
+          "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+        }
+      },
+      "search": {
+        "serviceUrls": {
+          "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
+          "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
+          "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+          "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
+          "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+        }
+      }
+    },
+    "map": {
+      "initialBasemapId": "baseNrCan",
+      "components": {
+        "geoSearch": {
+          "enabled": true,
+          "showGraphic": true,
+          "showInfo": true
+        },
+        "mouseInfo": {
+          "enabled": true,
+          "spatialReference": {
+            "wkid": 102100
+          }
+        },
+        "northArrow": {
+          "enabled": true
+        },
+        "basemap": {
+          "enabled": true
+        },
+        "overviewMap": {
+          "enabled": true,
+          "layerType": "imagery"
+        },
+        "scaleBar": {
+          "enabled": true
+        }
+      },
+      "legend": {
+        "type": "structured",
+        "root": {
+          "name": "root",
+          "children": [{
+              "layerId": "somepowerplants",
+              "symbologyExpanded": false
+            },
+            {
+              "layerId": "onepowerplant",
+              "symbologyExpanded": false
+            }
+          ]
+        }
+      },
+      "layers": [{
+          "id": "somepowerplants",
+          "name": "Power Plants Proper Subset",
+          "layerType": "esriDynamic",
+          "layerEntries": [{
+              "index": 17
+            },
+            {
+              "index": 19
+            },
+            {
+              "index": 21, "stateOnly": true
+            }
+          ],
+          "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer"
+        },
+        {
+          "id": "onepowerplant",
+          "name": "Power Plant",
+          "layerType": "esriDynamic",
+          "layerEntries": [{
+            "index": 20, "stateOnly": true
+          }],
+          "singleEntryCollapse": true,
+          "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer"
+        }
+      ],
+      "extentSets": [{
+          "id": "EXT_NRCAN_Lambert_3978",
+          "default": {
+            "xmax": 3549492,
+            "xmin": -2681457,
+            "ymax": 3482193,
+            "ymin": -883440
+          },
+          "spatialReference": {
+            "wkid": 3978
+          }
+        },
+        {
+          "id": "EXT_ESRI_World_AuxMerc_3857",
+          "default": {
+            "xmax": -5007771.626060756,
+            "xmin": -16632697.354854,
+            "ymax": 10015875.184845109,
+            "ymin": 5022907.964742964
+          },
+          "spatialReference": {
+            "wkid": 102100,
+            "latestWkid": 3857
+          }
+        }
+      ],
+      "lodSets": [{
+          "id": "LOD_NRCAN_Lambert_3978",
+          "lods": [{
+              "level": 0,
+              "resolution": 38364.660062653464,
+              "scale": 145000000
+            },
+            {
+              "level": 1,
+              "resolution": 22489.62831258996,
+              "scale": 85000000
+            },
+            {
+              "level": 2,
+              "resolution": 13229.193125052918,
+              "scale": 50000000
+            },
+            {
+              "level": 3,
+              "resolution": 7937.5158750317505,
+              "scale": 30000000
+            },
+            {
+              "level": 4,
+              "resolution": 4630.2175937685215,
+              "scale": 17500000
+            },
+            {
+              "level": 5,
+              "resolution": 2645.8386250105837,
+              "scale": 10000000
+            },
+            {
+              "level": 6,
+              "resolution": 1587.5031750063501,
+              "scale": 6000000
+            },
+            {
+              "level": 7,
+              "resolution": 926.0435187537042,
+              "scale": 3500000
+            },
+            {
+              "level": 8,
+              "resolution": 529.1677250021168,
+              "scale": 2000000
+            },
+            {
+              "level": 9,
+              "resolution": 317.50063500127004,
+              "scale": 1200000
+            },
+            {
+              "level": 10,
+              "resolution": 185.20870375074085,
+              "scale": 700000
+            },
+            {
+              "level": 11,
+              "resolution": 111.12522225044451,
+              "scale": 420000
+            },
+            {
+              "level": 12,
+              "resolution": 66.1459656252646,
+              "scale": 250000
+            },
+            {
+              "level": 13,
+              "resolution": 38.36466006265346,
+              "scale": 145000
+            },
+            {
+              "level": 14,
+              "resolution": 22.48962831258996,
+              "scale": 85000
+            },
+            {
+              "level": 15,
+              "resolution": 13.229193125052918,
+              "scale": 50000
+            },
+            {
+              "level": 16,
+              "resolution": 7.9375158750317505,
+              "scale": 30000
+            },
+            {
+              "level": 17,
+              "resolution": 4.6302175937685215,
+              "scale": 17500
+            }
+          ]
+        },
+        {
+          "id": "LOD_ESRI_World_AuxMerc_3857",
+          "lods": [{
+              "level": 0,
+              "resolution": 19567.87924099992,
+              "scale": 73957190.948944
+            },
+            {
+              "level": 1,
+              "resolution": 9783.93962049996,
+              "scale": 36978595.474472
+            },
+            {
+              "level": 2,
+              "resolution": 4891.96981024998,
+              "scale": 18489297.737236
+            },
+            {
+              "level": 3,
+              "resolution": 2445.98490512499,
+              "scale": 9244648.868618
+            },
+            {
+              "level": 4,
+              "resolution": 1222.992452562495,
+              "scale": 4622324.434309
+            },
+            {
+              "level": 5,
+              "resolution": 611.4962262813797,
+              "scale": 2311162.217155
+            },
+            {
+              "level": 6,
+              "resolution": 305.74811314055756,
+              "scale": 1155581.108577
+            },
+            {
+              "level": 7,
+              "resolution": 152.87405657041106,
+              "scale": 577790.554289
+            },
+            {
+              "level": 8,
+              "resolution": 76.43702828507324,
+              "scale": 288895.277144
+            },
+            {
+              "level": 9,
+              "resolution": 38.21851414253662,
+              "scale": 144447.638572
+            },
+            {
+              "level": 10,
+              "resolution": 19.10925707126831,
+              "scale": 72223.819286
+            },
+            {
+              "level": 11,
+              "resolution": 9.554628535634155,
+              "scale": 36111.909643
+            },
+            {
+              "level": 12,
+              "resolution": 4.77731426794937,
+              "scale": 18055.954822
+            },
+            {
+              "level": 13,
+              "resolution": 2.388657133974685,
+              "scale": 9027.977411
+            },
+            {
+              "level": 14,
+              "resolution": 1.1943285668550503,
+              "scale": 4513.988705
+            },
+            {
+              "level": 15,
+              "resolution": 0.5971642835598172,
+              "scale": 2256.994353
+            },
+            {
+              "level": 16,
+              "resolution": 0.29858214164761665,
+              "scale": 1128.497176
+            },
+            {
+              "level": 17,
+              "resolution": 0.14929107082380833,
+              "scale": 564.248588
+            },
+            {
+              "level": 18,
+              "resolution": 0.07464553541190416,
+              "scale": 282.124294
+            },
+            {
+              "level": 19,
+              "resolution": 0.03732276770595208,
+              "scale": 141.062147
+            },
+            {
+              "level": 20,
+              "resolution": 0.01866138385297604,
+              "scale": 70.5310735
+            }
+          ]
+        }
+      ],
+      "tileSchemas": [{
+          "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+          "name": "Lambert Maps",
+          "extentSetId": "EXT_NRCAN_Lambert_3978",
+          "lodSetId": "LOD_NRCAN_Lambert_3978",
+          "hasNorthPole": true
+        },
+        {
+          "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+          "name": "Web Mercator Maps",
+          "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+          "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+        }
+      ],
+      "baseMaps": [{
+          "id": "baseNrCan",
+          "name": "Canada Base Map - Transportation (CBMT)",
+          "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+          "altText": "altText - The Canada Base Map - Transportation (CBMT)",
+          "layers": [{
+            "id": "CBMT",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
+          }],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseSimple",
+          "name": "Canada Base Map - Simple",
+          "description": "Canada Base Map - Simple",
+          "altText": "altText - Canada base map - Simple",
+          "layers": [{
+            "id": "SMR",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer"
+          }],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseCBME_CBCE_HS_RO_3978",
+          "name": "Canada Base Map - Elevation (CBME)",
+          "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+          "altText": "altText - Canada Base Map - Elevation (CBME)",
+          "layers": [{
+            "id": "CBME_CBCE_HS_RO_3978",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+          }],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseCBMT_CBCT_GEOM_3978",
+          "name": "Canada Base Map - Transportation (CBMT)",
+          "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+          "altText": "altText - Canada Base Map - Transportation (CBMT)",
+          "layers": [{
+            "id": "CBMT_CBCT_GEOM_3978",
+            "layerType": "esriFeature",
+            "url": "http://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+          }],
+          "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+        },
+        {
+          "id": "baseEsriWorld",
+          "name": "World Imagery",
+          "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+          "altText": "altText - World Imagery",
+          "layers": [{
+            "id": "World_Imagery",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+          }],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriPhysical",
+          "name": "World Physical Map",
+          "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+          "altText": "altText - World Physical Map",
+          "layers": [{
+            "id": "World_Physical_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+          }],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriRelief",
+          "name": "World Shaded Relief",
+          "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+          "altText": "altText - World Shaded Relief",
+          "layers": [{
+            "id": "World_Shaded_Relief",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+          }],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriStreet",
+          "name": "World Street Map",
+          "description": "This worldwide street map presents highway-level data for the world.",
+          "altText": "altText - ESWorld Street Map",
+          "layers": [{
+            "id": "World_Street_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+          }],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriTerrain",
+          "name": "World Terrain Base",
+          "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+          "altText": "altText - World Terrain Base",
+          "layers": [{
+            "id": "World_Terrain_Base",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+          }],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        },
+        {
+          "id": "baseEsriTopo",
+          "name": "World Topographic Map",
+          "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+          "altText": "altText - World Topographic Map",
+          "layers": [{
+            "id": "World_Topo_Map",
+            "layerType": "esriFeature",
+            "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+          }],
+          "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+        }
+      ]
+    }
+  }

--- a/packages/ramp-core/src/content/samples/index-samples.tpl
+++ b/packages/ramp-core/src/content/samples/index-samples.tpl
@@ -190,6 +190,7 @@
                 <option value="config/config-sample-90.json">90. Layer with custom field alias + outfields on feature layers</option>
                 <option value="config/config-sample-91.json">91. Custom Symbology Stacks</option>
                 <option value="config/config-sample-92.json">92. Third Basemap Schema using WKT</option>
+                <option value="config/config-sample-93.json">93. Dynamic Layer with 'stateOnly' set to true</option>
             </select>
         </div>
 

--- a/packages/ramp-geoapi/src/layer/layerRec/dynamicRecord.js
+++ b/packages/ramp-geoapi/src/layer/layerRec/dynamicRecord.js
@@ -326,9 +326,7 @@ class DynamicRecord extends attribRecord.AttribRecord {
         // process the child layers our config is interested in, and all their children.
         if (this.config.layerEntries) {
             this.config.layerEntries.forEach(le => {
-                if (!le.stateOnly) {
-                    processLayerInfo(this._layer.layerInfos.find(li => li.id === le.index), this._childTree);
-                }
+                processLayerInfo(this._layer.layerInfos.find(li => li.id === le.index), this._childTree);
             });
         }
 


### PR DESCRIPTION
Closes #3908 

Dynamic Layers with `stateOnly` set to true should now properly be displayed on the map, while not being displayed in the legend. If every child has `stateOnly` set to true, the entire group will not be displayed on the legend.

This PR adds a new sample page that contains a dynamic layer with `stateOnly` set to true on all children (the icon with the water droplets on it), and a dynamic layer with `stateOnly` set to true on one of its children (the blue circle with a flame in it).

You can test this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3908/samples/index-samples.html?sample=93).