### PR TITLE
Add configurable option for turning off dynamic sublayers removal

### DIFF
--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -1872,6 +1872,11 @@
                     "default": true,
                     "description": "Specifies if the user-added layers are allowed."
                 },
+                "sublayerRemovable": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies if ESRI dynamic sublayers can be removed separately."
+                },
                 "isOpen": {
                     "type": "object",
                     "description": "Specifies whether the legend is opened by default on initial loading of the map for small, medium, and large viewports",
@@ -2004,7 +2009,6 @@
             "required": ["data"]
         }
     },
-
     "properties": {
         "version": {
             "type": "string",
@@ -2016,7 +2020,6 @@
             "enum": ["en", "fr", "es"],
             "description": "ISO 639-1 code indicating the language of strings in the schema file"
         },
-
         "ui": {
             "description": "A set of service endpoints used by the viewer",
             "type": "object",
@@ -2112,12 +2115,10 @@
                 }
             }
         },
-
         "plugins": {
             "description": "A set of config snippets correponding to the plugins loaded onto the viewer",
             "type": "object"
         },
-
         "services": {
             "description": "A set of service endpoints used by the viewer",
             "type": "object",
@@ -2208,7 +2209,6 @@
             },
             "additionalProperties": false
         },
-
         "map": {
             "type": "object",
             "description": "Core map properties (extent sets, levels of detail)",
@@ -2263,6 +2263,5 @@
             "required": ["tileSchemas", "baseMaps"]
         }
     },
-
     "required": ["version"]
 }

--- a/packages/ramp-core/src/app/core/config.class.js
+++ b/packages/ramp-core/src/app/core/config.class.js
@@ -3168,6 +3168,7 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
         constructor(uiLegendSource = {}) {
             this._reorderable = uiLegendSource.reorderable !== false;
             this._allowImport = uiLegendSource.allowImport !== false;
+            this._sublayerRemovable = uiLegendSource.sublayerRemovable !== false;
             this._isOpen = new LegendIsOpen(uiLegendSource.isOpen);
         }
 
@@ -3177,6 +3178,9 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
         get allowImport() {
             return this._allowImport;
         }
+        get sublayerRemovable() {
+            return this._sublayerRemovable;
+        }
         get isOpen() {
             return this._isOpen;
         }
@@ -3185,6 +3189,7 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
             return {
                 reorderable: this.reorderable,
                 allowImport: this.allowImport,
+                sublayerRemovable: this.sublayerRemovable,
                 isOpen: this.isOpen.JSON,
             };
         }

--- a/packages/ramp-core/src/app/ui/toc/legend-block.directive.js
+++ b/packages/ramp-core/src/app/ui/toc/legend-block.directive.js
@@ -33,6 +33,7 @@ function rvLegendBlock($compile, $templateCache, layoutService, appInfo, common,
         scope: {
             block: '=',
             isReorder: '=', // this is a flag indicating if Toc is in reorder mode; consider creating a `mode` variable in the TocService if a third mode is created (`select` for example)
+            slRemovable: '='
         },
         link: link,
         controller: () => {},

--- a/packages/ramp-core/src/app/ui/toc/templates/legend-node.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/legend-node.html
@@ -61,7 +61,13 @@
 
             <rv-legend-control block="self.block" template="menu" name="boundary"></rv-legend-control>
             <rv-legend-control block="self.block" template="menu" name="reload"></rv-legend-control>
-            <rv-legend-control block="self.block" template="menu" name="remove"></rv-legend-control>
+            <!-- Check if config sublayer removable flag is turned off for dynamic layers -->
+            <rv-legend-control
+                ng-if="self.slRemovable || self.block.parentLayerType !== 'esriDynamic'"
+                block="self.block"
+                template="menu"
+                name="remove"
+            ></rv-legend-control>
         </md-menu-content>
     </md-menu>
 

--- a/packages/ramp-core/src/app/ui/toc/toc.html
+++ b/packages/ramp-core/src/app/ui/toc/toc.html
@@ -55,6 +55,7 @@
                     class="rv-legend-{{ block.template }}"
                     block="block"
                     is-reorder="self.isReorder"
+                    sl-removable="self.config.ui.legend.sublayerRemovable"
                     ng-class="{ 'rv-selected': block.isSelected }"
                 ></rv-legend-block>
 

--- a/packages/ramp-core/src/content/samples/config/config-sample-83.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-83.json
@@ -11,6 +11,7 @@
             "folderName": "default"
         },
         "legend": {
+            "sublayerRemovable": false,
             "isOpen": {
                 "large": true,
                 "medium": true,


### PR DESCRIPTION
Closes #4011

Adds config option solution proposed in [comment](https://github.com/fgpv-vpgf/fgpv-vpgf/issues/4011#issuecomment-1104338415) to turn off dynamic sublayers children remove control when flag is set to `false`, applying to all dynamic layers on the page. All other layer types remains unaffected. 

Since there may already be a workaround for the original issue, this can be closed if not needed.

[Demo](http://ramp4-app.azureedge.net/legacy/users/yileifeng/4011-sublayer-remove/samples/index-samples.html?sample=83)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4030)
<!-- Reviewable:end -->
