### PR TITLE
feat(ui): add legend + expand/collapse tooltips

### DIFF
--- a/packages/ramp-core/src/app/ui/details/details-record-esrifeature-item.html
+++ b/packages/ramp-core/src/app/ui/details/details-record-esrifeature-item.html
@@ -7,6 +7,9 @@
         ng-click="self.toggleDetails()"
         aria-label="{{ 'details.aria.toggle' | translate }}"
     >
+        <md-tooltip md-direction="top"
+            >{{ self.isExpanded ? 'details.tooltip.collapse' : 'details.tooltip.expand' | translate }}</md-tooltip
+        >
     </md-button>
 
     <rv-symbology-stack symbology="self.item.symbologyStack"></rv-symbology-stack>

--- a/packages/ramp-core/src/app/ui/help/help-summary.html
+++ b/packages/ramp-core/src/app/ui/help/help-summary.html
@@ -24,8 +24,11 @@
                     <md-button
                         class="rv-group-body-button rv-button-square"
                         ng-click="section.isExpanded = !section.isExpanded"
-                        aria-label="{{ 'helpui.expand' | translate }}"
-                    ></md-button>
+                        aria-label="{{ section.isExpanded ? 'helpui.collapse' : 'helpui.expand' | translate }}"
+                        ><md-tooltip md-direction="top"
+                            >{{ section.isExpanded ? 'helpui.collapse' : 'helpui.expand' | translate }}</md-tooltip
+                        ></md-button
+                    >
 
                     <h4
                         class="rv-group-name"

--- a/packages/ramp-core/src/app/ui/toc/legend-element-factory.class.js
+++ b/packages/ramp-core/src/app/ui/toc/legend-element-factory.class.js
@@ -421,6 +421,10 @@ function LegendElementFactory(
             return 'toc.label.dataTable';
         }
 
+        get tooltip() {
+            return 'toc.tooltip.openDataTable';
+        }
+
         action() {
             this._debouncedAction();
         }

--- a/packages/ramp-core/src/app/ui/toc/templates/legend-control-body.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/legend-control-body.html
@@ -4,6 +4,9 @@
     ng-disabled="self.uiControl.isDisabled"
     ng-click="self.uiControl.action(); self.notifyApiClick(self.block)"
 >
+    <md-tooltip md-direction="top"
+        >{{ !!self.uiControl.tooltip ? self.uiControl.tooltip : self.uiControl.label | translate }}</md-tooltip
+    >
     <md-tooltip md-delay="self.node.getTooltipDelay()" md-direction="{{ self.node.getTooltipDirection() }}"
         >{{ self.block.name }}</md-tooltip
     >

--- a/packages/ramp-core/src/app/ui/toc/templates/legend-group.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/legend-group.html
@@ -5,6 +5,9 @@
         ng-click="self.block.expanded = !self.block.expanded"
         aria-label="{{ self.block.expanded ? 'toc.label.group.collapse' : 'toc.label.group.expand' | translate }}"
     >
+        <md-tooltip md-direction="top"
+            >{{ self.block.expanded ? 'toc.label.group.collapse' : 'toc.label.group.expand' | translate }}</md-tooltip
+        >
         <md-tooltip md-delay="self.getTooltipDelay()" md-direction="{{ self.getTooltipDirection() }}"
             >{{ self.block.name }}</md-tooltip
         >

--- a/packages/ramp-core/src/content/samples/config/config-sample-05.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-05.json
@@ -2,7 +2,12 @@
     "ui": {
         "navBar": {
             "zoom": "buttons",
-            "extra": ["fullscreen", "geoLocator", "home", "help"]
+            "extra": [
+                "fullscreen",
+                "geoLocator",
+                "home",
+                "help"
+            ]
         },
         "sideMenu": {
             "logo": true
@@ -77,7 +82,9 @@
                     {
                         "name": "Power Plants, 100 MW or more",
                         "expanded": true,
-                        "controls": ["visibility"],
+                        "controls": [
+                            "visibility"
+                        ],
                         "children": [
                             {
                                 "exclusiveVisibility": [

--- a/packages/ramp-core/src/locales/translations.csv
+++ b/packages/ramp-core/src/locales/translations.csv
@@ -86,6 +86,7 @@ Details pane aria label for expand button,details.aria.expand,Expand,1,Agrandir,
 Details pane aria label for dialog modal,details.aria.dialog,Details Summary,1,Détails Résumé,0
 Details pane aria label for toggle button,details.aria.toggle,Toggle Details,1,Détails à bascule,0
 Details pane tooltip for expand button,details.tooltip.expand,Expand,1,Agrandir,1
+,details.tooltip.collapse,Collapse,1,Réduire,1
 Details pane label for no result,details.label.noresult,Nothing found,1,Aucun résultat,1
 Details pane label for searching,details.label.searching,Searching ...,1,Rechercher ...,1
 Content pane aria label for close button,contentPane.aria.close,Close,1,Fermer,1
@@ -264,6 +265,7 @@ Table of Content templates placeholder loading error label,toc.tmp.label.error.l
 Table of Content zoom to boundary label,toc.label.boundaryZoom,Zoom to Layer Boundary,1,Zoomer à la limite,1
 Table of Content open datatable label,toc.label.dataTable,Datatable,1,Tableau de données,1
 Table of Content zoom to boundary tooltip,toc.tooltip.boundaryZoom,Zoom to Layer Boundary,1,Zoomer à la limite,1
+,toc.tooltip.openDataTable,Open Datatable,1,Ouvrir le tableau de données,0
 ,toc.layer.longload.message,{{name}} is taking longer than expected,1,{{name}} prend plus longtemps que prévu,1
 ,toc.layer.longload.hide,Dismiss,1,Rejeter,0
 ,toc.layer.longload.failed,{{name}} failed to load,1,Échec du chargement de {{name}},1
@@ -383,6 +385,7 @@ Geometry types,geometry.type.imagery,imagery,1,imagerie,1
 ,helpui.search,Search Help,1,Aide à la recherche,1
 ,helpui.clearsearch,Clear,1,Effacer,1
 ,helpui.expand,Expand,1,Agrandir,1
+,helpui.collapse,Collapse,1,Réduire,1
 Error message when resource fails to load,toc.error.resource.loadfailed,There was an error retrieving this resource - try again later,1,Une erreur s'est produite lors du chargement de cette ressource - réessayez plus tard,1
 Error message when feature count cannot be retrieved,toc.error.resource.countfailed,Could not get number of,1,Impossible d'obtenir le nombre de,1
 ,metadata.xslt.Abstract,Abstract,1,Résumé,1


### PR DESCRIPTION
closes #3961 

Tooltips added to
- legend groups
- legend entries that are clickable
- expand/collapse buttons in details + help

DEMO: http://ramp4-app.azureedge.net/legacy/users/spencerwahl/missing-labels/samples/index-samples.html

hover over/tab to stuff, you should see the tooltips listed above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3969)
<!-- Reviewable:end -->
