### PR TITLE
feat(toc): add focus box around symbology stack

### DIFF
--- a/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
+++ b/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
@@ -55,7 +55,7 @@ class ToggleSymbol {
  */
 angular.module('app.ui').directive('rvSymbologyStack', rvSymbologyStack).factory('SymbologyStack', symbologyStack);
 
-function rvSymbologyStack($rootScope, $q, Geo, animationService, layerRegistry, $timeout) {
+function rvSymbologyStack($rootScope, $rootElement, $q, Geo, animationService, layerRegistry, $timeout) {
     const directive = {
         require: '^?rvTocEntry', // need access to layerItem to get its element reference
         restrict: 'E',
@@ -85,6 +85,8 @@ function rvSymbologyStack($rootScope, $q, Geo, animationService, layerRegistry, 
 
         self.expandSymbology = expandSymbology;
         self.fanOutSymbology = fanOutSymbology;
+
+        self.showSymbologyBorder = showSymbologyBorder;
 
         self.symbologyWidth = 32;
 
@@ -395,6 +397,31 @@ function rvSymbologyStack($rootScope, $q, Geo, animationService, layerRegistry, 
         }
 
         return true;
+
+        /**
+         * Draws a black box around the symbology stack for accessibility purposes.
+         *
+         * @function showSymbologyBorder
+         * @private
+         * @param {Boolean} toggle true will draw an outline around the stack; false will remove the border
+         */
+        function showSymbologyBorder(toggle) {
+            // If the viewer isn't in keyboard mode don't bother drawing these outlines.
+            if (!$rootElement.hasClass('rv-keyboard')) {
+                return;
+            }
+
+            // If a value is provided (aka the symbology was focused or blurred), then apply the outline as necessary.
+            if (toggle !== undefined) {
+                toggle && !self.isExpanded
+                    ? element.addClass('rv-symbol-outline')
+                    : element.removeClass('rv-symbol-outline');
+            } else {
+                // If no value is provided (aka the symbology was clicked), then ensure that the border is removed if the
+                // symbology is expanded (to prevent a double border around the symbology and the close button).
+                self.isExpanded ? element.addClass('rv-symbol-outline') : element.removeClass('rv-symbol-outline');
+            }
+        }
 
         /**
          * Expands the symbology stack to show all its individual elements.

--- a/packages/ramp-core/src/app/ui/toc/templates/symbology-stack.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/symbology-stack.html
@@ -59,9 +59,9 @@
         ng-style="{'z-index': 100 + self.symbology.stack.length + 2 }"
         class="rv-symbol-trigger rv-button-32 rv-icon-24 md-icon-button"
         ng-if="self.symbology.isInteractive"
-        ng-click="self.expandSymbology()"
-        ng-focus="self.fanOutSymbology(true)"
-        ng-blur="self.fanOutSymbology(false)"
+        ng-click="self.expandSymbology(); self.showSymbologyBorder()"
+        ng-focus="self.fanOutSymbology(true); self.showSymbologyBorder(true)"
+        ng-blur="self.fanOutSymbology(false); self.showSymbologyBorder(false)"
         ng-mouseover="self.fanOutSymbology(true)"
         ng-mouseout="self.fanOutSymbology(false)"
     >

--- a/packages/ramp-core/src/content/styles/modules/_toc.scss
+++ b/packages/ramp-core/src/content/styles/modules/_toc.scss
@@ -216,6 +216,12 @@ $layer-item-height-touch: rem(7.2);
             &.rv-selected:before {
                 background-color: $accent-color;
             }
+
+            .rv-symbol-outline {
+                border: 1px solid;
+                padding: 7px;
+                margin: 0px -8px;
+            }
         }
 
         &.rv-legend-bad-projection {


### PR DESCRIPTION
Closes #3932 

When focusing on a symbology stack while in keyboard mode, a box will be drawn around the element.

[Demo 1](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3932/samples/index-samples.html) (regular symbology stack)
[Demo 2](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3932/samples/index-samples.html?sample=70) (symbology stack expanded by default)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3952)
<!-- Reviewable:end -->
