### PR TITLE
Fix whitespace breaking embedded images

### DIFF
--- a/packages/ramp-core/src/app/core/formatters.filter.js
+++ b/packages/ramp-core/src/app/core/formatters.filter.js
@@ -135,7 +135,7 @@ function picture() {
          */
         function process(item) {
             // check if it is a picture
-            const isPicture = /(.*?)\.(jpe?g|png|gif|bmp)$/.test(item);
+            const isPicture = /(.*?)\.(jpe?g|png|gif|bmp)$/.test(item.trim());
             return isPicture ? `<a class="rv-picture-lightbox" href="${item}"><img src="${item}"></img></a>` : item;
         }
     }


### PR DESCRIPTION
Trailing spaces in data was breaking embedding images in the details panel. Added a trim in the regex match in our `picture` filter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4068)
<!-- Reviewable:end -->
