### PR TITLE
fix(wcag): fix focus getting stuck in viewer when using iframe

### DIFF
--- a/packages/ramp-core/src/content/samples/iframe-map.tpl
+++ b/packages/ramp-core/src/content/samples/iframe-map.tpl
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <title>Test Samples - RAMP2 Viewer</title>
+
+    <% for (var index in htmlWebpackPlugin.files.css) { %>
+        <% if (webpackConfig.output.crossOriginLoading) { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" integrity="<%= htmlWebpackPlugin.files.cssIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"/>
+        <% } else { %>
+            <link rel="stylesheet" href="<%= htmlWebpackPlugin.files.css[index] %>" />
+        <% } %>
+    <% } %>
+
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .myMap {
+            height: 100%;
+        }
+    </style>
+
+</head>
+
+<body>
+<div id="fgpmap" is="rv-map" class="myMap" data-rv-config="config/config-sample-01.json" data-rv-langs='["en-CA"]' data-rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/" data-rv-keys=''>
+    <noscript>
+        <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
+
+        <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
+    </noscript>
+</div>
+
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Object.entries,Object.values,Array.prototype.find,Array.prototype.findIndex,Array.prototype.values,Array.prototype.includes,HTMLCanvasElement.prototype.toBlob,String.prototype.repeat,String.prototype.codePointAt,String.fromCodePoint,NodeList.prototype.@@iterator,Promise,Promise.prototype.finally"></script>
+
+<% for (var index in htmlWebpackPlugin.files.js) { %>
+    <% if (webpackConfig.output.crossOriginLoading) { %>
+        <script src="<%= htmlWebpackPlugin.files.js[index] %>" integrity="<%= htmlWebpackPlugin.files.jsIntegrity[index] %>" crossorigin="<%= webpackConfig.output.crossOriginLoading %>"></script>
+    <% } else { %>
+        <script src="<%= htmlWebpackPlugin.files.js[index] %>"></script>
+    <% } %>
+<% } %>
+</body>
+</html>

--- a/packages/ramp-core/src/content/samples/index-iframe.tpl
+++ b/packages/ramp-core/src/content/samples/index-iframe.tpl
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width,initial-scale=1" name="viewport">
+    <title>Test iframe - RAMP2 Viewer</title>
+
+    <style>
+        iframe {
+            width: 1108px;
+            height: 600px;
+            border: 0;
+            margin-top: 15px;
+        }
+    </style>
+</head>
+
+
+<body>
+    <h3>Host page with an embedded viewer (iframe)</h3>
+    <!-- LOADING THE IFRAME MAP -->
+    <iframe src="./iframe-map.html" allowfullscreen></iframe><br />
+    This is some content below the map. And this is a button: <button>Hello I am a button.</button>
+</body>
+
+</html>


### PR DESCRIPTION
Closes #4024 

This PR fixes the issue that caused focus to get stuck in the viewer when using RAMP inside of an iframe. This PR also re-adds the `index-iframe` test page, and adds some content below the viewer to ensure you can tab past it.

[You can find a demo for this PR here.](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-4024/samples/index-iframe.html)

To test this PR, ensure that:

1. You can tab straight past the viewer without activating keyboard mode (just keep pressing tab, ignore keyboard instruction button)
2. You can activate keyboard mode, escape from it (esc + tab), and then tab past the viewer afterwards.

The `index-iframe.html` test page will be helpful for testing this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4032)
<!-- Reviewable:end -->
