### PR TITLE
fix(ui): fix side menu opening unexpectedly 

### DIFF
--- a/packages/ramp-core/src/app/ui/appbar/appbar.html
+++ b/packages/ramp-core/src/app/ui/appbar/appbar.html
@@ -48,7 +48,7 @@
         ng-if="self.config.ui.appBar.basemap"
         aria-label="{{ 'nav.tooltip.basemap' | translate }}"
         class="md-icon-button primary"
-        ng-click="self.openBasemapSelector()"
+        ng-click="self.openBasemapSelector(false)"
         ng-show="self.panelRegistry.legend.isOpen"
     >
         <md-tooltip>{{ 'nav.tooltip.basemap' | translate }}</md-tooltip>

--- a/packages/ramp-core/src/app/ui/basemap/basemap.service.js
+++ b/packages/ramp-core/src/app/ui/basemap/basemap.service.js
@@ -11,6 +11,7 @@ angular.module('app.ui').factory('basemapService', basemapService);
 
 function basemapService($rootElement, $mdSidenav, $q) {
     let closePromise;
+    let isSideMenuOpen;
 
     const service = {
         open,
@@ -27,13 +28,16 @@ function basemapService($rootElement, $mdSidenav, $q) {
      * @function open
      * @return  {Promise}   resolves to undefined when panel animation is complete
      */
-    function open() {
+    function open(sideMenuOpen = false) {
         closePromise = $q($mdSidenav('right').onClose).then(() => setOtherChromeOpacity(1));
+        isSideMenuOpen = sideMenuOpen;
 
         setOtherChromeOpacity(0.2);
 
-        // close the side menu
-        $mdSidenav('left').close();
+        // if opened using the side menu, close it while this panel is open.
+        if (isSideMenuOpen) {
+            $mdSidenav('left').close();
+        }
 
         return (
             $mdSidenav('right')
@@ -59,7 +63,10 @@ function basemapService($rootElement, $mdSidenav, $q) {
      * @return  {Promise}   resolves to undefined when panel animation is complete
      */
     function close() {
-        $mdSidenav('left').open();
+        if (isSideMenuOpen) {
+            $mdSidenav('left').open();
+        }
+
         return $mdSidenav('right').close();
     }
 

--- a/packages/ramp-core/src/app/ui/sidenav/sidenav.service.js
+++ b/packages/ramp-core/src/app/ui/sidenav/sidenav.service.js
@@ -66,7 +66,7 @@ function sideNavigationService(
             label: 'nav.label.basemap',
             icon: 'maps:map',
             action: () => {
-                basemapService.open();
+                basemapService.open(true);
             },
         },
         geoSearch: {

--- a/packages/ramp-core/src/content/samples/config/config-sample-01.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-01.json
@@ -169,6 +169,7 @@
                 "name": "WMS Layer with a really long name",
                 "layerType": "ogcWms",
                 "disabledControls": ["styles"],
+                "suppressGetCapabilities": true,
                 "layerEntries": [
                     {
                         "id": "GDPS.ETA_UU",
@@ -176,7 +177,7 @@
                         "currentStyle": "WINDARROWKMH"
                     }
                 ],
-                "url": "http://geo.weather.gc.ca/geomet/?lang=E&service=WMS&request=GetCapabilities"
+                "url": "https://geo.weather.gc.ca/geomet/?lang=E&service=WMS&request=GetCapabilities"
             }
         ],
         "extentSets": [


### PR DESCRIPTION
Closes #3966 

The side menu will no longer open after closing the basemap panel (after it has been opened through the appbar).

This PR also fixes some small issues with sample 1: the WMS layer & legend icon should now load properly.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/334-fixes/samples/index-samples.html).

**Test 1 Instructions**
- open the basemap panel through the appbar
- close the basemap panel
- the side menu should not open

**Test 2 Instructions**
- open the basemap panel through the side menu
- close the basemap panel
- the side menu should open

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3967)
<!-- Reviewable:end -->
