### PR TITLE
Fix date filter to single-out dates when min=max

### DIFF
--- a/packages/ramp-plugin-enhanced-table/src/custom-floating-filters.ts
+++ b/packages/ramp-plugin-enhanced-table/src/custom-floating-filters.ts
@@ -58,17 +58,36 @@ export function setUpDateFilter(
     defaultValue = minAndMaxFilters !== undefined ? minAndMaxFilters : defaultValue;
 
     colDef.minWidth = 423;
+
     // Column should render and filter date properly
     colDef.filter = 'agDateColumnFilter';
+    colDef.filterParams.inRangeInclusive = true;
     colDef.filterParams.comparator = function (filterDate, entryDate) {
         let entry = new Date(entryDate);
-        if (entry > filterDate) {
+
+        // We need to specifically compare the UTC year, month, and date because
+        // directly comparing the dates returns the wrong value due to timezone differences
+        // Thus both dates need to be converted to UTC before comparing
+
+        // Check year
+        if (entry.getFullYear() > filterDate.getFullYear()) {
             return 1;
-        } else if (entry < filterDate) {
+        } else if (entry.getFullYear() < filterDate.getFullYear()) {
             return -1;
-        } else {
-            return 0;
         }
+
+        // At this point year is the same
+        // Check month
+        if (entry.getMonth() > filterDate.getMonth()) {
+            return 1;
+        } else if (entry.getMonth() < filterDate.getMonth()) {
+            return -1;
+        }
+
+        // At this point month is the same
+        // Now return the sign based on the date difference
+        // Note here we use getDate() and not getUTCDate() to avoid shifting the date
+        return entry.getDate() - filterDate.getDate();
     };
 
     $.extend(colDef.floatingFilterComponentParams, {


### PR DESCRIPTION
Related issue: #3975 

When the min and max date are set to the same value on the date filter, it will now filter out that specific date. 

[Demo](http://ramp4-app.azureedge.net/legacy/users/sharvenp/date-filter-fix/samples/index-samples.html)

To test:
1. Load RAMP
2. Load this layer: https://maps-cartes.ec.gc.ca/arcgis/rest/services/Shellfish_Classification_Mollusques/MapServer/6 (Feature layer)
3. In the "RISC_DATE" field, set the min date and max date to the same value
    - Pick one of the existing date values in the column to single it out

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3992)
<!-- Reviewable:end -->
