### PR TITLE
WCAG: add roles and aria labels to sidenav buttons and modal

### DIFF
--- a/packages/ramp-core/src/app/ui/sidenav/menulink.html
+++ b/packages/ramp-core/src/app/ui/sidenav/menulink.html
@@ -2,6 +2,7 @@
     ng-if="self.control.type === 'link'"
     ng-click="self.control.action(self.control, $event)"
     class="rv-button-square"
+    aria-label="{{ self.control.label | translate }}"
 >
     <div layout="row">
         <md-icon md-svg-src="{{ ::self.control.icon }}"></md-icon>{{ self.control.label | translate }}<span flex></span>
@@ -9,7 +10,12 @@
     </div>
 </md-button>
 
-<md-button ng-if="self.control.type === 'fullscreen'" class="rv-button-square" ngsf-toggle-fullscreen>
+<md-button
+    ng-if="self.control.type === 'fullscreen'"
+    class="rv-button-square"
+    aria-label="{{ self.control.label | translate }}"
+    ngsf-toggle-fullscreen
+>
     <div layout="row">
         <md-icon md-svg-src="{{ ::self.control.icon }}"></md-icon>{{ self.control.label | translate }}<span flex></span>
         <md-icon md-svg-src="navigation:check" ng-if="self.control.isChecked(self.control)"></md-icon>

--- a/packages/ramp-core/src/app/ui/sidenav/sidenav.html
+++ b/packages/ramp-core/src/app/ui/sidenav/sidenav.html
@@ -1,4 +1,11 @@
-<md-sidenav rv-trap-focus class="site-sidenav md-sidenav-left md-whiteframe-z2" md-component-id="left">
+<md-sidenav
+    rv-trap-focus
+    class="site-sidenav md-sidenav-left md-whiteframe-z2"
+    md-component-id="left"
+    role="dialog"
+    aria-modal="true"
+    aria-label="{{ self.uiConfig.title || 'sidenav.title' | translate }}"
+>
     <header class="rv-sidemenu-header">
         <div class="app-logo" ng-class="{ 'rv-no-logo': !self.uiConfig.sideMenu.logo }">
             <div ng-if="self.uiConfig.sideMenu.logo">


### PR DESCRIPTION
Closes #3913 and #3920 

Adds the required dialog roles + aria properties for the sidenav as a modal and `aria-labels` for each of the buttons on the sidenav (all buttons were missing labels). 

[Demo page](http://ramp4-app.azureedge.net/legacy/users/yileifeng/3920-3913-WCAG-roles-labels/samples/index-samples.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3939)
<!-- Reviewable:end -->
