### PR TITLE
Feature layer filter fix

### DIFF
--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -1153,6 +1153,11 @@
                         "$ref": "#/definitions/fieldMetadataEntry"
                     },
                     "description": "Specifies options for the fields of a layer."
+                },
+                "initialFilteredQuery": {
+                    "type": "string",
+                    "default": "",
+                    "description": "A where clause filter to be initially applied to the layer"
                 }
             },
             "required": ["id", "layerType", "url"],

--- a/packages/ramp-core/src/app/core/config.class.js
+++ b/packages/ramp-core/src/app/core/config.class.js
@@ -761,6 +761,7 @@ function ConfigObjectFactory(Geo, gapiService, common, events, $rootScope) {
             this._disabledControls = defaultedSource.disabledControls;
             this._userDisabledControls = defaultedSource.userDisabledControls;
 
+            this._initialFilteredQuery = defaultedSource.initialFilteredQuery;
             this._toggleSymbology = typeof source.toggleSymbology === 'boolean' ? source.toggleSymbology : true;
 
             this._details = source.details;


### PR DESCRIPTION
Donethankses #4066

Makes the config defaulter pass along the filter value so the layer can use it. Also added the property to the schema.

[Demo page](https://fgpv-vpgf.github.io/fgpv-vpgf/defexp/samples/index-fgp-en.html)

Then paste into console

```text
var map = RAMP.mapInstances[0];

var lconf = {
	"id": "funtimes",
	"layerType": "esriFeature",
	"state":{"visibility": true},
	"url": "https://maps-cartes.ec.gc.ca/arcgis/rest/services/EcoGeo/EcoGeo/MapServer/6",
	"initialFilteredQuery": "Year_='2009'"
}

map.layers.addLayer(lconf)
```

When the layer draws, there will be less points than usual.
As is tradition, it appears the original specs of this item are lost, but seems to me this filter only gets applied initially; any subsequent filter stuff erases it. So you can toggle visibility and get the full set of points to appears.
Also the grid does not seem to be respecting the filter. We could log this, but seeing as this option has been broken for years, I think this is more a "make it work in RAMP4" initiative.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4067)
<!-- Reviewable:end -->
