### PR TITLE
fix stateOnly check to work with layer groups

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -38,7 +38,7 @@ specifiers:
   babel-preset-latest: ^6.24.1
   babel-preset-stage-2: ^6.24.1
   babel-runtime: 6.26.0
-  caniuse-lite: ^1.0.30001159
+  caniuse-lite: ^1.0.30001283
   canvg-origin: ^1.0.0
   colourpicker: github:fgpv-vpgf/colourpicker#2464e48ac0f373055dcdbe2fb0f8b3ab72244fef
   copy-webpack-plugin: 5.0.4
@@ -145,7 +145,7 @@ dependencies:
   babel-preset-latest: 6.24.1
   babel-preset-stage-2: 6.24.1
   babel-runtime: 6.26.0
-  caniuse-lite: 1.0.30001218
+  caniuse-lite: 1.0.30001283
   canvg-origin: 1.0.0
   colourpicker: github.com/fgpv-vpgf/colourpicker/2464e48ac0f373055dcdbe2fb0f8b3ab72244fef
   copy-webpack-plugin: 5.0.4
@@ -2497,7 +2497,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001218
+      caniuse-lite: 1.0.30001283
       colorette: 1.2.2
       electron-to-chromium: 1.3.722
       escalade: 3.1.1
@@ -2716,13 +2716,17 @@ packages:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
       browserslist: 4.16.5
-      caniuse-lite: 1.0.30001218
+      caniuse-lite: 1.0.30001283
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: false
 
   /caniuse-lite/1.0.30001218:
     resolution: {integrity: sha512-0ASydOWSy3bB88FbDpJSTt+PfDwnMqrym3yRZfqG8EXSQ06OZhF+q5wgYP/EN+jJMERItNcDQUqMyNjzZ+r5+Q==}
+    dev: false
+
+  /caniuse-lite/1.0.30001283:
+    resolution: {integrity: sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==}
     dev: false
 
   /canonical-path/0.0.2:
@@ -7236,27 +7240,6 @@ packages:
     resolution: {integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=}
     dev: false
 
-  /jsdoc/3.6.6:
-    resolution: {integrity: sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==}
-    engines: {node: '>=8.15.0'}
-    hasBin: true
-    dependencies:
-      '@babel/parser': 7.13.16
-      bluebird: 3.7.2
-      catharsis: 0.8.11
-      escape-string-regexp: 2.0.0
-      js2xmlparser: 4.0.1
-      klaw: 3.0.0
-      markdown-it: 10.0.0
-      markdown-it-anchor: 5.3.0_markdown-it@10.0.0
-      marked: 0.8.2
-      mkdirp: 1.0.4
-      requizzle: 0.2.3
-      strip-json-comments: 3.1.1
-      taffydb: 2.6.2
-      underscore: 1.10.2
-    dev: false
-
   /jsdoc/3.6.7:
     resolution: {integrity: sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==}
     engines: {node: '>=8.15.0'}
@@ -11284,6 +11267,7 @@ packages:
   /svgo/1.3.2:
     resolution: {integrity: sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==}
     engines: {node: '>=4.0.0'}
+    deprecated: This SVGO version is no longer supported. Upgrade to v2.x.x.
     hasBin: true
     dependencies:
       chalk: 2.4.2
@@ -13320,7 +13304,7 @@ packages:
     dev: false
 
   file:projects/ramp-core.tgz:
-    resolution: {integrity: sha512-8b/3ycD+M/I7rrYMdZ1n9dEoNaELkePKyyRcP5DtE9x2b+AnVMgRMCoddlRhlYqkDSg2CB5OcplDdqgkCit0cQ==, tarball: file:projects/ramp-core.tgz}
+    resolution: {integrity: sha512-9B9nS/rY2MDLq0jkgOZ1lflANjjgyQlNgVa3k709Tehj98gUfT+sb2eX/UzODayP+NZoAFtUpubKBJkf7ty16g==, tarball: file:projects/ramp-core.tgz}
     name: '@rush-temp/ramp-core'
     version: 0.0.0
     dependencies:
@@ -13345,7 +13329,7 @@ packages:
       babel-plugin-transform-runtime: 6.23.0
       babel-preset-env: 1.6.1
       babel-runtime: 6.26.0
-      caniuse-lite: 1.0.30001218
+      caniuse-lite: 1.0.30001283
       colourpicker: github.com/fgpv-vpgf/colourpicker/2464e48ac0f373055dcdbe2fb0f8b3ab72244fef
       copy-webpack-plugin: 5.0.4_webpack@4.39.1
       css-loader: 3.2.0_webpack@4.39.1
@@ -13426,7 +13410,7 @@ packages:
       docdash: github.com/alyec/docdash/0ac9d0dd482a9b65aa0885d5279fafc566a91f9b
       jasmine: 2.99.0
       js-sql-parser: 1.0.7
-      jsdoc: 3.6.6
+      jsdoc: 3.6.7
       lodash: 4.17.21
       proj4: 2.7.2
       rcolor: 1.0.1

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -29,7 +29,7 @@
         "angular-translate": "2.18.1",
         "angular-translate-loader-static-files": "2.18.1",
         "babel-runtime": "6.26.0",
-        "caniuse-lite": "^1.0.30001159",
+        "caniuse-lite": "^1.0.30001283",
         "colourpicker": "github:fgpv-vpgf/colourpicker#2464e48ac0f373055dcdbe2fb0f8b3ab72244fef",
         "csvtojson": "1.1.11",
         "dotjem-angular-tree": "github:dotJEM/angular-tree",


### PR DESCRIPTION
Closes #4002 

Layer groups that are added through the wizard should now correctly work with identify and should no longer display an error in the console.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-4002/samples/index-samples.html?sample=93).

To test this PR, make sure sample 93 still works as described in the fix for #3908:
>This PR adds a new sample page that contains a dynamic layer with stateOnly set to true on all children (the icon with the water droplets on it), and a dynamic layer with stateOnly set to true on one of its children (the blue circle with a flame in it).

Additionally, try following the steps posted [here](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/4002#issuecomment-978163190) and ensure that no error appears and that the sublayers can be identified correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4005)
<!-- Reviewable:end -->
