### PR TITLE
fix(ui): add aria-label to help and bookmark

### DIFF
--- a/packages/ramp-core/src/app/ui/help/help-summary.html
+++ b/packages/ramp-core/src/app/ui/help/help-summary.html
@@ -24,6 +24,7 @@
                     <md-button
                         class="rv-group-body-button rv-button-square"
                         ng-click="section.isExpanded = !section.isExpanded"
+                        aria-label="{{ 'helpui.expand' | translate }}"
                     ></md-button>
 
                     <h4

--- a/packages/ramp-core/src/app/ui/sidenav/share-dialog.html
+++ b/packages/ramp-core/src/app/ui/sidenav/share-dialog.html
@@ -17,7 +17,15 @@
         </md-switch>
 
         <md-input-container class="md-block" flex-gt-xs>
-            <input class="rv-shareLink" type="text" ng-model="self.url" readonly md-select-on-focus rv-focus />
+            <input
+                class="rv-shareLink"
+                type="text"
+                ng-model="self.url"
+                aria-label="{{'sidenav.label.sharelink' | translate}}"
+                readonly
+                md-select-on-focus
+                rv-focus
+            />
             <span>{{'sidenav.label.copy' | translate}}</span>
         </md-input-container>
     </rv-content-pane>

--- a/packages/ramp-core/src/locales/translations.csv
+++ b/packages/ramp-core/src/locales/translations.csv
@@ -382,6 +382,7 @@ Geometry types,geometry.type.imagery,imagery,1,imagerie,1
 ,helpui.nothingfound,Nothing is found. Please try a different search.,1,Rien n’est trouvé. Veuillez essayer une recherche différente.,1
 ,helpui.search,Search Help,1,Aide à la recherche,1
 ,helpui.clearsearch,Clear,1,Effacer,1
+,helpui.expand,Expand,1,Agrandir,1
 Error message when resource fails to load,toc.error.resource.loadfailed,There was an error retrieving this resource - try again later,1,Une erreur s'est produite lors du chargement de cette ressource - réessayez plus tard,1
 Error message when feature count cannot be retrieved,toc.error.resource.countfailed,Could not get number of,1,Impossible d'obtenir le nombre de,1
 ,metadata.xslt.Abstract,Abstract,1,Résumé,1


### PR DESCRIPTION
fixes #3963 #3959 

The help expand buttons now have an `aria-label` of "Expand", this is the same as the expand buttons in details.

The bookmark "input" has an `aria-label` of "Link to share".

DEMO: http://ramp4-app.azureedge.net/legacy/users/spencerwahl/missing-labels/samples/index-samples.html
Nothing should be different visually, if you inspect both of the elements talked about above you should see an `aria-label` attribute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3965)
<!-- Reviewable:end -->
