### PR TITLE
WCAG - alert users on map changes

### DIFF
--- a/packages/ramp-core/src/app/core/shell.service.js
+++ b/packages/ramp-core/src/app/core/shell.service.js
@@ -9,7 +9,7 @@ angular.module('app.core').factory('shellService', shellService);
  * @param {object} errorService error notification service
  * @returns {object} shell service signature
  */
-function shellService(common, errorService) {
+function shellService($translate, common, configService, errorService, events) {
     const service = {
         // returns `true` if at least one of the loading processes is active
         get isLoading() {
@@ -18,8 +18,16 @@ function shellService(common, errorService) {
 
         setLoadingFlag,
         clearLoadingFlag,
+        updateAlert,
         loadingProcesses: {},
     };
+
+    events.$on(events.rvMapLoaded, () => {
+        // wire in a hook to any map for updating user alert message
+        configService.getSync.map.instance.updateAlert = (alertMsg, params = null) => {
+            service.updateAlert(alertMsg, params);
+        };
+    });
 
     return service;
 
@@ -157,5 +165,19 @@ function shellService(common, errorService) {
         delete service.loadingProcesses[id];
 
         // console.log('[]- clear complete', id, Object.values(service.loadingProcesses).map(p => ({ id: p.id, state: p._state })), service.isLoading);
+    }
+
+    /**
+     * Changes invisible alert message on map changes to be announced to screen readers.
+     *
+     * @param {String} alertMsg is the alert message that should be announced to screen readers
+     * @param  {Object} params [optional] specifies any variables that should be interpolated in translations
+     */
+    function updateAlert(alertMsg, params) {
+        // translate the message and create new element to inject into rv-alert-message
+        alertMsg = params === null ? $translate.instant(alertMsg) : $translate.instant(alertMsg, params);
+        const alert = $('.rv-inner-shell').find('.rv-alert-message');
+        const alertEl = $(`<span>${alertMsg}</span>`);
+        alert.empty().append(alertEl);
     }
 }

--- a/packages/ramp-core/src/app/geo/identify.service.js
+++ b/packages/ramp-core/src/app/geo/identify.service.js
@@ -181,6 +181,8 @@ function identifyService($q, configService, gapiService, referenceService, state
         // show details panel only when there is data and the identifyMode is set to `Details`
         if (mApi.layers.identifyMode.includes(IdentifyMode.Details)) {
             stateManager.toggleDisplayPanel('mainDetails', details, requester, 0);
+            // alert SR user on details panel opening
+            mapInstance.updateAlert('details.alert.open');
         }
 
         if (mApi.layers.identifyMode.includes(IdentifyMode.Highlight)) {

--- a/packages/ramp-core/src/app/geo/legend.service.js
+++ b/packages/ramp-core/src/app/geo/legend.service.js
@@ -266,6 +266,11 @@ function legendServiceFactory(
         // add the new block config to the legend config (always to the root group), so it will be preserved when map is rebuilt
         configService.getSync.map.legend.addChild(importedBlockConfig, position);
 
+        // alert SR user on adding layer to legend (user-added)
+        if (layerBlueprint.config.state.userAdded) {
+            configService.getSync.map.instance.updateAlert('toc.layer.alert.added', { name: layerBlueprint.config.name });
+        }
+
         return importedLegendBlock;
     }
 
@@ -436,6 +441,10 @@ function legendServiceFactory(
 
             // remove any bounding box layers associated with this legend block
             _boundingBoxRemoval(legendBlock);
+
+            // alert SR user on removing layer from legend
+            const map = configService.getSync.map.instance;
+            map.updateAlert('toc.layer.alert.removed', { name: legendBlock.name });
 
             // TODO: modify the legend accordingly to update our api legend object as well, currently it never changes
         }

--- a/packages/ramp-core/src/app/layout/shell.html
+++ b/packages/ramp-core/src/app/layout/shell.html
@@ -42,6 +42,8 @@
     margin: 100px auto 0 auto;
     -->
 
+    <rv-alert-message class="rv-alert-message" role="alert"></rv-alert-message>
+
     <rv-north-arrow class="rv-icon-32 rv-north-arrow"></rv-north-arrow>
 
     <rv-appbar></rv-appbar>

--- a/packages/ramp-core/src/app/ui/details/detail.service.js
+++ b/packages/ramp-core/src/app/ui/details/detail.service.js
@@ -13,7 +13,7 @@ angular.module('app.ui').factory('detailService', detailService);
 const parserFunctions = [];
 const templates = [];
 
-function detailService($mdDialog, stateManager, mapService, referenceService, events) {
+function detailService($mdDialog, stateManager, configService, mapService, referenceService, events) {
     const service = {
         expandPanel,
         closeDetails,
@@ -82,6 +82,10 @@ function detailService($mdDialog, stateManager, mapService, referenceService, ev
             bindToController: true,
             hasBackdrop,
         });
+
+        // alert SR user on expanding details content
+        const map = configService.getSync.map.instance;
+        map.updateAlert('details.alert.expand');
     }
 
     /**
@@ -90,6 +94,10 @@ function detailService($mdDialog, stateManager, mapService, referenceService, ev
      */
     function closeDetails() {
         stateManager.clearDisplayPanel('mainDetails');
+
+        // alert SR user on closing details content
+        const map = configService.getSync.map.instance;
+        map.updateAlert('details.alert.close');
 
         // remove highlighted features and the haze when the details panel is closed
         mapService.clearHighlight(false);

--- a/packages/ramp-core/src/app/ui/details/details-record-esrifeature-item.directive.js
+++ b/packages/ramp-core/src/app/ui/details/details-record-esrifeature-item.directive.js
@@ -127,7 +127,7 @@ function rvDetailsRecordEsrifeatureItem(
     }
 }
 
-function Controller() {
+function Controller(configService) {
     'ngInject';
     const self = this;
 
@@ -140,6 +140,11 @@ function Controller() {
     function toggleDetails() {
         self.isRendered = true;
         self.isExpanded = !self.isExpanded;
+
+        // alert SR user on expanding/collapsing individual identify record
+        const map = configService.getSync.map.instance;
+        const alertMsg = self.isExpanded ? 'details.alert.expanded' : 'details.alert.collapsed';
+        map.updateAlert(alertMsg);
 
         self.toggleHighlight(self.item.oid, self.isExpanded);
     }

--- a/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
+++ b/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
@@ -55,7 +55,7 @@ class ToggleSymbol {
  */
 angular.module('app.ui').directive('rvSymbologyStack', rvSymbologyStack).factory('SymbologyStack', symbologyStack);
 
-function rvSymbologyStack($rootScope, $rootElement, $q, Geo, animationService, layerRegistry, $timeout) {
+function rvSymbologyStack($rootScope, $rootElement, $q, Geo, configService, animationService, layerRegistry, $timeout) {
     const directive = {
         require: '^?rvTocEntry', // need access to layerItem to get its element reference
         restrict: 'E',
@@ -453,7 +453,17 @@ function rvSymbologyStack($rootScope, $rootElement, $q, Geo, animationService, l
                     self.showSymbologyToggle = false;
                     ref.fanOutTimeline.play();
                 }
+                const expandedChanged = self.symbology.expanded !== value;
                 self.symbology.expanded = value;
+
+                // alert user that symbology has been expanded/collapsed
+                if (expandedChanged) {
+                    const map = configService.getSync.map.instance;
+                    const alertMsg = self.symbology.expanded
+                        ? 'toc.layer.label.symbologyExpand'
+                        : 'toc.layer.label.symbologyCollapse';
+                    map.updateAlert(alertMsg);
+                }
             }
         }
 

--- a/packages/ramp-core/src/app/ui/toc/toc.service.js
+++ b/packages/ramp-core/src/app/ui/toc/toc.service.js
@@ -101,22 +101,22 @@ function tocService(
             }
         };
 
-        //wire in a hook to any map for removing a layer using the given LegendBlock
+        // wire in a hook to any map for removing a layer using the given LegendBlock
         configService.getSync.map.instance.removeAPILegendBlock = (legendBlock) => {
             service.removeLayer(legendBlock, false);
         };
 
-        //wire in a hook to any map for reloading a layer using the given LegendBlock
+        // wire in a hook to any map for reloading a layer using the given LegendBlock
         configService.getSync.map.instance.reloadAPILegendBlock = (legendBlock) => {
             service.reloadLayer(legendBlock);
         };
 
-        //wire in a hook to any map for toggling Metadata for any given legendBlock
+        // wire in a hook to any map for toggling Metadata for any given legendBlock
         configService.getSync.map.instance.toggleMetadata = (legendBlock) => {
             service.toggleMetadata(legendBlock);
         };
 
-        //wire in a hook to any map for toggling settings for any given legendBlock
+        // wire in a hook to any map for toggling settings for any given legendBlock
         configService.getSync.map.instance.toggleSettings = (legendBlock) => {
             service.toggleSettings(legendBlock);
         };
@@ -400,6 +400,10 @@ function tocService(
 
         // send to display manager method
         stateManager.toggleDisplayPanel('sideSettings', legendBlock, requester);
+
+        // alert SR user on toggling setting panel
+        const map = configService.getSync.map.instance;
+        map.updateAlert('settings.alert.toggled');
     }
 
     function toggleLayerTablePanel(legendBlock) {
@@ -458,6 +462,10 @@ function tocService(
 
         // send to display manager method
         stateManager.toggleDisplayPanel('sideMetadata', dataPromise, requester);
+
+        // alert SR user on toggling metadata panel
+        const map = configService.getSync.map.instance;
+        map.updateAlert('metadata.alert.toggled');
     }
 
     /**

--- a/packages/ramp-core/src/content/styles/modules/_shell.scss
+++ b/packages/ramp-core/src/content/styles/modules/_shell.scss
@@ -89,6 +89,19 @@
             padding: 5px 0px;
         }
 
+        // sr-only accessible hiding element (only accessible to screen reader users)
+        .rv-alert-message {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
         .rv-north-arrow {
             position: absolute;
             transform-origin: top center;

--- a/packages/ramp-core/src/locales/translations.csv
+++ b/packages/ramp-core/src/locales/translations.csv
@@ -76,6 +76,11 @@ Datatable settings name column label,filter.settings.label.name,Name,1,Nom,1
 Datatable settings filter column label,filter.settings.label.filter,Filter,1,Filtre,1
 Datatable settings sort column label,filter.settings.label.sort,Sort,1,Trier,1
 Datatable settings display column label,filter.settings.label.show,Show,1,Montrer,1
+Details pane open alert,details.alert.open,Details panel opened,1,Détails panneau ouvert,0
+Details pane expand alert,details.alert.expand,Expanding details panel,1,Élargir les détails panneau,0
+Details pane close alert,details.alert.close,Details panel closed,1,Panneau détails fermé,0
+Details pane entry expanded alert,details.alert.expanded,Details entry expanded,1,Détails entrée élargi,0
+Details pane entry collapsed alert,details.alert.collapsed,Details entry collapsed,1,Détails de fondre d’entréey,1
 Details pane title,details.title,Feature Information,1,Information sur l'élément,1
 Details pane aria label for expand button,details.aria.expand,Expand,1,Agrandir,1
 Details pane aria label for dialog modal,details.aria.dialog,Details Summary,1,Détails Résumé,0
@@ -142,10 +147,12 @@ Map Navigation history tooltip,nav.tooltip.history,History,1,Historique,1
 Map Navigation basemap tooltip,nav.tooltip.basemap,Basemap,1,Carte de base,1
 Metadata pane title,metadata.title,Metadata,1,Métadonnées,1
 Metadata pane expand,metadata.expand.tooltip,Expand metadata,1,Agrandir les métadonnées,1
+Metadata pane toggled alert, metadata.alert.toggled,Metadata panel toggled,1,Métadonnées panneau activer,1
 Hovertip loading text,maptip.hover.label.loading,Loading...,1,Chargement en cours...,1
 ,settings.change.at,Change <span class="rv-control-name" translate="settings.label.{{controlName}}"></span> at:,1,Changement <span class="rv-control-name" translate="settings.label.{{controlName}}"></span> à:,0
 Settings main title,settings.title,Settings,1,Paramètres,1
 Settings visibility header label,settings.label.display,Display,1,Affichage,1
+Settings toggled alert,settings.alert.toggled,Settings panel toggled,1,Paramètres panneau activer,1
 Settings bounding box visibility label,settings.label.boundingBox,Bounding box,1,Zone de délimitation,1
 Settings bounding box visibility aria label,settings.aria.boundingBox,Bounding box,1,Zone de délimitation,1
 Settings opacity slider label,settings.label.opacity,Opacity,1,Opacité,1
@@ -179,9 +186,13 @@ Side Navigation language,sidenav.label.language,Language,1,Langue,1
 Table of Content Unnamed service,toc.layer.unnamed,Unnamed service #{{count}},1,Service sans nom #{{count}},1
 Table of Content Layer open data panel aria label,toc.layer.aria.openData,Open data panel menu,1,Menu du panneau des données ouvertes,1
 Table of Content Layer options label,toc.layer.tooltip.options,More options,1,Plus d'options,1
+Table of Content Layer added alert,toc.layer.alert.added,{{name}} layer added to legend,1,{{name}} couche ajoutée à la légende,1
+Table of Content Layer removed alert,toc.layer.alert.removed,{{name}} layer removed from legend,1,Couche {{name}} retiré de la légende,1
 Table of Content show symbology label,toc.layer.label.symbology,Legend,1,Légende,1
 Table of Content show symbology label,toc.layer.label.symbologyShow,Expand legend,1,Développer la légende,1
 Table of Content hide symbology label,toc.layer.label.symbologyHide,Hide legend,1,Masquer la légende,1
+Table of Content expand symbology alert label,toc.layer.label.symbologyExpand,Expanded,1,Élargi,1
+Table of Content collapse symbology alert label,toc.layer.label.symbologyCollapse,Collapsed,1,Effondrée,1
 Table of Content main title,toc.title,Layer Selector,1,Sélecteur de couche,1
 Table of Content toggle group visibility label,toc.label.toggleGroupViz,Toggle group visibility,1,Masquer le groupe de visibilité,1
 Table of Content toggle group visibility tootlip,toc.tooltip.toggleGroupViz,Toggle group visibility,1,Masquer le groupe de visibilité,1

--- a/packages/ramp-plugin-enhanced-table/src/index.ts
+++ b/packages/ramp-plugin-enhanced-table/src/index.ts
@@ -429,6 +429,7 @@ TableBuilder.prototype.translations = {
             placeholder: 'Search table',
         },
         table: {
+            alert: 'Data table loaded',
             filter: {
                 clear: 'Clear filters',
                 apply: 'Apply filters to map',
@@ -475,6 +476,7 @@ TableBuilder.prototype.translations = {
             placeholder: 'Texte à rechercher',
         },
         table: {
+            alert: 'Tableau de données chargées',
             filter: {
                 clear: 'Effacer les filtres',
                 apply: 'Appliquer des filtres à la carte', // TODO: Add official French translation

--- a/packages/ramp-plugin-enhanced-table/src/panel-manager.ts
+++ b/packages/ramp-plugin-enhanced-table/src/panel-manager.ts
@@ -320,6 +320,10 @@ export class PanelManager {
                 this.panel.open();
                 this.autoSizeToMaxWidth();
                 this.sizeColumnsToFitIfNeeded();
+
+                // alert SR user on data table loaded
+                const map = this.mapApi.mapI;
+                map.updateAlert('plugins.enhancedTable.table.alert');
             };
         }
     }


### PR DESCRIPTION
Closes #3847

Announces map changes to screen reader users. Currently, the user is only alerted upon opening a data table (when it finishes loading) and when legend symbology is toggled as these were the two instances discussed in the issue. If there are more map changes that should be included (e.g. expanding details, opening settings/metadata panels, etc.), leave a comment and I will work on incorporating those in the PR.

Most of the browser extension SRs seemed to be fairly low quality so I ended up using [Microsoft Narrator](https://support.microsoft.com/en-us/windows/complete-guide-to-narrator-e4397a0d-ef4f-b386-d8ae-c172f109bdb1) for testing which I found to be quite good. Let me know if there is a default/recommended SR that should be used instead.

[Demo link](http://ramp4-app.azureedge.net/legacy/users/yileifeng/3847-WCAG-alert-changes/samples/index-samples.html)

Thanks to @RyanCoulsonCA for helping out and testing PR with SR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3953)
<!-- Reviewable:end -->
