### PR TITLE
fix(map): remove race condition on overview map load

### DIFF
--- a/packages/ramp-geoapi/src/map/esriMap.js
+++ b/packages/ramp-geoapi/src/map/esriMap.js
@@ -102,26 +102,32 @@ function esriMap(esriBundle, geoApi) {
                 this.scalebar.show();
             }
 
-            if (opts.overviewMap && opts.overviewMap.enabled) {
-                overviewExpand = opts.overviewMap.expandFactor;
+            // once the map has loaded, begin creation of the overview map and display it
+            this._map.on('load', () => {
+                if (opts.overviewMap && opts.overviewMap.enabled) {
+                    overviewExpand = opts.overviewMap.expandFactor;
 
-                if (opts.tileSchema.overviewUrl) {
-                    // initial implementation.  we only are supporting tile layers.
-                    // if we want to enhance to have other layer types, will need to determine
-                    // how to go about it. we could just use raw objects in a switch statement here,
-                    // or attempt to wire in the layer records.
-                    this.checkCorsException(opts.tileSchema.overviewUrl.url);
-                    this.defaultOverview = false;
-                    const customOverview = new esriBundle.ArcGISTiledMapServiceLayer(opts.tileSchema.overviewUrl.url);
-                    customOverview.on('load', () => {
-                        this.initOverviewMap(overviewExpand, customOverview);
-                    });
-                } else {
-                    // we use the active basemap, and reset the overview whenever it changes
-                    this.defaultOverview = true;
-                    this.initOverviewMap(overviewExpand);
+                    if (opts.tileSchema.overviewUrl) {
+                        // initial implementation.  we only are supporting tile layers.
+                        // if we want to enhance to have other layer types, will need to determine
+                        // how to go about it. we could just use raw objects in a switch statement here,
+                        // or attempt to wire in the layer records.
+                        this.checkCorsException(opts.tileSchema.overviewUrl.url);
+                        this.defaultOverview = false;
+                        const customOverview = new esriBundle.ArcGISTiledMapServiceLayer(
+                            opts.tileSchema.overviewUrl.url
+                        );
+
+                        customOverview.on('load', () => {
+                            this.initOverviewMap(overviewExpand, customOverview);
+                        });
+                    } else {
+                        // we use the active basemap, and reset the overview whenever it changes
+                        this.defaultOverview = true;
+                        this.initOverviewMap(overviewExpand);
+                    }
                 }
-            }
+            });
 
             this.zoomPromise = Promise.resolve();
             this.zoomCounter = 0;


### PR DESCRIPTION
Closes #3906 

This PR fixes a race condition that occurred between the Esri map load and the overview map load which caused the overview map to sometimes not be displayed on the viewer.

🚨 Before merging this PR, the config file for `index-fgp-en.html` needs to be reverted back. The config used in this PR is just for testing purposes. 🚨 

You can find a demo of this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3906/samples/index-fgp-en.html).

**Test Instructions**
1. Open the demo link above in Firefox.
2. The overview map should always be displayed in the top right corner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3957)
<!-- Reviewable:end -->
