### PR TITLE
fix(details): fix empty expanded panel for wms bc templating

### DIFF
--- a/packages/ramp-core/src/app/ui/details/details-modal.html
+++ b/packages/ramp-core/src/app/ui/details/details-modal.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Details Summary" class="rv-details-summary">
+<md-dialog aria-label="{{ 'details.aria.dialog' | translate }}" class="rv-details-summary">
     <!-- TODO: add metadata translation -->
     <rv-content-pane close-panel="self.cancel()" title-style="title" title-value="{{ self.item.requester.proxy.name }}">
         <div class="rv-details">

--- a/packages/ramp-core/src/app/ui/details/details-record-esrifeature-item.html
+++ b/packages/ramp-core/src/app/ui/details/details-record-esrifeature-item.html
@@ -5,6 +5,7 @@
         ng-focus="self.isRendered = true"
         ng-mouseover="self.isRendered = true"
         ng-click="self.toggleDetails()"
+        aria-label="{{ 'details.aria.toggle' | translate }}"
     >
     </md-button>
 

--- a/packages/ramp-core/src/app/ui/details/details-record-html.directive.js
+++ b/packages/ramp-core/src/app/ui/details/details-record-html.directive.js
@@ -59,6 +59,13 @@ function rvDetailsRecordHtml($compile, $translate, events, detailService, $timeo
             }
 
             detailService.getTemplate(l.layerId, self.details.template).then((template) => {
+                // ensure custom template does not contain non-existent attributes (ng-show) that will disrupt content rendering
+                const $div = $('<div>').html(template);
+                $div.find('[ng-show]').each((idx, el) => {
+                    $(el).attr('ng-show', 'self.item.data[0]');
+                });
+                const updatedTemplate = $div.html();
+
                 if (!self.details.parser) {
                     compileTemplate();
                     return;
@@ -92,7 +99,7 @@ function rvDetailsRecordHtml($compile, $translate, events, detailService, $timeo
                     // this ensures we have the data and don't display and "{{ VARIABLE }}"s
                     $timeout(() => {
                         // compile the template with the scope and append it to the mount
-                        el.find('.template-mount').empty().append($compile(template)(scope));
+                        el.find('.template-mount').empty().append($compile(updatedTemplate)(scope));
                     });
                 }
             });

--- a/packages/ramp-core/src/content/samples/templates/wms-bc-script.js
+++ b/packages/ramp-core/src/content/samples/templates/wms-bc-script.js
@@ -1,0 +1,51 @@
+function parser(data, lang) {
+    const table = $.parseHTML(data);
+
+    let title = [];
+    $(table[13]).find('th').each((index, th) => {
+        title.push(th.textContent);
+    });
+
+    let value = [];
+    $(table[13]).find('td').each((index, td) => {
+        value.push(td.textContent !== '' ? td.textContent : '---');
+    });
+
+    let output = [];
+    const year = new Date().getFullYear() - 2000;
+    for (let [i, item] of title.entries()) {
+        // convert date to YYYY-MM-DD (weird because from metadata, it is the format it should be)
+        // inside the response it is dd-mm-yy
+        if (i === 36 | i === 37) {
+            // get date portion
+            let arr = value[i].split(' ')[0].split('/');
+
+            // loop to pad DD and MM
+            for (let [j, date] of arr.entries()) {
+                arr[j] = date.padStart(2, 0);
+
+                // For year, check if we need to add 19 or 20
+                if (j === 2) {
+
+                    arr[j] = (arr[j] <= year) ? `20${arr[j]}` : `19${arr[j]}`;
+                }
+            }
+            value[i] = arr.reverse().join('-');
+        }
+
+        let tmp = {
+            title: item,
+            value: value[i]
+        };
+        output.push(tmp);
+    }
+
+    const inter = setInterval(() => {
+        $('#bcDetails').css('opacity', 1).css('height', 'auto');
+        clearInterval(inter);
+    }, 1000);
+
+    if (output.length === 0) output[0] = { title: (lang === 'en-CA') ? 'Nothing found' : 'Aucun rÃ©sultat' };
+
+    return { items: output };
+}

--- a/packages/ramp-core/src/content/samples/templates/wms-bc-template.html
+++ b/packages/ramp-core/src/content/samples/templates/wms-bc-template.html
@@ -1,0 +1,8 @@
+<ul id="bcDetails" class="rv-details-list rv-toggle-slide" ng-show="self.isExpanded" aria-hidden="false" style="height: auto !important; opacity: 1 !important; display: block !important">
+    <li rv-lightbox="" ng-switch="" on="row.type" class="ng-scope" ng-repeat="item in self.layer.items" style="display: flex; flex-wrap: wrap; justify-content: flex-end; padding: 5px">
+        <div class="rv-details-attrib-key ng-binding" style="margin-right: 0; padding-right: 10px; font-weight: bold; word-break: break-word;">{{ item.title }}</div>
+        <span flex="" class="flex"></span>
+        <div class="rv-details-attrib-value ng-binding ng-scope" ng-bind-html="::item.value | picture | autolink">{{ item.value }}</div>
+    </li>
+    <br>
+</ul>

--- a/packages/ramp-core/src/locales/translations.csv
+++ b/packages/ramp-core/src/locales/translations.csv
@@ -78,6 +78,8 @@ Datatable settings sort column label,filter.settings.label.sort,Sort,1,Trier,1
 Datatable settings display column label,filter.settings.label.show,Show,1,Montrer,1
 Details pane title,details.title,Feature Information,1,Information sur l'élément,1
 Details pane aria label for expand button,details.aria.expand,Expand,1,Agrandir,1
+Details pane aria label for dialog modal,details.aria.dialog,Details Summary,1,Détails Résumé,0
+Details pane aria label for toggle button,details.aria.toggle,Toggle Details,1,Détails à bascule,0
 Details pane tooltip for expand button,details.tooltip.expand,Expand,1,Agrandir,1
 Details pane label for no result,details.label.noresult,Nothing found,1,Aucun résultat,1
 Details pane label for searching,details.label.searching,Searching ...,1,Rechercher ...,1


### PR DESCRIPTION
Closes the main issue in #3888, will be writing a follow-up to this [comment](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3888#issuecomment-843202034) shortly. 

To test, use the following steps: 
1. Add this [layer](https://openmaps.gov.bc.ca/geo/pub/WHSE_HUMAN_CULTURAL_ECONOMIC.MPI_ECON_MAJOR_PROJECTS_POINT/ows?SERVICE=WMS&REQUEST=GetCapabilities) via wizard (ogcWms)
2. `const mapInstance = RAMP.mapInstances[0]`
3. `let layer = mapInstance.layers.allLayers[2]` (access the added layer - index may vary depending on layer order)
4. `layer._viewerLayer.config._details = { parser: "templates/wms-bc-script.js", template: "templates/wms-bc-template.html" };`
5. `layer._viewerLayer.config._featureInfoMimeType = "text/html"`
6. Click one of the points for the wms BC layer and expand the details panel, it should not be blank and render time should be smooth

Steps 2-5 adds custom details templating to the newly added layer via API following the same steps as the original [issue](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3888#issuecomment-843384728). To see the original problem, you can use this [link](https://osdp-psdo.canada.ca/assets/osdp/osdp-Developments-en.html) and follow the same steps. 

[Demo link](http://ramp4-app.azureedge.net/legacy/users/yileifeng/3888-custom-details-expand/samples/index-samples.html?sample=71)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3948)
<!-- Reviewable:end -->
