### PR TITLE
fix(details): add validate function to autolink function

### DIFF
--- a/packages/ramp-core/src/app/core/formatters.filter.js
+++ b/packages/ramp-core/src/app/core/formatters.filter.js
@@ -46,7 +46,13 @@ function dateTimeZone() {
 }
 
 function autolink() {
-    const defaultOptions = { className: 'rv-linkified', ignoreTags: ['script'] };
+    const defaultOptions = {
+        className: 'rv-linkified',
+        ignoreTags: ['script'],
+        validate: {
+            url: (value) => /^https?:\/\//.test(value), // before converting to a link, ensure that the domain name begins with http:// or https://.
+        },
+    };
 
     return autolink;
 


### PR DESCRIPTION
Closes #4001 

This PR adds a validate function to the linkifyjs formatter to ensure that domain names are at least two characters long (as is required to be a valid domain name) in order to prevent it from converting `p.id` to a hyperlink.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-4001/samples/index-samples.html). I'm not able to load the service linked in the initial issue but just ensure that the details panel is still working as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4008)
<!-- Reviewable:end -->
