### PR TITLE
fix page jumping to top when exiting fullscreen mode

### DIFF
--- a/packages/ramp-core/src/app/ui/common/full-screen.service.js
+++ b/packages/ramp-core/src/app/ui/common/full-screen.service.js
@@ -90,6 +90,7 @@ function fullScreenService($rootElement, configService, $interval, events, $time
         const shellNode = angular.element('rv-shell');
         body.attr('style', 'width: 100%; height: 100%');
         $rootElement.attr('style', `overflow: visible; z-index: ${FULL_SCREEN_Z_INDEX};`);
+        $rootElement.addClass('rv-full-screen-element');
         shellNode.attr('style', `position: fixed; margin: 0; z-index: ${FULL_SCREEN_Z_INDEX};`);
         angular.element('body').addClass('rv-full-screen');
 
@@ -117,6 +118,12 @@ function fullScreenService($rootElement, configService, $interval, events, $time
         if (screenfull.isFullscreen) {
             screenfull.toggle(body[0]);
             onChange();
+        }
+
+        // Prevents the page from jumping back to the top when exiting full screen.
+        if ($rootElement.hasClass('rv-full-screen-element')) {
+            $('html,body').animate({ scrollTop: $($rootElement).offset().top }, 0);
+            $rootElement.removeClass('rv-full-screen-element');
         }
     }
 

--- a/packages/ramp-core/src/content/samples/index-many-2.tpl
+++ b/packages/ramp-core/src/content/samples/index-many-2.tpl
@@ -8,7 +8,7 @@
 
     <style>
         body {
-            display: flex;
+
             flex-direction: column;
         }
 
@@ -32,7 +32,7 @@
 
         .row {
             height: 650px;
-            display: flex;
+
         }
     </style>
     <script src="./plugins/coordInfo/coordInfo.js"></script>
@@ -50,6 +50,7 @@
 <!-- rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/" rv-keys='["Airports"]' -->
 
 <body>
+    <h1>Title 1</h1>
     <div class="myMap" id="sample-map" is="rv-map" ramp-gtm
         rv-config="config/config-many-1.json"
         rv-langs='["en-CA", "fr-CA"]'
@@ -62,7 +63,7 @@
             <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
         </noscript>
     </div>
-    <div class="row">
+        <h1>Title 2</h1>
         <div class="myMap flexMap" id="second-map" is="rv-map" ramp-gtm
             rv-config="config/config-many-2.json"
             rv-langs='["en-CA", "fr-CA"]'
@@ -75,6 +76,7 @@
                 <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
             </noscript>
         </div>
+        <h1>Title 3</h1>
         <div class="myMap flexMap" id="third-map" is="rv-map" ramp-gtm
             rv-config="config/config-many-3.json"
             rv-langs='["en-CA", "fr-CA"]'
@@ -87,7 +89,7 @@
                 <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
             </noscript>
         </div>
-    </div>
+
 
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Object.entries,Object.values,Array.prototype.find,Array.prototype.findIndex,Array.prototype.values,Array.prototype.includes,HTMLCanvasElement.prototype.toBlob,String.prototype.repeat,String.prototype.codePointAt,String.fromCodePoint,NodeList.prototype.@@iterator,Promise,Promise.prototype.finally"></script>
 


### PR DESCRIPTION
Closes https://github.com/ramp4-pcar4/story-ramp/issues/187

This PR fixes an issue where the page jumps back to the top after exiting fullscreen. Now when you exit the page will jump to the map that was set to full screen.

For testing purposes, I've modified the `index-many-2.html` test page to display maps vertically. I can change this back once testing is complete. Try full screening each of these and ensure the page jumps to the correct map when you exit. You can also play around with other samples to make sure this works for those too.