### PR TITLE
Fix opening side menu on multiple instances (RE-PR)

### DIFF
--- a/packages/ramp-core/src/app/core/core.run.js
+++ b/packages/ramp-core/src/app/core/core.run.js
@@ -171,7 +171,7 @@ function apiBlock(
         setMapCursor,
         projectGeometry,
         toggleSideNav: (val) => {
-            $mdSidenav('left')[val]();
+            $mdSidenav(`left-${appInfo.id}`)[val]();
         },
         reInitialize: (bookmark) => reloadService.reloadConfig(bookmark),
         getConfig,

--- a/packages/ramp-core/src/app/ui/basemap/basemap.service.js
+++ b/packages/ramp-core/src/app/ui/basemap/basemap.service.js
@@ -9,7 +9,7 @@
  */
 angular.module('app.ui').factory('basemapService', basemapService);
 
-function basemapService($rootElement, $mdSidenav, $q) {
+function basemapService($rootElement, $mdSidenav, appInfo, $q) {
     let closePromise;
     let isSideMenuOpen;
 
@@ -36,7 +36,7 @@ function basemapService($rootElement, $mdSidenav, $q) {
 
         // if opened using the side menu, close it while this panel is open.
         if (isSideMenuOpen) {
-            $mdSidenav('left').close();
+            $mdSidenav(`left-${appInfo.id}`).close();
         }
 
         return (
@@ -64,7 +64,7 @@ function basemapService($rootElement, $mdSidenav, $q) {
      */
     function close() {
         if (isSideMenuOpen) {
-            $mdSidenav('left').open();
+            $mdSidenav(`left-${appInfo.id}`).open();
         }
 
         return $mdSidenav('right').close();

--- a/packages/ramp-core/src/app/ui/sidenav/sidenav.directive.js
+++ b/packages/ramp-core/src/app/ui/sidenav/sidenav.directive.js
@@ -24,12 +24,14 @@ function rvSidenav() {
     return directive;
 }
 
-function Controller(sideNavigationService, version, configService) {
+function Controller(sideNavigationService, appInfo, version, configService) {
     'ngInject';
     const self = this;
 
     // expose sidemenu config to the template
     configService.onEveryConfigLoad((config) => (self.uiConfig = config.ui));
+
+    self.appID = appInfo.id;
 
     self.service = sideNavigationService;
 

--- a/packages/ramp-core/src/app/ui/sidenav/sidenav.html
+++ b/packages/ramp-core/src/app/ui/sidenav/sidenav.html
@@ -1,7 +1,7 @@
 <md-sidenav
     rv-trap-focus
     class="site-sidenav md-sidenav-left md-whiteframe-z2"
-    md-component-id="left"
+    md-component-id="left-{{ self.appID }}"
     role="dialog"
     aria-modal="true"
     aria-label="{{ self.uiConfig.title || 'sidenav.title' | translate }}"

--- a/packages/ramp-core/src/app/ui/sidenav/sidenav.service.js
+++ b/packages/ramp-core/src/app/ui/sidenav/sidenav.service.js
@@ -320,9 +320,9 @@ function sideNavigationService(
      * @function open
      */
     function open() {
-        $mdSidenav('left')
+        $mdSidenav(`left-${appInfo.id}`)
             .open()
-            .then(() => $('md-sidenav[md-component-id="left"] button').first().rvFocus());
+            .then(() => $rootElement.find(`md-sidenav[md-component-id="left-${appInfo.id}"] button`).first().rvFocus());
     }
 
     /**
@@ -330,7 +330,7 @@ function sideNavigationService(
      * @function close
      */
     function close() {
-        return $mdSidenav('left').close();
+        return $mdSidenav(`left-${appInfo.id}`).close();
     }
 
     /**

--- a/packages/ramp-core/src/content/samples/index-many-2.tpl
+++ b/packages/ramp-core/src/content/samples/index-many-2.tpl
@@ -7,11 +7,6 @@
     <title>Test Samples - RAMP2 Viewer</title>
 
     <style>
-        body {
-            display: flex;
-            flex-direction: column;
-        }
-
         .myMap {
             height: 100%;
             border: 1px black solid;
@@ -51,7 +46,7 @@
 
 <body>
     <div class="myMap" id="sample-map" is="rv-map" ramp-gtm
-        rv-config="config/config-many-1.json"
+        rv-config="config/config-many-2.json"
         rv-langs='["en-CA", "fr-CA"]'
         rv-restore-bookmark="bookmark"
         rv-plugins="coordInfo"
@@ -62,31 +57,29 @@
             <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
         </noscript>
     </div>
-    <div class="row">
-        <div class="myMap flexMap" id="second-map" is="rv-map" ramp-gtm
-            rv-config="config/config-many-2.json"
-            rv-langs='["en-CA", "fr-CA"]'
-            rv-restore-bookmark="bookmark"
-            rv-plugins="coordInfo"
-            rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/">
-            <noscript>
-                <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
+    <div class="myMap" id="second-map" is="rv-map" ramp-gtm
+        rv-config="config/config-many-1.json"
+        rv-langs='["en-CA", "fr-CA"]'
+        rv-restore-bookmark="bookmark"
+        rv-plugins="coordInfo"
+        rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/">
+        <noscript>
+            <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
 
-                <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
-            </noscript>
-        </div>
-        <div class="myMap flexMap" id="third-map" is="rv-map" ramp-gtm
-            rv-config="config/config-many-3.json"
-            rv-langs='["en-CA", "fr-CA"]'
-            rv-restore-bookmark="bookmark"
-            rv-plugins="coordInfo"
-            rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/">
-            <noscript>
-                <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
+            <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
+        </noscript>
+    </div>
+    <div class="myMap" id="third-map" is="rv-map" ramp-gtm
+        rv-config="config/config-many-3.json"
+        rv-langs='["en-CA", "fr-CA"]'
+        rv-restore-bookmark="bookmark"
+        rv-plugins="coordInfo"
+        rv-service-endpoint="http://section917.canadacentral.cloudapp.azure.com/">
+        <noscript>
+            <p>This interactive map requires JavaScript. To view this content please enable JavaScript in your browser or download a browser that supports it.<p>
 
-                <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
-            </noscript>
-        </div>
+            <p>Cette carte interactive nécessite JavaScript. Pour voir ce contenu, s'il vous plaît, activer JavaScript dans votre navigateur ou télécharger un navigateur qui le prend en charge.</p>
+        </noscript>
     </div>
 
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Object.entries,Object.values,Array.prototype.find,Array.prototype.findIndex,Array.prototype.values,Array.prototype.includes,HTMLCanvasElement.prototype.toBlob,String.prototype.repeat,String.prototype.codePointAt,String.fromCodePoint,NodeList.prototype.@@iterator,Promise,Promise.prototype.finally"></script>


### PR DESCRIPTION
Same PR as #4045

Fixes Storylines issue where page jumps to a previous map (with side menu already open) after opening side menu for a different map on the page. This is due to sidemenu IDs named the same so we end up calling `rvFocus` on the first element found. Instead, using `$rootElement.find()` should find the correct menu. Changes to sample page can be discarded after demo if needed.

[Demo](https://fgpv-vpgf.github.io/fgpv-vpgf/multi-instance-sidemenu/samples/index-many-2.html)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4045)
<!-- Reviewable:end -->
