### PR TITLE
Details links open in new tab

### DIFF
--- a/packages/ramp-core/src/app/core/formatters.filter.js
+++ b/packages/ramp-core/src/app/core/formatters.filter.js
@@ -49,6 +49,7 @@ function autolink() {
     const defaultOptions = {
         className: 'rv-linkified',
         ignoreTags: ['script'],
+        target: '_blank',
         validate: {
             url: (value) => /^https?:\/\//.test(value), // before converting to a link, ensure that the domain name begins with http:// or https://.
         },


### PR DESCRIPTION
Added `target: "_blank"` to the linkify default options

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4071)
<!-- Reviewable:end -->
