### PR TITLE
feat(map): pressing CTRL key allows for a more granular pan of map

### DIFF
--- a/packages/ramp-core/src/app/geo/init-map.directive.js
+++ b/packages/ramp-core/src/app/geo/init-map.directive.js
@@ -253,7 +253,7 @@ function rvInitMap(
 
         let x = 0;
         let y = 0;
-        let hasShiftMultiplier = 1;
+        let movementMultiplier = 1;
         for (let i = 0; i < keyMap.length; i++) {
             switch (keyMap[i]) {
                 // enter key is pressed - trigger identify
@@ -268,7 +268,11 @@ function rvInitMap(
                     break;
                 // shift key pressed - pan distance increased
                 case keyNames.SHIFT:
-                    hasShiftMultiplier = 2;
+                    movementMultiplier = 2;
+                    break;
+                // ctrl key pressed - pan distance decreased
+                case keyNames.CTRL:
+                    movementMultiplier = 0.25;
                     break;
                 // left arrow key pressed
                 case keyNames.LEFT_ARROW:
@@ -310,8 +314,8 @@ function rvInitMap(
         // result in x = 0 so no animation is run)
         if (x !== 0 || y !== 0) {
             animationInterval = $interval(() => {
-                mapPntCntr.x += hasShiftMultiplier * x;
-                mapPntCntr.y += hasShiftMultiplier * y;
+                mapPntCntr.x += movementMultiplier * x;
+                mapPntCntr.y += movementMultiplier * y;
                 mapInstance.centerAt(mapPntCntr);
                 events.$broadcast(events.rvKeyboardMove, mapPntCntr);
             }, 40);

--- a/packages/ramp-core/src/locales/help/default/en-CA.md
+++ b/packages/ramp-core/src/locales/help/default/en-CA.md
@@ -15,6 +15,8 @@ The following navigation controls can be found in the bottom right corner of the
 
 You can also pan the map by using your left, right, up and down arrow keys, or by click-holding on the map and dragging. Using the mouse scroll wheel while hovering over the map will zoom the map in/out.
 
+If you are panning the map using arrow keys, you can press SHIFT or CTRL to pan the map faster or slower (respectively).
+
 Note that the map __must be__ focused for key binding to work. The map has focus when there is a blue border around it.
 
 

--- a/packages/ramp-core/src/locales/help/default/fr-CA.md
+++ b/packages/ramp-core/src/locales/help/default/fr-CA.md
@@ -15,6 +15,8 @@ Les commandes de navigation suivantes se trouvent dans le coin inférieur droit 
 
 Vous pouvez également parcourir la carte en utilisant les touches fléchées gauche, droite, haut et bas ou en cliquant sur la carte et en la faisant glisser. L'utilisation de la molette de la souris zoomera la carte en avant ou en arrière.
 
+Si vous êtes panoramique de la carte en utilisant les touches fléchées, vous pouvez appuyer sur « SHIFT » ou « CTRL » pour déplacer la carte plus rapidement ou plus lentement, respectivement.
+
 Notez que la carte doit être la zone active (avoir le « focus ») pour que les touches clavier fonctionnent. La carte devient la zone active lorsqu'il y a une bordure bleue autour d'elle.
 
 


### PR DESCRIPTION
Closes #3917 

This PR adds the ability to pan the map in a more granular manner by holding the `CTRL` key whilst using the arrow keys. The original issue also requests for a button to speed up panning, but this already exists by holding the `CTRL` key. 

I've added a new line to the help page that mentions this feature.

A demo for this PR can be found [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3917/samples/index-samples.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3935)
<!-- Reviewable:end -->
