### PR TITLE
feat: add custom stopPropagation & preventDefault

### DIFF
--- a/packages/ramp-core/src/app/focus-manager.js
+++ b/packages/ramp-core/src/app/focus-manager.js
@@ -905,6 +905,9 @@ HTMLElement.prototype.focus = $.fn.focus = function () {
     }
 };
 
+jQuery.Event.prototype.originalStopImmediatePropagation = jQuery.Event.prototype.stopImmediatePropagation;
+jQuery.Event.prototype.originalStopPropagation = jQuery.Event.prototype.stopPropagation;
+jQuery.Event.prototype.originalPreventDefault = jQuery.Event.prototype.preventDefault;
 // these event functions are disabled for events stemming from within a viewer. Angular material was, for
 // example, preventing mouse clicks from bubbling for mouse clicks on menu items. In general we want to always
 // see events then decide if they require action


### PR DESCRIPTION
Adds a way to bypass the focus manager when attempting to call `stopPropagation`  and `preventDefault` on events originating from inside the map. Since this is adding more options to an event nothing should be breaking.

This PR is for E2Reg where ramp is placed inside a form and hitting the `Enter` key on active inputs submits the form/page. By calling `originalPreventDefault` and `originalStopPropagation` we can stop that event from moving past ramp. 