### PR TITLE
Rename "Hide Columns" button to "Toggle Columns" in the data table

### DIFF
--- a/packages/ramp-plugin-enhanced-table/src/index.ts
+++ b/packages/ramp-plugin-enhanced-table/src/index.ts
@@ -434,8 +434,8 @@ TableBuilder.prototype.translations = {
                 clear: 'Clear filters',
                 apply: 'Apply filters to map',
             },
-            hideColumns: 'Hide columns',
-            hideAllColumns: 'All',
+            toggleColumns: 'Toggle columns',
+            toggleAllColumns: 'All',
             complexValue: 'Complex Value',
         },
         menu: {
@@ -481,8 +481,8 @@ TableBuilder.prototype.translations = {
                 clear: 'Effacer les filtres',
                 apply: 'Appliquer des filtres à la carte', // TODO: Add official French translation
             },
-            hideColumns: 'Masquer les colonnes', // TODO: Add Official French translation
-            hideAllColumns: 'Tous les',
+            toggleColumns: 'Toggle les colonnes', // TODO: Add Official French translation
+            toggleAllColumns: 'Tous les',
             complexValue: 'Valeur Complexes',
         },
         menu: {

--- a/packages/ramp-plugin-enhanced-table/src/templates.ts
+++ b/packages/ramp-plugin-enhanced-table/src/templates.ts
@@ -47,19 +47,19 @@ export const COLUMN_VISIBILITY_MENU_TEMPLATE = `
 <md-menu-bar class="table-control" ng-controller="ColumnVisibilityMenuCtrl as ctrl">
     <md-menu md-position-mode="target-right target">
         <md-button
-            aria-label="{{ 'plugins.enhancedTable.table.hideColumns' | translate }}"
+            aria-label="{{ 'plugins.enhancedTable.table.toggleColumns' | translate }}"
             class="md-icon-button black"
             ng-click="$mdOpenMenu($event)">
-            <md-tooltip>{{ 'plugins.enhancedTable.table.hideColumns' | translate }}</md-tooltip>
+            <md-tooltip>{{ 'plugins.enhancedTable.table.toggleColumns' | translate }}</md-tooltip>
             <md-icon md-svg-src="community:format-list-checks"></md-icon>
         </md-button>
         <md-menu-content class="rv-menu rv-dense">
             <md-menu-item>
                 <md-button
                     ng-click="ctrl.toggleAllColumns()"
-                    aria-label="{{ 'plugins.enhancedTable.table.hideAllColumns' | translate }}"
+                    aria-label="{{ 'plugins.enhancedTable.table.toggleAllColumns' | translate }}"
                     md-prevent-menu-close="md-prevent-menu-close">
-                    <span style='flex-basis: auto; overflow-wrap:normal;'>{{ 'plugins.enhancedTable.table.hideAllColumns' | translate }}</span>
+                    <span style='flex-basis: auto; overflow-wrap:normal;'>{{ 'plugins.enhancedTable.table.toggleAllColumns' | translate }}</span>
                     <md-icon md-svg-icon="action:done" ng-if="!ctrl.allColumnsVisible()"></md-icon>
                 </md-button>
             </md-menu-item>


### PR DESCRIPTION
Related issue: #3973 

Renamed the "Hide Columns" button to "Toggle Columns" to better describe the button functionality.
Added unofficial French translations for the new strings. 

[Demo](http://ramp4-app.azureedge.net/legacy/users/sharvenp/3973/samples/index-samples.html)

To test:
1. Load RAMP
2. Hover over the toggle columns button in the data table and check the label
3. Use a [screen reader](https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn?hl=en) and TAB to the button and check if the label can be read
4. Change the language and do the same

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3991)
<!-- Reviewable:end -->
