### PR TITLE
Bug in legacy centerAndZoom

### DIFF
--- a/packages/ramp-core/src/app/core/core.run.js
+++ b/packages/ramp-core/src/app/core/core.run.js
@@ -264,12 +264,12 @@ function apiBlock(
      * @param {Number} zoom                 The level to zoom to
      */
     function centerAndZoom(x, y, spatialReference, zoom) {
-        const coords = gapiService.gapi.proj.localProjectPoint(
-            spatialReference,
-            geoService.mapObject.spatialReference,
-            { x: x, y: y }
-        );
-        const zoomPoint = gapiService.gapi.proj.Point(coords.x, coords.y, geoService.mapObject.spatialReference);
+        const coords = gapiService.gapi.proj.localProjectPoint(spatialReference, geoService.map.spatialReference, {
+            x: x,
+            y: y,
+        });
+
+        const zoomPoint = gapiService.gapi.proj.Point(coords.x, coords.y, geoService.map.spatialReference);
 
         // separate zoom and center calls, calling centerAndZoom sets the map to an extent made up of NaN
         configService.getSync.map.instance.setZoom(zoom);


### PR DESCRIPTION
Corrects #4052 

Can test by opening a site and in the console pasting a request.  E.g.

`RV.getMap('fgpmap').centerAndZoom(-100.659, 63.07, 4326, 11)`

The map name string needs to match the map name. This one works for the fpg sample. I believe the main sample page is called `sample-map`