### PR TITLE
fix(legend): add tooltip and icon for Multipoint geometry

### DIFF
--- a/packages/ramp-core/src/app/geo/geo.constant.service.js
+++ b/packages/ramp-core/src/app/geo/geo.constant.service.js
@@ -21,6 +21,7 @@ const GEO = {
         Esri: {
             GEOMETRY_TYPES: {
                 esriGeometryPoint: 'geometry.type.esriGeometryPoint',
+                esriGeometryMultipoint: 'geometry.type.esriGeometryMultipoint',
                 esriGeometryPolygon: 'geometry.type.esriGeometryPolygon',
                 esriGeometryPolyline: 'geometry.type.esriGeometryPolyline',
                 generic: 'geometry.type.generic',

--- a/packages/ramp-core/src/app/ui/toc/legend-element-factory.class.js
+++ b/packages/ramp-core/src/app/ui/toc/legend-element-factory.class.js
@@ -617,6 +617,7 @@ function LegendElementFactory(
                 get esriFeature() {
                     return {
                         esriGeometryPoint: 'community:vector-point',
+                        esriGeometryMultipoint: 'community:vector-point',
                         esriGeometryPolygon: 'community:vector-polygon',
                         esriGeometryPolyline: 'community:vector-polyline',
                     }[geometryType];

--- a/packages/ramp-core/src/locales/translations.csv
+++ b/packages/ramp-core/src/locales/translations.csv
@@ -270,6 +270,7 @@ ToC slider mixed values,toc.slider.mixed,Mixed values,1,Valeurs mixtes,1
 While counting geometry,geometry.counting, ...counting,1, ...compte,1
 Geometry types,geometry.type.generic,feature|features,1,élément|éléments,1
 Geometry types,geometry.type.esriGeometryPoint,point|points,1,point|points,1
+Geometry types,geometry.type.esriGeometryMultipoint,multipoint|multipoints,1,multipoint|multipoints,0
 Geometry types,geometry.type.esriGeometryPolygon,polygon|polygons,1,polygone|polygones,1
 Geometry types,geometry.type.esriGeometryPolyline,line|lines,1,ligne|lignes,1
 Geometry types,geometry.type.imagery,imagery,1,imagerie,1


### PR DESCRIPTION
Closes #3945 

This PR adds an icon and tooltip to the legend when displaying a layer that uses multipoint geometry.

You can find a demo of this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3945/samples/index-samples.html). Try to import the following feature layer using the wizard and check that the symbol shows up in the legend entry. When hovering over the symbol, the tooltip should say `ESRI Feature Layer (974 points)`.

The feature layer: https://maps-cartes.services.geo.ca/server_serveur/rest/services/IAAC/assessment_inventory_en/MapServer/0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3947)
<!-- Reviewable:end -->
