### PR TITLE
fix(enhancedTable): remove error when navigating using arrow keys

### DIFF
--- a/packages/ramp-plugin-enhanced-table/src/panel-manager.ts
+++ b/packages/ramp-plugin-enhanced-table/src/panel-manager.ts
@@ -278,7 +278,9 @@ export class PanelManager {
                     .find(`[legend-block-id="${this.legendBlock.id}"] button`)
                     .filter(':visible')
                     .first();
-                (<EnhancedJQuery>(<unknown>$(sourceEl))).link($(document).find(`#enhancedTable`));
+                (<EnhancedJQuery>(<unknown>$(sourceEl))).link(
+                    $(document).find(`#enhancedTable-${this.mapApi.identifier}`)
+                );
 
                 // Set up grid <-> filter accessibility
                 this.gridBody = this.panel.element[0].getElementsByClassName('ag-body')[0];

--- a/packages/ramp-plugin-enhanced-table/src/panel-status-manager.ts
+++ b/packages/ramp-plugin-enhanced-table/src/panel-status-manager.ts
@@ -30,9 +30,12 @@ export class PanelStatusManager {
             const focusedCell = that.tableOptions.api.getFocusedCell();
 
             if (focusedCell !== null) {
+                const mapName = that.panelManager.mapApi.identifier;
+
                 const topRow = parseInt(scrollRange.split(' - ')[0]) - 1;
                 const bottomRow = parseInt(scrollRange.split(' - ')[1]) - 1;
-                const tableRight = $('#enhancedTable').position().left + $('#enhancedTable').width();
+                const tableRight =
+                    $(`#enhancedTable-${mapName}`).position().left + $(`#enhancedTable-${mapName}`).width();
                 const focusedCellRight = $('.ag-cell-focus').offset().left + $('.ag-cell-focus').width();
                 const focusedRow = focusedCell.rowIndex;
 


### PR DESCRIPTION
Closes #3978 

When using the arrow keys to navigate through the data table cells, console errors will no longer appear.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3978/samples/index-samples.html).

**Test Instructions**
1. Open a data table and the developer console.
2. Use the arrow keys to navigate through cells.
3. There should no longer be errors displayed in the console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/3993)
<!-- Reviewable:end -->
