### PR TITLE
feat(enhancedTable): add a toggle all button for column visibility

### DIFF
--- a/packages/ramp-plugin-enhanced-table/src/index.ts
+++ b/packages/ramp-plugin-enhanced-table/src/index.ts
@@ -434,6 +434,7 @@ TableBuilder.prototype.translations = {
                 apply: 'Apply filters to map',
             },
             hideColumns: 'Hide columns',
+            hideAllColumns: 'All',
             complexValue: 'Complex Value',
         },
         menu: {
@@ -479,6 +480,7 @@ TableBuilder.prototype.translations = {
                 apply: 'Appliquer des filtres à la carte', // TODO: Add official French translation
             },
             hideColumns: 'Masquer les colonnes', // TODO: Add Official French translation
+            hideAllColumns: 'Tous les',
             complexValue: 'Valeur Complexes',
         },
         menu: {

--- a/packages/ramp-plugin-enhanced-table/src/panel-manager.ts
+++ b/packages/ramp-plugin-enhanced-table/src/panel-manager.ts
@@ -863,6 +863,24 @@ export class PanelManager {
                 // fit columns widths to table if there's empty space
                 that.sizeColumnsToFitIfNeeded();
             };
+
+            // Determine whether any columns are hidden.
+            this.allColumnsVisible = function () {
+                return this.columnVisibilities.some((col) => !col.visibility);
+            };
+
+            // toggle visibility for all entries
+            this.toggleAllColumns = function () {
+                // If any columns are not visible, then clicking the button should turn them on. If all columns are
+                // visible, then clicking the button should turn them all off.
+                const allVisible = this.allColumnsVisible();
+
+                this.columnVisibilities
+                    .filter((col) => col.visibility === !allVisible)
+                    .forEach((col) => {
+                        this.toggleColumn(col);
+                    });
+            };
         });
 
         this.mapApi.agControllerRegister('MobileMenuCtrl', function () {

--- a/packages/ramp-plugin-enhanced-table/src/templates.ts
+++ b/packages/ramp-plugin-enhanced-table/src/templates.ts
@@ -54,6 +54,15 @@ export const COLUMN_VISIBILITY_MENU_TEMPLATE = `
             <md-icon md-svg-src="community:format-list-checks"></md-icon>
         </md-button>
         <md-menu-content class="rv-menu rv-dense">
+            <md-menu-item>
+                <md-button
+                    ng-click="ctrl.toggleAllColumns()"
+                    aria-label="{{ 'plugins.enhancedTable.table.hideAllColumns' | translate }}"
+                    md-prevent-menu-close="md-prevent-menu-close">
+                    <span style='flex-basis: auto; overflow-wrap:normal;'>{{ 'plugins.enhancedTable.table.hideAllColumns' | translate }}</span>
+                    <md-icon md-svg-icon="action:done" ng-if="!ctrl.allColumnsVisible()"></md-icon>
+                </md-button>
+            </md-menu-item>
             <md-menu-item ng-repeat="col in ctrl.columnVisibilities">
                 <md-button ng-click="ctrl.toggleColumn(col)" aria-label="{{ col.title }}" md-prevent-menu-close="md-prevent-menu-close">
                     <span style='flex-basis: auto; overflow-wrap:normal;'>{{col.title}}</span>


### PR DESCRIPTION
Closes #3821 

This PR adds a new `hide all` button to the `Hide columns` panel in the table.

If all columns are visible, clicking this button will hide all of the columns. If some columns are hidden, then clicking this button will make the hidden columns visible.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3821/samples/index-samples.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3936)
<!-- Reviewable:end -->
