### PR TITLE
fix(geosearch): keep province and type filters after projection change

### DIFF
--- a/packages/ramp-core/src/app/ui/geosearch/geosearch-bottom-filters.directive.js
+++ b/packages/ramp-core/src/app/ui/geosearch/geosearch-bottom-filters.directive.js
@@ -36,9 +36,9 @@ function Controller(geosearchFiltersService, debounceService) {
     'ngInject';
     const self = this;
 
-    self.visibleOnly = false;
-
     self.service = geosearchFiltersService;
+
+    self.visibleOnly = self.service.lastVisible;
 
     self.onUpdateDebounce = onUpdateDebounceBuilder();
 

--- a/packages/ramp-core/src/app/ui/geosearch/geosearch-filters.service.js
+++ b/packages/ramp-core/src/app/ui/geosearch/geosearch-filters.service.js
@@ -17,6 +17,10 @@ function geosearchFiltersService($translate, events, configService, geoService, 
         provinceIndexes: [],
         typeIndexes: [],
 
+        lastProvince: '', // last province filter saved
+        lastType: '', // last type filter saved
+        lastVisible: false, // last value of visible only
+
         setProvince,
         setType,
         setVisible,
@@ -46,20 +50,24 @@ function geosearchFiltersService($translate, events, configService, geoService, 
      * Sets the filter promise for the query.
      *
      * @function setProvince
-     * @param {String} provinceCode code of the province to be set
+     * @param {String} selectedProvince province filter to be set
      */
-    function setProvince(provinceCode) {
-        geosearchService.setProvince(provinceCode);
+    function setProvince(selectedProvince) {
+        const provinceFilter = selectedProvince && selectedProvince.name ? selectedProvince.name : undefined;
+        geosearchService.setProvince(provinceFilter);
+        service.lastProvince = selectedProvince;
     }
 
     /**
      * Sets the type promise for the query.
      *
      * @function setType
-     * @param {String} typeCode code of the results type to be set
+     * @param {String} selectedType type filter to be set
      */
-    function setType(typeCode) {
-        geosearchService.setType(typeCode);
+    function setType(selectedType) {
+        const typeFilter = selectedType && selectedType.name ? selectedType.name : undefined;
+        geosearchService.setType(typeFilter);
+        service.lastType = selectedType;
     }
 
     /**
@@ -75,6 +83,7 @@ function geosearchFiltersService($translate, events, configService, geoService, 
         } else {
             ref.extentChangeListener(); // unsubscribe from event
         }
+        service.lastVisible = visibleOnly;
 
         setExtentParameter();
 

--- a/packages/ramp-core/src/app/ui/geosearch/geosearch-top-filters.directive.js
+++ b/packages/ramp-core/src/app/ui/geosearch/geosearch-top-filters.directive.js
@@ -36,14 +36,15 @@ function Controller(geosearchFiltersService) {
     'ngInject';
     const self = this;
 
-    self.selectedProvince = null;
-    self.selectedType = null;
-
     self.service = geosearchFiltersService;
 
     self.clear = clear;
     self.setType = setType;
     self.setProvince = setProvince;
+
+    // keep existing filter values if necessary
+    self.selectedProvince = self.service.lastProvince ? self.service.lastProvince : null;
+    self.selectedType = self.service.lastType ? self.service.lastType : null;
 
     return;
 
@@ -54,7 +55,7 @@ function Controller(geosearchFiltersService) {
      * @private
      */
     function setProvince() {
-        self.service.setProvince(self.selectedProvince.name);
+        self.service.setProvince(self.selectedProvince);
         self.onUpdate();
 
         // reset the selection like clear to unselect the option if -1
@@ -71,7 +72,7 @@ function Controller(geosearchFiltersService) {
      * @private
      */
     function setType() {
-        self.service.setType(self.selectedType.name);
+        self.service.setType(self.selectedType);
         self.onUpdate();
 
         // reset the selection like clear to unselect the option if -1


### PR DESCRIPTION
Closes #3964 

Steps to test: 
1. Type anything into geosearch (e.g. Toronto) and add filter(s) (e.g. Type - City)
2. Change projection to trigger reload 
3. Open geosearch and all searched results should be there along with the filters applied and can be cleared properly
4. Ensure other geosearch functionality still works as intended

[Demo](http://ramp4-app.azureedge.net/legacy/users/yileifeng/3964-geosearch-reprojection/samples/index-samples.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3968)
<!-- Reviewable:end -->
