### PR TITLE
feat(toc): add dynamic layer support for tableIsOpen

### DIFF
--- a/packages/ramp-core/api/src/schema.d.ts
+++ b/packages/ramp-core/api/src/schema.d.ts
@@ -204,6 +204,10 @@ export interface FgpvConfigSchema {
              */
             id: string;
             /**
+             * If the layer is a dynamic layer, specify the index of the sublayer to open.
+             */
+            dynamicIndex?: string;
+            /**
              * Whether the table panel is opened by default on initial loading of the map for large viewports
              */
             large?: boolean;

--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -2081,6 +2081,10 @@
                             "type": "string",
                             "description": "The id of the layer for referencing within the viewer"
                         },
+                        "dynamicIndex": {
+                            "type": "string",
+                            "description": "If the layer is a dynamic layer, specify the index of the sublayer to open."
+                        },
                         "large": {
                             "type": "boolean",
                             "default": false,

--- a/packages/ramp-core/src/app/core/config.class.js
+++ b/packages/ramp-core/src/app/core/config.class.js
@@ -3052,6 +3052,7 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
             this._source = source;
 
             this._id = source.id;
+            this._dynamicIndex = this._id ? source.dynamicIndex : undefined;
             this._large = this._id ? source.large : false;
             this._medium = this._id ? source.medium : false;
             this._small = this._id ? source.small : false;
@@ -3059,6 +3060,9 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
 
         get id() {
             return this._id;
+        }
+        get dynamicIndex() {
+            return this._dynamicIndex;
         }
         get large() {
             return this._large;
@@ -3073,6 +3077,7 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
         get JSON() {
             return {
                 id: this.id,
+                dynamicIndex: this.dynamicIndex,
                 large: this.large,
                 medium: this.medium,
                 small: this.small,

--- a/packages/ramp-core/src/app/ui/toc/toc.directive.js
+++ b/packages/ramp-core/src/app/ui/toc/toc.directive.js
@@ -312,9 +312,17 @@ function Controller(
             const legendBlockId = legendMapping[0].legendBlockId;
 
             // find that legend block
-            const legendBlock = self.config.map.legendBlocks
+            let legendBlock = self.config.map.legendBlocks
                 .walk((entry, index, parentEntry) => (entry.id === legendBlockId ? entry : null))
                 .filter((a) => a !== null)[0];
+
+            // check if this is a dynamic layer. If so, then use the `dynamicIndex` attribute
+            // to find the specified sublayer.
+            if (legendBlock.blockType === 'group') {
+                legendBlock = legendBlock.entries.find((entry) => {
+                    return entry.itemIndex === self.config.ui.tableIsOpen.dynamicIndex;
+                });
+            }
 
             // open the datatable if the legend block is found
             if (legendBlock) {

--- a/packages/ramp-core/src/content/samples/config/config-sample-90.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-90.json
@@ -8,7 +8,8 @@
             "logo": true
         },
         "tableIsOpen": {
-            "id": "DateLayer",
+            "id": "1",
+            "dynamicIndex": "34",
             "large": true,
             "medium": true,
             "small": false


### PR DESCRIPTION
Closes #3823 

Adds a new option to the configuration file that allows you to open the table for a dynamic layer by default.

You can test this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3823/samples/index-samples.html?sample=90).

---
Note: This PR makes an assumption that the index provided will be a direct child of the `LegendBlock`. Is it possible that there may be a more deeply nested sublayer? If so, I'll need to modify the search code to do a recursive search.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3938)
<!-- Reviewable:end -->
