### PR TITLE
Proper map center

### DIFF
--- a/packages/ramp-core/api/src/geometry.ts
+++ b/packages/ramp-core/api/src/geometry.ts
@@ -38,10 +38,10 @@ export class XY {
     /**
      * Returns the value of this XY in a different projection
      *
-     * @param targetProjection - Projection of the result. Accepts WKID or EPSG codes as integers, or WTK as string.
+     * @param targetProjection - Projection of the result. Accepts WKID or EPSG codes as integers, a WTK as string, or object structured like an ESRI spatial reference object.
      * @returns a point object
      */
-    projectToPoint(targetProjection: number | string) {
+    projectToPoint(targetProjection: number | string | object) {
         const proj = (<any>window).RAMP.GAPI.proj;
 
         let projPoint = proj.localProjectPoint(4326, targetProjection, [this.x, this.y]);

--- a/packages/ramp-core/api/src/map.ts
+++ b/packages/ramp-core/api/src/map.ts
@@ -168,7 +168,15 @@ export class Map {
     }
 
     get center(): geo.XY {
-        return this.bounds.center;
+        //  wrong! .bounds is extent projected to latlong, so will be warped (unless map is in LL projection)
+        //  resulting in a distorted center point
+        //
+        //  return this.bounds.center;
+
+        const mapCenter = this.getExtent().getCenter(); // esri point object
+        const dummy = new geo.XY(1, 1); // nothingburger instance so we can use the projection method
+        const llPoint = dummy.projectFromPoint(mapCenter.spatialReference, mapCenter.x, mapCenter.y); // esri point object
+        return new geo.XY(llPoint.x, llPoint.y);
     }
 
     /** The main JQuery map element on the host page.  */

--- a/packages/ramp-core/src/content/samples/index-fgp-en.tpl
+++ b/packages/ramp-core/src/content/samples/index-fgp-en.tpl
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>FGP Viewer</title>
     <meta content="width=device-width,initial-scale=1" name="viewport">
-    <link href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css">
+    <link href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css">
 
     <script src="./plugins/backToCart/backToCart.js"></script>
 
@@ -367,7 +367,7 @@
             <div class="row">
                 <div class="brand col-xs-8 col-sm-9 col-md-6">
                     <a href="http://www.canada.ca/en/index.html">
-                        <object type="image/svg+xml" tabindex="-1" data="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/sig-blk-en.svg"></object><span class="wb-inv"> Government of Canada</span></a>
+                        <object type="image/svg+xml" tabindex="-1" data="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/sig-blk-en.svg"></object><span class="wb-inv"> Government of Canada</span></a>
                 </div>
                 <section class="wb-mb-links col-xs-4 col-sm-3 visible-sm visible-xs" id="wb-glb-mn">
                     <h2>Search and menus</h2>
@@ -502,7 +502,7 @@
                     </div>
 
                     <div class="col-xs-6 col-md-2 text-right">
-                        <object type="image/svg+xml" tabindex="-1" role="img" data="http://wet-boew.github.io/themes-dist/GCWeb/assets/wmms-blk.svg" aria-label="Symbol of the Government of Canada"></object>
+                        <object type="image/svg+xml" tabindex="-1" role="img" data="https://wet-boew.github.io/themes-dist/GCWeb/assets/wmms-blk.svg" aria-label="Symbol of the Government of Canada"></object>
                     </div>
                 </div>
             </div>
@@ -597,7 +597,7 @@
                 });
         }
     </script>
-    <script src="http://wet-boew.github.io/v4.0-ci/wet-boew/js/wet-boew.min.js"></script>
-    <script src="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
+    <script src="https://wet-boew.github.io/v4.0-ci/wet-boew/js/wet-boew.min.js"></script>
+    <script src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
 </body>
 </html>

--- a/packages/ramp-core/src/content/samples/index-fgp-fr.tpl
+++ b/packages/ramp-core/src/content/samples/index-fgp-fr.tpl
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <title>FGP Viewer</title>
     <meta content="width=device-width,initial-scale=1" name="viewport">
-    <link href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/favicon.ico" rel="icon" type="image/x-icon">
-    <link rel="stylesheet" href="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css">
+    <link href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/favicon.ico" rel="icon" type="image/x-icon">
+    <link rel="stylesheet" href="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css">
 
     <script src="./plugins/backToCart/backToCart.js"></script>
 
@@ -372,7 +372,7 @@
             <div class="row">
                 <div class="brand col-xs-8 col-sm-9 col-md-6">
                     <a href="http://www.canada.ca/en/index.html">
-                        <object type="image/svg+xml" tabindex="-1" data="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/sig-blk-en.svg"></object><span class="wb-inv"> Government of Canada</span></a>
+                        <object type="image/svg+xml" tabindex="-1" data="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/assets/sig-blk-en.svg"></object><span class="wb-inv"> Government of Canada</span></a>
                 </div>
                 <section class="wb-mb-links col-xs-4 col-sm-3 visible-sm visible-xs" id="wb-glb-mn">
                     <h2>Search and menus</h2>
@@ -608,8 +608,8 @@
                 });
         }
     </script>
-    <script src="http://wet-boew.github.io/v4.0-ci/wet-boew/js/wet-boew.min.js"></script>
-    <script src="http://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
+    <script src="https://wet-boew.github.io/v4.0-ci/wet-boew/js/wet-boew.min.js"></script>
+    <script src="https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/js/theme.min.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Donethankses #4061

The map API `.center` now returns the center of the map, not the center of the extent after being modified to be orthoganal in lat/long projection. 
Also adds `https` to some WET script tags which hopefully will make the fgp demo page look less horrendous.


To test, go to the [Demo](https://fgpv-vpgf.github.io/fgpv-vpgf/goodcent/samples/index-fgp-en.html), zoom somewhere fun, open the console, and paste this line

```text
RV.getMap("fgpmap").centerAndZoom(RAMP.mapInstances[0].center.x, RAMP.mapInstances[0].center.y, 4326, RAMP.mapInstances[0].zoom);
```

The map extent should remain the same, not jump to an offset view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4062)
<!-- Reviewable:end -->
