### PR TITLE
fix(enhancedTable): fix off-centre focus ring for column reorder arrows

### DIFF
--- a/packages/ramp-plugin-enhanced-table/src/main.scss
+++ b/packages/ramp-plugin-enhanced-table/src/main.scss
@@ -73,7 +73,7 @@ md-datepicker > div {
 .reorder-button {
     margin: 0 !important;
     width: 18px !important;
-    height: 18px !important;
+    height: 40px !important;
     min-height: 0 !important;
     border-radius: 0 !important;
 


### PR DESCRIPTION
Closes #3962 

Changes the height of reorder arrows to center focus ring: 

![image](https://user-images.githubusercontent.com/31557789/125510604-0630ed20-e730-4ea9-9187-4afc2b338b8e.png)

[Demo link](http://ramp4-app.azureedge.net/legacy/users/yileifeng/3962-grid-focus-ring/samples/index-samples.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3985)
<!-- Reviewable:end -->
