### PR TITLE
testing - another rcs recreation demo - NO PULLIN'

### DIFF
--- a/packages/ramp-core/features/epsg/epsg.feature.ts
+++ b/packages/ramp-core/features/epsg/epsg.feature.ts
@@ -22,7 +22,7 @@ export default {
         }
 
         return new Promise((resolve, reject) => {
-            $.get((location.protocol === 'https:' ? 'https:' : 'http:') + `//epsg.io/${matcher[1]}.proj4`)
+            $.get((location.protocol === 'https:' ? 'https:' : 'https:') + `//epsg.io/${matcher[1]}.proj4`)
                 .done(resolve)
                 .fail(reject);
         });

--- a/packages/ramp-core/src/app/core/config.service.js
+++ b/packages/ramp-core/src/app/core/config.service.js
@@ -138,6 +138,7 @@ function configService($q, $rootElement, $http, $translate, events, gapiService,
                 return this.config;
             }
 
+            /*
             if (typeof this.rcsEndpoint === 'undefined') {
                 throw new Error(
                     'RCS keys provided with no endpoint. Set on HTML element through rv-service-endpoint property'
@@ -145,6 +146,7 @@ function configService($q, $rootElement, $http, $translate, events, gapiService,
             }
 
             const endpoint = this.rcsEndpoint.endsWith('/') ? this.rcsEndpoint : this.rcsEndpoint + '/';
+*/
             const results = {};
             let rcsLang = this.language.split('-')[0];
 
@@ -155,9 +157,41 @@ function configService($q, $rootElement, $http, $translate, events, gapiService,
                 rcsLang = 'en';
             }
 
-            return $http.get(`${endpoint}v2/docs/${rcsLang}/${this._rcsKeys.join(',')}`).then(
-                (resp) => {
+            //             return $http.get(`${endpoint}v2/docs/${rcsLang}/${this._rcsKeys.join(',')}`).then(
+            //    (resp) => {
+
+            return new Promise((fakeResolve) => {
+                setTimeout(() => {
+                    // mimic RCS waiting for a return
+                    fakeResolve();
+                }, 500);
+            }).then(
+                () => {
                     const result = [];
+
+                    // pretend we got data back
+                    var resp = {
+                        data: [
+                            {
+                                layers: [
+                                    {
+                                        id: 'rcs.fake1.en',
+                                        url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/6',
+                                        layerType: 'esriFeature',
+                                    },
+                                ],
+                            },
+                            {
+                                layers: [
+                                    {
+                                        id: 'rcs.fake2.en',
+                                        url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/8',
+                                        layerType: 'esriFeature',
+                                    },
+                                ],
+                            },
+                        ],
+                    };
 
                     // there is an array of layer configs in resp.data.
                     // moosh them into one single layer array on the result

--- a/packages/ramp-core/src/content/samples/config.rcs.en-CA.json
+++ b/packages/ramp-core/src/content/samples/config.rcs.en-CA.json
@@ -21,6 +21,7 @@
     "version": "2.0",
     "language": "en",
     "services": {
+        "corsEverywhere": true,
         "proxyUrl": "https://maps.canada.ca/wmsproxy/ws/wmsproxy/executeFromProxy",
         "exportMapUrl": "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
         "export": {

--- a/packages/ramp-core/src/content/samples/features/epsg.js
+++ b/packages/ramp-core/src/content/samples/features/epsg.js
@@ -30,7 +30,7 @@ window.customEPSG = {
         }
 
         return new Promise(function (resolve, reject) {
-            $.get('http://epsg.io/' + matcher[1] + '.proj4')
+            $.get('https://epsg.io/' + matcher[1] + '.proj4')
                 .done(resolve)
                 .fail(reject);
         });

--- a/packages/ramp-core/src/content/samples/index-fgp-en.tpl
+++ b/packages/ramp-core/src/content/samples/index-fgp-en.tpl
@@ -544,6 +544,12 @@
         const baseUrl = window.location.href.split('?')[0] + '?keys={RV_LAYER_LIST}';
         RAMP.mapAdded.subscribe(function (mapi) {
             backToCart.setCatalogueUrl('fgpmap', baseUrl);
+
+            // listener to layers being added.
+            console.log('adding layer added listener now');
+            mapi.layers.layerAdded.subscribe(mylayer => {
+                console.log('Saw Layer Added', mylayer);
+            })
         })
 
         function queryStringToJSON(q) {
@@ -567,6 +573,13 @@
             // console.log(bookmark);
             RV.getMap('fgpmap').initialBookmark(bookmark);
         }
+
+        // RCS fake test
+        setTimeout(()=>{
+            console.log('requesting rcs');
+            RV.getMap('fgpmap').loadRcsLayers(['fake1', 'fake2']);
+        }, 1000);
+
         // Toggle language
         function toggleLanguage(){
             RV.getMap('fgpmap').getBookmark().then(function (bookmark) {


### PR DESCRIPTION
Mimics RCS layers being loaded via legacy API `loadRcsLayers()`, and shows the `layerAdded` observable is firing as expected.

[Demo Link](https://fgpv-vpgf.github.io/fgpv-vpgf/layerAddTest/samples/index-fgp-en.html). Console should show the two layers triggering the observable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4077)
<!-- Reviewable:end -->
