### PR TITLE
fix(legend): add timeout before auto expand to prevent race condition

### DIFF
--- a/packages/ramp-core/src/content/samples/config/config-many-1.json
+++ b/packages/ramp-core/src/content/samples/config/config-many-1.json
@@ -1,0 +1,266 @@
+{
+    "ui": {
+        "title": "Releases to Air by In Situ Facilities for All Substances 2009 to 2017 (time slider)",
+        "appBar": {
+            "basemap": false
+        },
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
+        },
+        "sideMenu": {
+            "logo": true,
+            "items": [["layers"], ["fullscreen", "export", "share", "touch", "help", "about"], ["language"]]
+        },
+        "help": {
+            "folderName": "default"
+        },
+        "legend": {
+            "allowImport": false,
+            "isOpen": {
+                "large": true,
+                "medium": true,
+                "small": true
+            }
+        }
+    },
+    "version": "2.0",
+    "language": "en",
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Releases to Air by In Situ Facilities for All Substances 2009 to 2017 (time slider)"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "timeout": 5000,
+            "footnote": {
+                "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+            }
+        },
+        "search": {
+            "serviceUrls": {
+                "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseEsriTopo",
+        "components": {
+            "geoSearch": {
+                "enabled": false
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 102100
+                }
+            },
+            "northArrow": {
+                "enabled": true
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "ReleasestoAirbyInSituFacilitiesforAllSubstances2009to2017(timeslider)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "ReleasestoAirbyInSituFacilitiesforAllSubstances2009to2017(timeslider)",
+                "name": "Releases to Air by In Situ Facilities for All Substances 2009 to 2017 (time slider)",
+                "layerType": "esriFeature",
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/StoryRAMP/MapServer/4"
+            }
+        ],
+        "extentSets": [
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -11484319.392198805,
+                    "xmin": -14267850.214231044,
+                    "ymax": 8349344.827914256,
+                    "ymin": 6637155.394326762
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.87924099992,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.992452562495,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.4962262813797,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.43702828507324,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.554628535634155,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.388657133974685,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.5971642835598172,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.07464553541190416,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.03732276770595208,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.01866138385297604,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            }
+        ]
+    }
+}

--- a/packages/ramp-core/src/content/samples/config/config-many-2.json
+++ b/packages/ramp-core/src/content/samples/config/config-many-2.json
@@ -1,0 +1,266 @@
+{
+    "ui": {
+        "title": "Releases to Air by In Situ Facilities for All Substances in 2017",
+        "appBar": {
+            "basemap": false
+        },
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
+        },
+        "sideMenu": {
+            "logo": true,
+            "items": [["layers"], ["fullscreen", "export", "share", "touch", "help", "about"], ["language"]]
+        },
+        "help": {
+            "folderName": "default"
+        },
+        "legend": {
+            "allowImport": false,
+            "isOpen": {
+                "large": true,
+                "medium": true,
+                "small": true
+            }
+        }
+    },
+    "version": "2.0",
+    "language": "en",
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Releases to Air by In Situ Facilities for All Substances in 2017"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "timeout": 5000,
+            "footnote": {
+                "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+            }
+        },
+        "search": {
+            "serviceUrls": {
+                "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseEsriTopo",
+        "components": {
+            "geoSearch": {
+                "enabled": false
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 102100
+                }
+            },
+            "northArrow": {
+                "enabled": true
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "ReleasestoAirbyInSituFacilitiesforAllSubstancesin2017",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "ReleasestoAirbyInSituFacilitiesforAllSubstancesin2017",
+                "name": "Releases to Air by In Situ Facilities for All Substances in 2017",
+                "layerType": "esriFeature",
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/StoryRAMP/MapServer/4"
+            }
+        ],
+        "extentSets": [
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -11484319.392198805,
+                    "xmin": -14267850.214231044,
+                    "ymax": 8349344.827914256,
+                    "ymin": 6637155.394326762
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.87924099992,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.992452562495,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.4962262813797,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.43702828507324,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.554628535634155,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.388657133974685,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.5971642835598172,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.07464553541190416,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.03732276770595208,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.01866138385297604,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            }
+        ]
+    }
+}

