### PR TITLE
fix(export): fix export service on multi-RAMP pages

### DIFF
--- a/packages/ramp-core/src/app/ui/export/export-generators.service.js
+++ b/packages/ramp-core/src/app/ui/export/export-generators.service.js
@@ -27,6 +27,7 @@ function exportGenerators(
     $filter,
     $translate,
     $mdToast,
+    $rootElement,
     configService,
     graphicsService,
     exportSizesService,
@@ -245,7 +246,8 @@ function exportGenerators(
                 const mainCanvas = graphicsService.createCanvas(exportSize.width, exportSize.height, backgroundColour);
                 const ctx = mainCanvas.getContext('2d');
 
-                const esriRoot = document.querySelector('.rv-esri-map').firstElementChild;
+                const esriRoot = $rootElement.find('.rv-esri-map')[0].firstElementChild;
+
                 const imagePromises = angular
                     .element(esriRoot)
                     .find('img:visible')
@@ -267,6 +269,7 @@ function exportGenerators(
                     );
 
                 // need to wait for all images to load, so they can be added to the canvas in the correct order
+
                 Promise.all(imagePromises).then((data) => {
                     // eslint-disable-next-line complexity
                     data.forEach(({ imgSource, imgItem, error }) => {

--- a/packages/ramp-core/src/content/samples/config/config-many-1.json
+++ b/packages/ramp-core/src/content/samples/config/config-many-1.json
@@ -1,265 +1,241 @@
 {
+    "language": "en",
     "ui": {
-        "title": "Releases to Air by In Situ Facilities for All Substances 2009 to 2017 (time slider)",
-        "appBar": {
-            "basemap": false
-        },
+        "title": "Interactive map",
+        "fullscreen": true,
         "navBar": {
             "zoom": "buttons",
             "extra": ["fullscreen", "geoLocator", "home", "help"]
         },
-        "sideMenu": {
-            "logo": true,
-            "items": [["layers"], ["fullscreen", "export", "share", "touch", "help", "about"], ["language"]]
+        "appBar": {
+            "basemap": false
         },
         "help": {
             "folderName": "default"
         },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
         "legend": {
             "allowImport": false,
             "isOpen": {
-                "large": true,
-                "medium": true,
-                "small": true
+                "large": false,
+                "medium": false,
+                "small": false
             }
         }
     },
     "version": "2.0",
-    "language": "en",
     "services": {
         "proxyUrl": "http://167.40.64.74/wmsproxy/ws/wmsproxy/executeFromProxy",
-        "exportMapUrl": "http://section917.cloudapp.net/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "exportMapUrl": "https://maps-cartes.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
         "export": {
             "title": {
-                "value": "Releases to Air by In Situ Facilities for All Substances 2009 to 2017 (time slider)"
+                "value": "Oil Sands Desposits"
             },
             "map": {},
             "mapElements": {},
             "legend": {},
             "timeout": 5000,
             "footnote": {
-                "value": "This is a footnote added from the configuration file. The note is very long so it should wrap on multiple lines when it reaches a certain limit in size. Maybe some user will want to use this as aplace holder to put a lot of information so we need to be able to wrap this content. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Fusce aliquet ante quis aliquet feugiat. Cras eget semper nunc, eu placerat purus. Nunc sed lacinia enim, ut sollicitudin quam. Nunc quis finibus massa, eget maximus enim. Donec ac nisl libero. Nunc eu pharetra arcu. Fusce luctus, magna cursus gravida tristique, risus nisi porttitor magna, ac dictum ipsum dui vel nulla. Integer id ornare augue. Quisque condimentum velit quis elementum porta. Sed dui enim, iaculis cursus diam volutpat, laoreet porta quam. Sed nec aliquet magna. Curabitur commodo fringilla metus, eu posuere sapien mollis nec."
-            }
-        },
-        "search": {
-            "serviceUrls": {
-                "geoNames": "http://geogratis.gc.ca/services/geoname/en/geonames.json",
-                "geoLocation": "http://geogratis.gc.ca/services/geolocation/en/locate?q=",
-                "geoSuggest": "http://geogratis.gc.ca/services/geolocation/en/suggest?q=",
-                "provinces": "http://geogratis.gc.ca/services/geoname/en/codes/province.json",
-                "types": "http://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+                "value": "Oil Sands Deposits"
             }
         }
     },
     "map": {
-        "initialBasemapId": "baseEsriTopo",
+        "initialBasemapId": "baseNrCan",
         "components": {
             "geoSearch": {
-                "enabled": false
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
             },
             "mouseInfo": {
                 "enabled": true,
                 "spatialReference": {
-                    "wkid": 102100
+                    "wkid": 4326
                 }
             },
             "northArrow": {
                 "enabled": true
             },
             "basemap": {
-                "enabled": true
+                "enabled": false
             },
             "overviewMap": {
-                "enabled": true,
+                "enabled": false,
                 "layerType": "imagery"
             },
             "scaleBar": {
                 "enabled": true
             }
         },
+        "extentSets": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmin": -2036967.8855660555,
+                    "ymin": 225988.15031441953,
+                    "xmax": -430249.8990248912,
+                    "ymax": 1630799.2940631039
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.628312589961,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.04351875370423,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.16772500211675,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.364660062653464,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.489628312589961,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            }
+        ],
         "legend": {
             "type": "structured",
             "root": {
                 "name": "root",
                 "children": [
                     {
-                        "layerId": "ReleasestoAirbyInSituFacilitiesforAllSubstances2009to2017(timeslider)",
-                        "symbologyExpanded": true
+                        "layerId": "0",
+                        "symbologyExpanded": false,
+                        "entryIndex": 0
                     }
                 ]
             }
         },
         "layers": [
             {
-                "id": "ReleasestoAirbyInSituFacilitiesforAllSubstances2009to2017(timeslider)",
-                "name": "Releases to Air by In Situ Facilities for All Substances 2009 to 2017 (time slider)",
-                "layerType": "esriFeature",
-                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/StoryRAMP/MapServer/4"
-            }
-        ],
-        "extentSets": [
-            {
-                "id": "EXT_ESRI_World_AuxMerc_3857",
-                "default": {
-                    "xmax": -11484319.392198805,
-                    "xmin": -14267850.214231044,
-                    "ymax": 8349344.827914256,
-                    "ymin": 6637155.394326762
-                },
-                "spatialReference": {
-                    "wkid": 102100,
-                    "latestWkid": 3857
-                }
-            }
-        ],
-        "lodSets": [
-            {
-                "id": "LOD_ESRI_World_AuxMerc_3857",
-                "lods": [
+                "id": "0",
+                "layerType": "esriDynamic",
+                "url": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/StoryRAMP/oilsands_polys/MapServer",
+                "layerEntries": [
                     {
-                        "level": 0,
-                        "resolution": 19567.87924099992,
-                        "scale": 73957190.948944
+                        "index": 0
                     },
                     {
-                        "level": 1,
-                        "resolution": 9783.93962049996,
-                        "scale": 36978595.474472
+                        "index": 1
                     },
                     {
-                        "level": 2,
-                        "resolution": 4891.96981024998,
-                        "scale": 18489297.737236
-                    },
-                    {
-                        "level": 3,
-                        "resolution": 2445.98490512499,
-                        "scale": 9244648.868618
-                    },
-                    {
-                        "level": 4,
-                        "resolution": 1222.992452562495,
-                        "scale": 4622324.434309
-                    },
-                    {
-                        "level": 5,
-                        "resolution": 611.4962262813797,
-                        "scale": 2311162.217155
-                    },
-                    {
-                        "level": 6,
-                        "resolution": 305.74811314055756,
-                        "scale": 1155581.108577
-                    },
-                    {
-                        "level": 7,
-                        "resolution": 152.87405657041106,
-                        "scale": 577790.554289
-                    },
-                    {
-                        "level": 8,
-                        "resolution": 76.43702828507324,
-                        "scale": 288895.277144
-                    },
-                    {
-                        "level": 9,
-                        "resolution": 38.21851414253662,
-                        "scale": 144447.638572
-                    },
-                    {
-                        "level": 10,
-                        "resolution": 19.10925707126831,
-                        "scale": 72223.819286
-                    },
-                    {
-                        "level": 11,
-                        "resolution": 9.554628535634155,
-                        "scale": 36111.909643
-                    },
-                    {
-                        "level": 12,
-                        "resolution": 4.77731426794937,
-                        "scale": 18055.954822
-                    },
-                    {
-                        "level": 13,
-                        "resolution": 2.388657133974685,
-                        "scale": 9027.977411
-                    },
-                    {
-                        "level": 14,
-                        "resolution": 1.1943285668550503,
-                        "scale": 4513.988705
-                    },
-                    {
-                        "level": 15,
-                        "resolution": 0.5971642835598172,
-                        "scale": 2256.994353
-                    },
-                    {
-                        "level": 16,
-                        "resolution": 0.29858214164761665,
-                        "scale": 1128.497176
-                    },
-                    {
-                        "level": 17,
-                        "resolution": 0.14929107082380833,
-                        "scale": 564.248588
-                    },
-                    {
-                        "level": 18,
-                        "resolution": 0.07464553541190416,
-                        "scale": 282.124294
-                    },
-                    {
-                        "level": 19,
-                        "resolution": 0.03732276770595208,
-                        "scale": 141.062147
-                    },
-                    {
-                        "level": 20,
-                        "resolution": 0.01866138385297604,
-                        "scale": 70.5310735
+                        "index": 2
                     }
                 ]
             }
         ],
         "tileSchemas": [
             {
-                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
-                "name": "Web Mercator Maps",
-                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
-                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
             }
         ],
         "baseMaps": [
             {
-                "id": "baseEsriWorld",
-                "name": "World Imagery",
-                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
-                "altText": "altText - World Imagery",
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "altText - The Canada Base Map - Transportation (CBMT)",
                 "layers": [
                     {
-                        "id": "World_Imagery",
+                        "id": "CBMT",
                         "layerType": "esriFeature",
-                        "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                        "url": "https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer"
                     }
                 ],
-                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
-            },
-            {
-                "id": "baseEsriTopo",
-                "name": "World Topographic Map",
-                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
-                "altText": "altText - World Topographic Map",
-                "layers": [
-                    {
-                        "id": "World_Topo_Map",
-                        "layerType": "esriFeature",
-                        "url": "http://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
-                    }
-                ],
-                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
             }
         ]
     }


### PR DESCRIPTION
Closes https://github.com/ramp4-pcar4/story-ramp/issues/67

The export service was grabbing the map element using `document.querySelector`, which always took the map element from the first map instance on the page. This doesn't work for pages that have multiple map instances, so I've modified this section of the code to search within the angular root element instead, which should keep each RAMP instance separate.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-export-bug/samples/index-many-2.html).

To test this PR, wait for all three maps on the demo page to load and then try to export one of the bottom two maps. The export image should only contain the layers for that particular map instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4010)
<!-- Reviewable:end -->
