### PR TITLE
 layers respect defaultVisibility if not defined in config

### DIFF
--- a/packages/ramp-geoapi/src/attribute.js
+++ b/packages/ramp-geoapi/src/attribute.js
@@ -316,6 +316,7 @@ function loadServerAttribsBuilder(esriBundle, geoApi) {
                         layerData.maxScale = serviceResult.effectiveMaxScale || serviceResult.maxScale;
                         layerData.supportsFeatures = false; // saves us from having to keep comparing type to 'Feature Layer' on the client
                         layerData.extent = serviceResult.extent;
+                        layerData.defaultVisibility = serviceResult.defaultVisibility;
 
                         if (serviceResult.type === 'Feature Layer') {
                             layerData.supportsFeatures = true;

--- a/packages/ramp-geoapi/src/layer/layerRec/attribFC.js
+++ b/packages/ramp-geoapi/src/layer/layerRec/attribFC.js
@@ -63,6 +63,14 @@ class AttribFC extends basicFC.BasicFC {
         return this._layerPackage ? this._layerPackage.loadedFeatureCount : 0;
     }
 
+    get defaultVisibility() {
+        return this._layerPackage
+            ? this._layerPackage.layerData.then((data) => {
+                  return data.defaultVisibility;
+              })
+            : Promise.resolve(true);
+    }
+
     /**
      * Returns attribute data for this FC.
      *

--- a/packages/ramp-geoapi/src/layer/layerRec/layerRecord.js
+++ b/packages/ramp-geoapi/src/layer/layerRec/layerRecord.js
@@ -298,6 +298,25 @@ class LayerRecord extends root.Root {
 
         this.extent = shared.makeSafeExtent(this.extent);
 
+        // If visibility isn't set in the config, and defaultVisibility is defined
+        // from the service, then set the visibility to be equal to the value of defaultVisibility.
+        const hasVisibleState = this.config.source.state && this.config.source.state.visibility !== undefined;
+        const defaultVisibility = this._layer.defaultVisibility;
+
+        if (!hasVisibleState && defaultVisibility !== undefined) {
+            this.visibility = defaultVisibility;
+            this.config.state.visibility = defaultVisibility;
+
+            // Save the visibility value so it is kept if the layer is refreshed.
+            if (!this.config.source.state) {
+                this.config.source.state = {
+                    visibility: defaultVisibility,
+                };
+            } else {
+                this.config.source.state.visibility = defaultVisibility;
+            }
+        }
+
         let lookupPromise = Promise.resolve();
         if (this._epsgLookup) {
             const check = this._apiRef.proj.checkProj(this.spatialReference, this._epsgLookup);


### PR DESCRIPTION
Closes #4020 

Layers that do not have a visibility defined in their configuration will now set their default visibility to the value retrieved from the server.

I tested this for both dynamic and feature layers by forcing defaultVisibility to false in the source code, but if anyone knows any layers that actually have defaultVisibility set to false for testing, please post below!

You can find a demo for this PR [here](https://fgpv-vpgf.github.io/fgpv-vpgf/fix-4020/samples/index-samples.html?sample=6).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4039)
<!-- Reviewable:end -->
