### PR TITLE
Fix fullscreen applying styles to all instance shells

### DIFF
--- a/packages/ramp-core/src/app/ui/common/full-screen.service.js
+++ b/packages/ramp-core/src/app/ui/common/full-screen.service.js
@@ -87,7 +87,7 @@ function fullScreenService($rootElement, configService, $interval, events, $time
     function _enterFullScreen() {
         lastKnownCenter = configService.getSync.map.instance.extent.getCenter();
         const body = angular.element('body');
-        const shellNode = angular.element('rv-shell');
+        const shellNode = $rootElement.find('rv-shell');
         body.attr('style', 'width: 100%; height: 100%');
         $rootElement.attr('style', `overflow: visible; z-index: ${FULL_SCREEN_Z_INDEX};`);
         $rootElement.addClass('rv-full-screen-element');
@@ -109,7 +109,7 @@ function fullScreenService($rootElement, configService, $interval, events, $time
     function _exitFullScreen() {
         lastKnownCenter = configService.getSync.map.instance.extent.getCenter();
         const body = angular.element('body');
-        const shellNode = angular.element('rv-shell');
+        const shellNode = $rootElement.find('rv-shell');
         body.attr('style', '');
         $rootElement.attr('style', '');
         shellNode.attr('style', '');


### PR DESCRIPTION
#4126 

We were applying fullscreen styles to all `rv-shell`s on the page, now it will only style the one under the specific instance getting fullscreened.

Checked in our `many` sample and in storylines and fullscreen seems to be working as intended everywhere now.

I would recommend using https://fgpv-vpgf.github.io/fgpv-vpgf/fullscreen-fix/samples/index-many.html to verify that fullscreen is working on different RAMP instances.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4127)
<!-- Reviewable:end -->
