### PR TITLE
fix(api): fix layerRemoved event when removing layer through API

### DIFF
--- a/packages/ramp-core/src/app/ui/toc/toc.service.js
+++ b/packages/ramp-core/src/app/ui/toc/toc.service.js
@@ -12,6 +12,7 @@ angular.module('app.ui').factory('tocService', tocService);
 function tocService(
     $q,
     $rootScope,
+    $rootElement,
     $mdToast,
     $translate,
     referenceService,


### PR DESCRIPTION
Closes #2592 

As far as I can tell, the original toast issue linked above has been fixed previously. The toast no longer appears when removing a layer via the API. If anyone is able to reproduce this issue, let me know.

This PR fixes another issue that is brought up in the comments of the issue, that the `layerRemoved` event is not fired when a console error related to the toast appears. This error was occurring due to a missing dependency in the `toc` service file. Now that this error no longer occurs, the event is emitted properly.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-2592/samples/index-samples.html?sample=1).

**Test Instructions**
To test this PR against a pre-added layer (i.e. through the config), use the following sequence of commands:
```js
const mapInstance = RAMP.mapInstances[0];
const layer = mapInstance.layers.allLayers[0];

mapInstance.layers.layerRemoved.subscribe(() => { console.log('see ya lay(t)er'); });
mapInstance.layers.removeLayer(layer);
```
The layer should be removed from the legend (notice that neither a toast nor an error appears). The layerRemoved event should also fire and display the console.log message in the console.


To manually add a layer, follow these instructions one line at a time. (note: if you did the previous test first you probably want to refresh the page, or you can just skip the first two lines below):
```js
const mapInstance = RAMP.mapInstances[0];
mapInstance.layers.layerRemoved.subscribe(() => { console.log('see ya lay(t)er'); });

const layerJson = {
    "id": "examplelayer",
    "name": "An exemplary Layer",
    "layerType": "esriFeature",
    "controls": [
      "remove"
    ],
    "state": {
      "visibility": true,
      "boundingBox": false
    },
    "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/NACEI/energy_infrastructure_of_north_america_en/MapServer/1"
  };
mapInstance.layers.addLayer(layerJson);
mapInstance.layers.removeLayer('examplelayer');
```
The layer should disappear from the map (again, notice that no toast or error appears), and the console.log should be displayed in the console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3954)
<!-- Reviewable:end -->
