### PR TITLE
fix(ui): center icon in expand metadata button

### DIFF
--- a/packages/ramp-core/src/app/ui/metadata/metadata.run.js
+++ b/packages/ramp-core/src/app/ui/metadata/metadata.run.js
@@ -1,8 +1,5 @@
 angular.module('app.ui').run(metadataBlock);
 
-const EXPAND_BTN_TEMPLATE = `<md-tooltip>{{ 'metadata.expand.tooltip' | translate }}</md-tooltip>
-                            <md-icon md-svg-src="action:open_in_new"></md-icon>`;
-
 function metadataBlock(events) {
     let mApi = null;
     const METADATA_BODY = `<rv-metadata-content max-text-length="250"></rv-metadata-content>`;
@@ -36,7 +33,7 @@ function metadataBlock(events) {
                 expandPanel();
             });
 
-            expandBtn.elem.addClass('md-icon-button rv-button-24 rv-gt-sm black');
+            expandBtn.elem.addClass('md-icon-button rv-gt-sm black');
             expandBtn.elem.removeClass('md-raised');
 
             metadataPanel.header.append(expandBtn);

--- a/packages/ramp-core/src/content/styles/modules/_content-pane.scss
+++ b/packages/ramp-core/src/content/styles/modules/_content-pane.scss
@@ -18,7 +18,7 @@
             height: auto; // 1px needed for a border
             min-height: $toolbar-height + 1px;
             align-items: center;
-            padding: 0 1 0 rem(1.6);
+            padding: 0 rem(0.6) 0 rem(1.6);
 
             .rv-header-content {
                 overflow: hidden;


### PR DESCRIPTION
Closes #3972 

This PR centers the icon in the middle of the `expand metadata` focus ring. I've also removed the `EXPAND_BTN_TEMPLATE` constant because it was not used anywhere.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-3972/samples/index-samples.html?sample=50).

To test this PR, open the sample link above and open the `Metadata` panel for the layer. Try tabbing to the `expand metadata` button in the panel header and ensure that the icon is centered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4007)
<!-- Reviewable:end -->
