### PR TITLE
fix(toc): focus can get stuck in the legend when pressing TAB

### DIFF
--- a/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
+++ b/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
@@ -305,7 +305,13 @@ function rvSymbologyStack($rootScope, $rootElement, $q, Geo, configService, anim
         scope.$watch('self.showSymbologyToggle', (value) => {
             if (value) {
                 element.find('.md-icon-button').addClass('show');
-                $.link(element.find('.md-icon-button'));
+
+                // If the symbology contains more than one icon, link the symbology stack to the first
+                // checkbox so it can be focused on.
+                if (self.symbology.stack.length > 1) {
+                    $.link(element.find('.md-icon-button'));
+                }
+
                 element.find('button').not('.rv-symbol-trigger').removeAttr('nofocus').addClass('focusOnce');
             } else {
                 element.find('.md-icon-button').removeClass('show');


### PR DESCRIPTION
Closes #3955 

Fixes an issue where the focus could be trapped in the legend if you press TAB too quickly after expanding symbology.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3955/samples/index-samples.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3956)
<!-- Reviewable:end -->
