### PR TITLE
fix(details): fix semantic structure of key-value pairs

### DIFF
--- a/packages/ramp-core/src/app/ui/details/details-record-esrifeature-item.html
+++ b/packages/ramp-core/src/app/ui/details/details-record-esrifeature-item.html
@@ -6,9 +6,9 @@
 
     <rv-symbology-stack symbology="self.item.symbologyStack"></rv-symbology-stack>
 
-    <span class="rv-group-name">
+    <h4 class="rv-group-name">
         {{ self.item.name }}
-    </span>
+    </h4>
 
     <div class="rv-group-controls">
 
@@ -35,31 +35,31 @@
 <div class="rv-details-list template-mount" ng-show="self.isExpanded" ng-if="self.details.template"></div>
 
 <div class="rv-details-list-wrapper" ng-if="self.isRendered && !self.details.template">
-    <ul class="rv-details-list rv-toggle-slide ng-hide" ng-show="self.isExpanded">
+    <dl class="rv-details-list rv-toggle-slide ng-hide" ng-show="self.isExpanded">
 
-        <li rv-lightbox ng-repeat="row in self.item.data" ng-switch on="row.type">
-            <div class="rv-details-attrib-key">{{ ::row.key }}</div>
+        <div rv-lightbox ng-repeat="row in self.item.data" ng-switch on="row.type">
+            <dt class="rv-details-attrib-key">{{ ::row.key }}</dt>
             <span flex></span>
 
             <!-- temporary fix for the wfs broken links by extracting href + title from object and formatting into a list -->
-            <ul class="rv-details-links-list" ng-if="row.listOfLinks">
-                <li class="rv-details-links-list-item" rv-lightbox ng-repeat="hlink in row.value">
+            <dl class="rv-details-links-list" ng-if="row.listOfLinks">
+                <div class="rv-details-links-list-item" rv-lightbox ng-repeat="hlink in row.value">
                     <a class="rv-wfs-details-hlink" href="{{ ::hlink.href }}" target="_blank">{{ ::hlink.title }}</a>
                     <span flex></span>
 
-                    <div class="rv-details-attrib-value" ng-switch-when="esriFieldTypeDate"
-                        ng-bind-html="::hlink.title | dateTimeZone"></div>
-                    <div class="rv-details-attrib-value" ng-switch-default
-                        ng-bind-html="::hlink.title | picture | autolink"></div>
-                </li>
-            </ul>
+                    <dd class="rv-details-attrib-value" ng-switch-when="esriFieldTypeDate"
+                        ng-bind-html="::hlink.title | dateTimeZone"></dd>
+                    <dd class="rv-details-attrib-value" ng-switch-default
+                        ng-bind-html="::hlink.title | picture | autolink"></dd>
+                </div>
+            </dl>
 
-            <div class="rv-details-attrib-value" ng-if="!row.listOfLinks" ng-switch-when="esriFieldTypeDate"
-                ng-bind-html="::row.value | dateTimeZone"></div>
-            <div class="rv-details-attrib-value" ng-if="!row.listOfLinks" ng-switch-default
-                ng-bind-html="::row.value | picture | autolink"></div>
-        </li>
-    </ul>
+            <dd class="rv-details-attrib-value" ng-if="!row.listOfLinks" ng-switch-when="esriFieldTypeDate"
+                ng-bind-html="::row.value | dateTimeZone"></dd>
+            <dd class="rv-details-attrib-value" ng-if="!row.listOfLinks" ng-switch-default
+                ng-bind-html="::row.value | picture | autolink"></dd>
+        </div>
+    </dl>
 </div>
 
 <div class="rv-shadow"></div>

--- a/packages/ramp-core/src/content/samples/config/config-sample-66.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-66.json
@@ -163,7 +163,7 @@
         "name": "Hydrometric Stations - Start with 6000th index",
         "layerType": "ogcWfs",
         "nameField": "STATION_NAME",
-        "url": "http://geo.wxod-dev.cmc.ec.gc.ca/geomet/features/collections/hydrometric-stations/items?startindex=6000",
+        "url": "https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=6000",
         "colour": "#FF0000"
       },
       {
@@ -171,7 +171,7 @@
         "name": "Hydrometric Stations - All features",
         "layerType": "ogcWfs",
         "nameField": "STATION_NAME",
-        "url": "http://geo.wxod-dev.cmc.ec.gc.ca/geomet/features/collections/hydrometric-stations/items",
+        "url": "https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items",
         "colour": "#00FF00"
       }
     ],

--- a/packages/ramp-core/src/content/styles/modules/_details.scss
+++ b/packages/ramp-core/src/content/styles/modules/_details.scss
@@ -287,7 +287,7 @@ $details-record-height: rem(6);
                 padding: rem(0.8) rem(1.6);
                 border-bottom: 1px solid $divider-color-light;
 
-                li {
+                div {
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: flex-end; // forces the key value to move the rigth of the container; key name is pushed to the left by the flexed span

--- a/packages/ramp-core/src/content/styles/modules/_lists.scss
+++ b/packages/ramp-core/src/content/styles/modules/_lists.scss
@@ -65,12 +65,12 @@
     %zebra-list {
         @extend %base-list;
 
-        > li {
+        > div {
             padding: rem(0.5);
             overflow: auto;
         }
 
-        > li:nth-child(even) {
+        > div:nth-child(even) {
             background-color: #ddd;
         }
     }


### PR DESCRIPTION
Closes #3914 

Changes the HTML structure of key-value pairs in the details panel to use `<dl>`, `<dt>`, and `<dd>` tags. Additionally, the feature title is surrounded by `<h4>` tags.

A demo link can be found [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3914/samples/index-samples.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3933)
<!-- Reviewable:end -->
