### PR TITLE
Add support for geojson geometry collection

### DIFF
--- a/packages/ramp-geoapi/src/layer/layerRec/graphicsRecord.js
+++ b/packages/ramp-geoapi/src/layer/layerRec/graphicsRecord.js
@@ -55,8 +55,9 @@ class GraphicsRecord extends root.Root {
      * @param {Object} esriBundle       bundle of API classes
      * @param {Object} apiRef           object pointing to the geoApi. allows us to call other geoApi functions.
      * @param {String} name             name and id of the layer.
+     * @param {GraphicsLayer} layer     an optional pre-constructed graphics layer
      */
-    constructor(esriBundle, apiRef, name) {
+    constructor(esriBundle, apiRef, name, layer = undefined) {
         super();
 
         this._bundle = esriBundle;
@@ -64,7 +65,7 @@ class GraphicsRecord extends root.Root {
         this._layerClass = esriBundle.GraphicsLayer;
         this._name = name;
         this._id = name;
-        this._layer = this._layerClass({ id: this._name });
+        this._layer = layer !== undefined ? layer : this._layerClass({ id: this._name });
         this.bindEvents(this._layer);
         this._hoverEvent = new shared.FakeEvent();
     }


### PR DESCRIPTION
Closes #4017 

Added support for GeoJSON with a geometry collection at geometry level by cleaning up and converting the geometry set to a single supported geometry structure (`Point` --> `MultiPoint`, `LineString` --> `MultiLineString`, `Polygon` --> `MultiPolygon`). Multiple error checks added to ensure geometry type is consistent through the collection as well as the entire file. 

**Testing** (IPR):
- add https://raw.githubusercontent.com/jolevesq/contributed-plugins/OSDP/osdp/src/samples/geoJSON/polygons.json as GeoJSON layer and ensure no errors
- all other layer behavior should remain unchanged 

[Demo](https://fgpv-vpgf.github.io/fgpv-vpgf/4017-geometry-collection/samples/index-samples.html)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4034)
<!-- Reviewable:end -->
