### PR TITLE
fix(toc): keyboard navigation stuck on keyboard instructions

### DIFF
--- a/packages/ramp-core/src/app/ui/common/keyboard-instructions.html
+++ b/packages/ramp-core/src/app/ui/common/keyboard-instructions.html
@@ -1,4 +1,4 @@
-<div class="rv-keyboard-controls-button">
+<div class="rv-keyboard-controls-button" tabindex="0">
     <md-button
         ng-click="self.open()"
         class="rv-close md-icon-button primary rv-button-40"


### PR DESCRIPTION
Closes #4004

Made some changes to focus manager behavior when viewer is in waiting state and user backtabs to prevent focus from being stuck on keyboard instructions button.

Services currently down but should still be able to test basic navigation. In particular, test out cases when focus is on keyboard instructions button. Shift-tab when focus is on button should remove focus, tabbing when focus is on button should move focus past viewer as expected. Another test is to enter the viewer and try leaving with `esc + tab` and see that the behavior around the keyboard instructions button remains consistent. 

[Demo](http://ramp4-app.azureedge.net/legacy/users/yileifeng/4004-keyboard-nav-stuck/samples/index-samples.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4009)
<!-- Reviewable:end -->
