### PR TITLE
feat(toc): add focusable element to see full layer name

### DIFF
--- a/packages/ramp-core/src/app/ui/toc/templates/legend-error.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/legend-error.html
@@ -26,6 +26,14 @@
 </div>
 
 <div class="rv-list-item-controls">
+    <!-- if layer name is truncated, displays full layer name -->
+    <md-button ng-if="self.isNameTruncated" class="md-info-button rv-icon-14 rv-layer-item-flag" role="presentation">
+        <md-tooltip md-delay="self.getTooltipDelay()" md-direction="{{ self.getTooltipDirection() }}"
+            >{{ 'toc.layer.name' | translate }}: {{ self.block.name }}</md-tooltip
+        >
+        <md-icon md-svg-src="community:help"></md-icon>
+    </md-button>
+
     <rv-legend-control
         block="self.block"
         name="reload"

--- a/packages/ramp-core/src/app/ui/toc/templates/legend-node.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/legend-node.html
@@ -3,6 +3,10 @@
     ng-mouseover="self.block.symbologyStack.fannedOut = true"
     ng-mouseleave="self.block.symbologyStack.fannedOut = false"
 >
+    <md-tooltip md-delay="self.getTooltipDelay()" md-direction="{{ self.getTooltipDirection() }}"
+        >{{ self.block.name }}</md-tooltip
+    >
+
     <rv-legend-control block="self.block" template="body" node="self" name="data"></rv-legend-control>
 </div>
 
@@ -21,6 +25,18 @@
     ></div>
 
     <div class="rv-list-item-flags">
+        <!-- if layer name is truncated, displays full layer name -->
+        <md-button
+            ng-if="self.isNameTruncated"
+            class="md-info-button rv-icon-12 rv-layer-item-flag"
+            role="presentation"
+        >
+            <md-tooltip md-delay="self.getTooltipDelay()" md-direction="{{ self.getTooltipDirection() }}"
+                >{{ 'toc.layer.name' | translate }}: {{ self.block.name }}</md-tooltip
+            >
+            <md-icon md-svg-src="community:help"></md-icon>
+        </md-button>
+
         <rv-legend-flag block="self.block" name="type"></rv-legend-flag>
         <rv-legend-flag block="self.block" name="data"></rv-legend-flag>
         <rv-legend-flag block="self.block" name="user"></rv-legend-flag>

--- a/packages/ramp-core/src/content/styles/modules/_buttons.scss
+++ b/packages/ramp-core/src/content/styles/modules/_buttons.scss
@@ -165,6 +165,10 @@
     .rv-icon-14 {
         @include icon-size(rem(1.4));
     }
+
+    .rv-icon-12 {
+        @include icon-size(rem(1.2));
+    }
 }
 
 @mixin icon-size($size) {

--- a/packages/ramp-core/src/locales/translations.csv
+++ b/packages/ramp-core/src/locales/translations.csv
@@ -184,6 +184,7 @@ Bookmark link copy hint,sidenav.label.copy,Press Ctrl+C to copy,1,Appuyez sur «
 Side Navigation help,sidenav.label.help,Help,1,Aide,1
 Side Navigation touch mode,sidenav.label.touch,Touch mode,1,Mode Tactile,1
 Side Navigation language,sidenav.label.language,Language,1,Langue,1
+Table of Content name,toc.layer.name,Name,1,Nom,1
 Table of Content Unnamed service,toc.layer.unnamed,Unnamed service #{{count}},1,Service sans nom #{{count}},1
 Table of Content Layer open data panel aria label,toc.layer.aria.openData,Open data panel menu,1,Menu du panneau des données ouvertes,1
 Table of Content Layer options label,toc.layer.tooltip.options,More options,1,Plus d'options,1

--- a/packages/ramp-core/src/material/angular-material.scss
+++ b/packages/ramp-core/src/material/angular-material.scss
@@ -2087,6 +2087,22 @@ button.md-button::-moz-focus-inner {
         border-radius: $button-icon-border-radius;
     }
 
+    &.md-info-button {
+        padding: 1px;
+        margin: 0px;
+        margin-right: 5px;
+        min-height: 6px;
+        min-width: 0px;
+        line-height: 6px;
+        border-radius: $button-icon-border-radius;
+        display: inline;
+    }
+
+    &.md-info-button:focus {
+        border: 1px solid black;
+        margin: -1px 4px -1px -1px;
+    }
+
     &.md-fab {
         // Include the top/left/bottom/right fab positions
         @include fab-all-positions();


### PR DESCRIPTION
Closes #4022

This PR adds a new focusable element to the legend entries that have names that are too long to be displayed. 

Focusing on this new element will display the full name of the layer as a tooltip. This PR also makes it so a tooltip displaying the layer's name appears when hovering over entries that have a data grid (as it already does for legend groups).

--- 
This PR doesn't have to be the final version. If anyone has better ideas for displaying the full name of layers that are cut-off through keyboard navigation, or if you don't like the placement of the new element on the legend, I'm very much open to feedback.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/legacy/users/RyanCoulsonCA/fix-4022/samples/index-samples.html).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4033)
<!-- Reviewable:end -->