--- a/packages/ramp-core/src/content/samples/config/config-many-3.json
+++ b/packages/ramp-core/src/content/samples/config/config-many-3.json
@@ -1,0 +1,266 @@
+{
+    "ui": {
+        "title": "Tailings from Mining Facilities 2009 to 2017 (time slider)",
+        "appBar": {
+            "basemap": false
+        },
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
+        },
+        "sideMenu": {
+            "logo": true,
+            "items": [["layers"], ["fullscreen", "export", "share", "touch", "help", "about"], ["language"]]
+        },
+        "help": {
+            "folderName": "default"
+        },
+        "legend": {
+            "allowImport": false,
+            "isOpen": {
+                "large": true,
+                "medium": true,
+                "small": true
+            }
+        }
+    },
+    "version": "2.0",
+    "language": "en",
+    "services": {
+        "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "value": "Tailings from Mining Facilities 2009 to 2017 (time slider)"
+            },
+            "map": {},
+            "mapElements": {},
+            "legend": {},
+            "timeout": 5000,
+            "footnote": {
+                "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
+            }
+        },
+        "search": {
+            "serviceUrls": {
+                "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        }
+    },
+    "map": {
+        "initialBasemapId": "baseEsriTopo",
+        "components": {
+            "geoSearch": {
+                "enabled": false
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 102100
+                }
+            },
+            "northArrow": {
+                "enabled": true
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery"
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "layerId": "TailingsfromMiningFacilities2009to2017(timeslider)",
+                        "symbologyExpanded": true
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "id": "TailingsfromMiningFacilities2009to2017(timeslider)",
+                "name": "Tailings from Mining Facilities 2009 to 2017 (time slider)",
+                "layerType": "esriFeature",
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/StoryRAMP/MapServer/3"
+            }
+        ],
+        "extentSets": [
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -12272079.405705657,
+                    "xmin": -12620020.758459613,
+                    "ymax": 7916959.668162176,
+                    "ymin": 7702935.9889637865
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.87924099992,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.992452562495,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.4962262813797,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.43702828507324,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.554628535634155,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.388657133974685,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.5971642835598172,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.07464553541190416,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.03732276770595208,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.01866138385297604,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "altText - World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "altText - World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            }
+        ]
+    }
+}

--- a/packages/ramp-core/src/content/samples/index-many-2.tpl
+++ b/packages/ramp-core/src/content/samples/index-many-2.tpl
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <title>Test Samples - RAMP2 Viewer</title>
+
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .myMap {
+            height: 100%;
+            border: 1px black solid;
+        }
+
+        .flexMap {
+            flex: 1;
+        }
+
+        #hideShow {
+            position: absolute;
+            width: 10%;
+            right: 45%;
+            z-index: 100;
+            top: 80px;
+            padding: 0;
+        }
+
+        .row {
+            height: 650px;
+            display: flex;
+        }
+    </style>
+    <script src="./plugins/coordInfo/coordInfo.js"></script>
+
+    <% for (var index in htmlWebpackPlugin.files.css) { %>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+        <% } else { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" />
+        <% } %>
+    <% } %>
+
+</head>
+
+<!-- rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/" rv-keys='["Airports"]' -->
+
+<body>
+    <div class="myMap" id="sample-map" is="rv-map" ramp-gtm
+        rv-config="config/config-many-1.json"
+        rv-langs='["en-CA", "fr-CA"]'
+        rv-restore-bookmark="bookmark"
+        rv-plugins="coordInfo"
+        rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/">
+         <noscript>
+            <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
+
+            <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
+        </noscript>
+    </div>
+    <div class="row">
+        <div class="myMap flexMap" id="second-map" is="rv-map" ramp-gtm
+            rv-config="config/config-many-2.json"
+            rv-langs='["en-CA", "fr-CA"]'
+            rv-restore-bookmark="bookmark"
+            rv-plugins="coordInfo"
+            rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/">
+            <noscript>
+                <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
+
+                <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
+            </noscript>
+        </div>
+        <div class="myMap flexMap" id="third-map" is="rv-map" ramp-gtm
+            rv-config="config/config-many-3.json"
+            rv-langs='["en-CA", "fr-CA"]'
+            rv-restore-bookmark="bookmark"
+            rv-plugins="coordInfo"
+            rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/">
+            <noscript>
+                <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
+
+                <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
+            </noscript>
+        </div>
+    </div>
+
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Object.entries,Object.values,Array.prototype.find,Array.prototype.findIndex,Array.prototype.values,Array.prototype.includes,HTMLCanvasElement.prototype.toBlob,String.prototype.repeat,String.prototype.codePointAt,String.fromCodePoint,NodeList.prototype.@@iterator,Promise,Promise.prototype.finally"></script>
+
+    <% for (var index in htmlWebpackPlugin.files.js) { %>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+        <% } else { %>
+            <script src="<%= htmlWebpackPlugin.files.js[index] %>"></script>
+        <% } %>
+    <% } %>
+</body>
+
+</html>


### PR DESCRIPTION
Closes https://github.com/ramp4-pcar4/story-ramp/issues/16. Race conditions are fun.

You can find some extra info on this issue [here](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/3911). The issue is caused by the symbology auto-expand code being called before the DOM elements are fully loaded. The code being called early means that the calculated height is not correct, and causes the elements to overlap or not expand at all. To solve this issue, I've moved the code that does the expanding so that it is run whenever the symbology stack is updated (instead of just being called once on creation in the `link` function). I've also added a short timeout to ensure that the checkboxes are loaded if necessary. Adding a timeout here ensures that the DOM elements have properly loaded before attempting to expand the stack.

I'm not sure if the timeout is the most ideal solution here, but it does seem to fix the problem for StoryRAMP. I wasn't able to figure out another way to ensure the elements had loaded correctly. If anyone has any recommendations here, I'll gladly implement a better solution.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-bad-legend-expand/samples/index-many-2.html).

To test this PR, simply ensure that the symbology stack on each map opens automatically on the sample page. Make sure that the elements don't overlap or open partially as mentioned in #3911.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4006)
<!-- Reviewable:end -->
