### PR TITLE
fix(geo): use placeholder symbology in tables/details for arcade

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For more info on individual packages builds/documentation read the READMEs in th
 
 ## Documentation
 
-The Reusable Accessible Mapping Platform (RAMP), also known as the Federal Geospatial Platform Visualiser (FGPV), is a Javascript based web mapping platform that provides a reusable, WCAG 2.0 AA compliant common viewer platform for the Government of Canada.
+The Reusable Accessible Mapping Platform (RAMP), also known as the Federal Geospatial Platform Visualiser (FGPV), is a Javascript based web mapping platform that provides a reusable, responsive and WCAG 2.0 AA compliant common viewer platform for the Government of Canada.
 
 For more information on this project, please see one of the sections below:
 

--- a/packages/ramp-geoapi/src/defaultSymbols.json
+++ b/packages/ramp-geoapi/src/defaultSymbols.json
@@ -1,0 +1,8 @@
+{
+    "placeholderSymbol": {
+        "type": "esriPMS",
+        "contentType": "image/svg+xml",
+        "width": 36,
+        "height": 36
+    }
+}

--- a/packages/ramp-geoapi/src/symbology.js
+++ b/packages/ramp-geoapi/src/symbology.js
@@ -2,6 +2,8 @@
 'use strict';
 const svgjs = require('svg.js');
 const shared = require('./shared.js')();
+const rcolour = require('rcolor');
+const defaultSymbols = require('./defaultSymbols.json');
 
 // Functions for turning ESRI Renderers into images
 // Specifically, converting ESRI "Simple" symbols into images,
@@ -142,7 +144,7 @@ function enhanceRenderer(renderer, legend) {
     return Promise.all(legendItemPromises).then(() => {
         switch (renderer.type) {
             case SIMPLE:
-                renderer.svgcode = legendLookup[renderer.label];
+                renderer.svgcode = renderer.svgcode ? renderer.svgcode : legendLookup[renderer.label];
                 break;
 
             case UNIQUE_VALUE:
@@ -212,6 +214,21 @@ function cleanRenderer(renderer, fields) {
         case SIMPLE:
             break;
         case UNIQUE_VALUE:
+            // detect layer with arcade symbology (no field values)
+            const containsField = renderer.field1 || renderer.field2 || renderer.field3;
+            if (renderer.valueExpression && !containsField) {
+                // convert to simple renderer with generated placeholder symbology using '?'
+                renderer.type = SIMPLE;
+                const color = rcolour({ saturation: 0.4, value: 0.8 });
+                const placeholder = generatePlaceholderSymbology('?', color);
+
+                // setup new renderer properties
+                renderer.svgcode = placeholder.svgcode;
+                renderer.symbol = defaultSymbols.placeholderSymbol;
+                renderer.symbol.imageData = btoa(renderer.svgcode);
+                break;
+            }
+
             ['field1', 'field2', 'field3'].forEach((f) => {
                 // call ehnace case for each field
                 renderer[f] = enhanceField(renderer[f], fields);
@@ -242,7 +259,8 @@ function searchRenderer(attributes, renderer) {
     switch (renderer.type) {
         case SIMPLE:
             svgcode = renderer.svgcode;
-            symbol = renderer.symbol;
+            // use empty symbol for arcade symbology with valueExpression to avoid having placeholder '?' symbols appearing during map highlighting
+            symbol = !renderer.valueExpression ? renderer.symbol : {};
 
             break;
 


### PR DESCRIPTION
Closes #3925 

This may be a bit harder to test since there is inconsistency in that the layer will sometimes error out when loading. 
1. Add this layer containing arcade symbology https://gisp.dfo-mpo.gc.ca/arcgis/rest/services/FGP/PATH/MapServer/0 and wait for it to fully load (hopefully)
2. Opening up the details panel or data table should work with a placeholder `?` symbology icon

[Demo link](http://ramp4-app.azureedge.net/legacy/users/yileifeng/3925-arcade-symbology/samples/index-samples.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3951)
<!-- Reviewable:end -->
