### PR TITLE
fix(toc): fix navigation between symbology stack components

### DIFF
--- a/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
+++ b/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
@@ -305,17 +305,8 @@ function rvSymbologyStack($rootScope, $rootElement, $q, Geo, configService, anim
         scope.$watch('self.showSymbologyToggle', (value) => {
             if (value) {
                 element.find('.md-icon-button').addClass('show');
-
-                // If the symbology contains more than one icon, link the symbology stack to the first
-                // checkbox so it can be focused on.
-                if (self.symbology.stack.length > 1) {
-                    $.link(element.find('.md-icon-button'));
-                }
-
-                element.find('button').not('.rv-symbol-trigger').removeAttr('nofocus').addClass('focusOnce');
             } else {
                 element.find('.md-icon-button').removeClass('show');
-                element.find('button').not('.rv-symbol-trigger').attr('nofocus', true).removeClass('focusOnce');
             }
         });
 

--- a/packages/ramp-core/src/app/ui/toc/templates/symbology-stack.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/symbology-stack.html
@@ -2,6 +2,23 @@
     class="rv-symbology-container rv-render-{{ self.symbology.renderStyle }} rv-compound"
     ng-class='[{ "rv-expanded" : self.isExpanded }, { "rv-one" : self.symbology.stack.length === 1 }]'
 >
+    <md-button
+        ng-style="{'z-index': 100 + self.symbology.stack.length + 2 }"
+        class="rv-symbol-trigger rv-button-32 rv-icon-24 md-icon-button"
+        ng-if="self.symbology.isInteractive"
+        ng-click="self.expandSymbology(); self.showSymbologyBorder()"
+        ng-focus="self.fanOutSymbology(true); self.showSymbologyBorder(true)"
+        ng-blur="self.fanOutSymbology(false); self.showSymbologyBorder(false)"
+        ng-mouseover="self.fanOutSymbology(true)"
+        ng-mouseout="self.fanOutSymbology(false)"
+    >
+        <md-tooltip md-direction="top">
+            {{ self.symbology.expanded ? 'toc.layer.label.symbologyHide' : 'toc.layer.label.symbologyShow' | translate
+            }}
+        </md-tooltip>
+        <md-icon md-svg-src="navigation:close"></md-icon>
+    </md-button>
+
     <div class="rv-description-container">
         <span class="rv-description">{{ ::self.description }}</span>
     </div>
@@ -54,21 +71,4 @@
             >
         </md-button>
     </div>
-
-    <md-button
-        ng-style="{'z-index': 100 + self.symbology.stack.length + 2 }"
-        class="rv-symbol-trigger rv-button-32 rv-icon-24 md-icon-button"
-        ng-if="self.symbology.isInteractive"
-        ng-click="self.expandSymbology(); self.showSymbologyBorder()"
-        ng-focus="self.fanOutSymbology(true); self.showSymbologyBorder(true)"
-        ng-blur="self.fanOutSymbology(false); self.showSymbologyBorder(false)"
-        ng-mouseover="self.fanOutSymbology(true)"
-        ng-mouseout="self.fanOutSymbology(false)"
-    >
-        <md-tooltip md-direction="top">
-            {{ self.symbology.expanded ? 'toc.layer.label.symbologyHide' : 'toc.layer.label.symbologyShow' | translate
-            }}
-        </md-tooltip>
-        <md-icon md-svg-src="navigation:close"></md-icon>
-    </md-button>
 </div>


### PR DESCRIPTION
Closes #3960 

This PR allows you to navigate properly between the individual components of the symbology stack.

You can find a demo link [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3660/samples/index-samples.html?sample=91).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3987)
<!-- Reviewable:end -->
