### PR TITLE
fix(ui): remove horizontal scrollbar from modal windows

### DIFF
--- a/packages/ramp-core/src/content/styles/modules/_content-pane.scss
+++ b/packages/ramp-core/src/content/styles/modules/_content-pane.scss
@@ -18,7 +18,7 @@
             height: auto; // 1px needed for a border
             min-height: $toolbar-height + 1px;
             align-items: center;
-            padding: 0 0 0 rem(1.6);
+            padding: 0 1 0 rem(1.6);
 
             .rv-header-content {
                 overflow: hidden;


### PR DESCRIPTION
Closes #3970 

When the `close` button tooltip is focused, there will no longer be a horizontal scroll bar at the bottom of the modal window. As far as I'm aware, the close button being focused when the window opens is intentional, so I didn't fix this part of the issue. Let me know if I'm wrong here though.

You can find a demo of this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3970/samples/index-samples.html).

**Test Instructions**
Click any button that opens a modal window (`share`, `help`, expand `details`, etc.) and put focus on the close button if it isn't already. There should no longer be a horizontal scroll bar at the bottom unless necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3989)
<!-- Reviewable:end -->
