### PR TITLE
fix(layer): storylines fix for filter query visibility

### DIFF
--- a/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
+++ b/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
@@ -166,12 +166,16 @@ function rvSymbologyStack($rootScope, $rootElement, $q, Geo, configService, anim
 
         // wire up a listener on the visibility change of the legend block
         if (self.block && self.block.visibilityChanged) {
-            // change all symbology stack to toggled/untoggled if top layer is visible/invisible
+            // change all symbology stack to toggled/untoggled (only if individual symbols can be toggled) if top layer is visible/invisible
             // TODO update this code when issue 3152 is implemented
             self.block.visibilityChanged.subscribe((val) => {
                 // make sure this doesn't fire if an individual symbology being toggled triggered visibilityChanged
                 // only toggle when toggling visibility on after all symbology have been turned off
-                if (!self.stackToggled) {
+                // first half of 'if' statement is included to ensure that individual symbols can be toggled
+                // if not, then we don't want to mess with the visibility of individual symbols, only the actual layer
+                // since individual symbols can not be toggled, we never run into the case where we need to 'revert' their visibility
+                // everything will happen by default when layer visibility is toggled
+                if (self.block.proxyWrapper.layerConfig.toggleSymbology && !self.stackToggled) {
                     const query = val ? '' : '1=2';
                     if (self.block.proxyWrapper.isActiveState) {
                         // layer is loaded, apply stuff now

--- a/packages/ramp-core/src/content/samples/config/config-sample-95.json
+++ b/packages/ramp-core/src/content/samples/config/config-sample-95.json
@@ -1,0 +1,821 @@
+{
+    "map": {
+        "initialBasemapId": "baseNrCan",
+        "components": {
+            "geoSearch": {
+                "enabled": true,
+                "showGraphic": true,
+                "showInfo": true
+            },
+            "mouseInfo": {
+                "enabled": true,
+                "spatialReference": {
+                    "wkid": 4326,
+                    "wkt": ""
+                }
+            },
+            "northArrow": {
+                "enabled": false
+            },
+            "basemap": {
+                "enabled": true
+            },
+            "overviewMap": {
+                "enabled": true,
+                "layerType": "imagery",
+                "expandFactor": 2,
+                "initiallyExpanded": true
+            },
+            "scaleBar": {
+                "enabled": true
+            }
+        },
+        "extentSets": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978",
+                "default": {
+                    "xmin": -1991097.88,
+                    "ymin": -140121.23,
+                    "xmax": -86094.07,
+                    "ymax": 1288631.62
+                },
+                "spatialReference": {
+                    "wkid": 3978
+                }
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857",
+                "default": {
+                    "xmax": -5007771.626060756,
+                    "xmin": -16632697.354854,
+                    "ymax": 10015875.184845109,
+                    "ymin": 5022907.964742964
+                },
+                "spatialReference": {
+                    "wkid": 102100,
+                    "latestWkid": 3857
+                }
+            }
+        ],
+        "lodSets": [
+            {
+                "id": "LOD_NRCAN_Lambert_3978",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 38364.660062653464,
+                        "scale": 145000000
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 22489.62831258996,
+                        "scale": 85000000
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 13229.193125052918,
+                        "scale": 50000000
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 7937.5158750317505,
+                        "scale": 30000000
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 4630.2175937685215,
+                        "scale": 17500000
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 2645.8386250105837,
+                        "scale": 10000000
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 1587.5031750063501,
+                        "scale": 6000000
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 926.0435187537042,
+                        "scale": 3500000
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 529.1677250021168,
+                        "scale": 2000000
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 317.50063500127004,
+                        "scale": 1200000
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 185.20870375074085,
+                        "scale": 700000
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 111.12522225044451,
+                        "scale": 420000
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 66.1459656252646,
+                        "scale": 250000
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 38.36466006265346,
+                        "scale": 145000
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 22.48962831258996,
+                        "scale": 85000
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 13.229193125052918,
+                        "scale": 50000
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 7.9375158750317505,
+                        "scale": 30000
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 4.6302175937685215,
+                        "scale": 17500
+                    }
+                ]
+            },
+            {
+                "id": "LOD_ESRI_World_AuxMerc_3857",
+                "lods": [
+                    {
+                        "level": 0,
+                        "resolution": 19567.87924099992,
+                        "scale": 73957190.948944
+                    },
+                    {
+                        "level": 1,
+                        "resolution": 9783.93962049996,
+                        "scale": 36978595.474472
+                    },
+                    {
+                        "level": 2,
+                        "resolution": 4891.96981024998,
+                        "scale": 18489297.737236
+                    },
+                    {
+                        "level": 3,
+                        "resolution": 2445.98490512499,
+                        "scale": 9244648.868618
+                    },
+                    {
+                        "level": 4,
+                        "resolution": 1222.992452562495,
+                        "scale": 4622324.434309
+                    },
+                    {
+                        "level": 5,
+                        "resolution": 611.4962262813797,
+                        "scale": 2311162.217155
+                    },
+                    {
+                        "level": 6,
+                        "resolution": 305.74811314055756,
+                        "scale": 1155581.108577
+                    },
+                    {
+                        "level": 7,
+                        "resolution": 152.87405657041106,
+                        "scale": 577790.554289
+                    },
+                    {
+                        "level": 8,
+                        "resolution": 76.43702828507324,
+                        "scale": 288895.277144
+                    },
+                    {
+                        "level": 9,
+                        "resolution": 38.21851414253662,
+                        "scale": 144447.638572
+                    },
+                    {
+                        "level": 10,
+                        "resolution": 19.10925707126831,
+                        "scale": 72223.819286
+                    },
+                    {
+                        "level": 11,
+                        "resolution": 9.554628535634155,
+                        "scale": 36111.909643
+                    },
+                    {
+                        "level": 12,
+                        "resolution": 4.77731426794937,
+                        "scale": 18055.954822
+                    },
+                    {
+                        "level": 13,
+                        "resolution": 2.388657133974685,
+                        "scale": 9027.977411
+                    },
+                    {
+                        "level": 14,
+                        "resolution": 1.1943285668550503,
+                        "scale": 4513.988705
+                    },
+                    {
+                        "level": 15,
+                        "resolution": 0.5971642835598172,
+                        "scale": 2256.994353
+                    },
+                    {
+                        "level": 16,
+                        "resolution": 0.29858214164761665,
+                        "scale": 1128.497176
+                    },
+                    {
+                        "level": 17,
+                        "resolution": 0.14929107082380833,
+                        "scale": 564.248588
+                    },
+                    {
+                        "level": 18,
+                        "resolution": 0.07464553541190416,
+                        "scale": 282.124294
+                    },
+                    {
+                        "level": 19,
+                        "resolution": 0.03732276770595208,
+                        "scale": 141.062147
+                    },
+                    {
+                        "level": 20,
+                        "resolution": 0.01866138385297604,
+                        "scale": 70.5310735
+                    }
+                ]
+            }
+        ],
+        "legend": {
+            "type": "structured",
+            "root": {
+                "name": "root",
+                "children": [
+                    {
+                        "symbologyExpanded": true,
+                        "layerId": "Priority species***13df5407"
+                    }
+                ]
+            }
+        },
+        "layers": [
+            {
+                "layerType": "esriFeature",
+                "toggleSymbology": false,
+                "refreshInterval": 0,
+                "expectedResponseTime": 4000,
+                "tolerance": 5,
+                "initialFilteredQuery": "CommName_E IN ('Greater Sage-grouse')",
+                "outfields": "CosewicID,SciName,CommName_E,Population_E,Subspecies_E,COSEWIC_Status,SARA_Status,RDoc_Name_E,SiteID,Range_Name_E,Range_Comment_E,ProvTerr_E,CommNamePop_E",
+                "controls": [
+                    "opacity",
+                    "visibility",
+                    "boundingBox",
+                    "query",
+                    "snapshot",
+                    "boundaryZoom",
+                    "refresh",
+                    "remove",
+                    "settings",
+                    "data",
+                    "styles"
+                ],
+                "disabledControls": [],
+                "enableStructuredDelete": false,
+                "state": {
+                    "opacity": 1,
+                    "visibility": true,
+                    "boundingBox": false,
+                    "query": true,
+                    "snapshot": false,
+                    "hovertips": true
+                },
+                "table": {
+                    "title": "",
+                    "maximize": false,
+                    "lazyFilter": false,
+                    "applyMap": false,
+                    "showFilter": true,
+                    "filterByExtent": false,
+                    "searchStrictMatch": false,
+                    "printEnabled": false,
+                    "columns": [
+                        {
+                            "data": "OBJECTID",
+                            "title": "OBJECTID",
+                            "visible": false,
+                            "searchable": true,
+                            "filter": {
+                                "type": "number"
+                            }
+                        },
+                        {
+                            "data": "CosewicID",
+                            "title": "COSEWIC ID",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "number"
+                            }
+                        },
+                        {
+                            "data": "SciName",
+                            "title": "Scientific Name",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "data": "CommName_E",
+                            "title": "Common Name",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "data": "Population_E",
+                            "title": "Population",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "data": "Subspecies_E",
+                            "title": "Subspecies",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "data": "COSEWIC_Status",
+                            "title": "COSEWIC Status",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "number"
+                            }
+                        },
+                        {
+                            "data": "SARA_Status",
+                            "title": "SARA Status",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "number"
+                            }
+                        },
+                        {
+                            "data": "RDoc_Name_E",
+                            "title": "Reference Docuemnt",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "data": "SiteID",
+                            "title": "Site ID",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "data": "Range_Name_E",
+                            "title": "Range Name",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "data": "Range_Comment_E",
+                            "title": "Range Comments",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "data": "ProvTerr_E",
+                            "title": "Province / Territory",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "string"
+                            }
+                        },
+                        {
+                            "data": "CommNamePop_E",
+                            "title": "Common Name and Population",
+                            "visible": true,
+                            "searchable": true,
+                            "filter": {
+                                "type": "string"
+                            }
+                        }
+                    ]
+                },
+                "url": "https://maps-cartes.ec.gc.ca/arcgis/rest/services/CWS_SCF/PrioritySpecies/MapServer/0",
+                "name": "Priority species",
+                "id": "Priority species***13df5407"
+            }
+        ],
+        "tileSchemas": [
+            {
+                "id": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978",
+                "name": "Lambert Maps",
+                "extentSetId": "EXT_NRCAN_Lambert_3978",
+                "lodSetId": "LOD_NRCAN_Lambert_3978",
+                "hasNorthPole": true
+            },
+            {
+                "id": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857",
+                "name": "Web Mercator Maps",
+                "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
+                "lodSetId": "LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "baseMaps": [
+            {
+                "id": "baseNrCan",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": "The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "The Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT",
+                        "layerType": "esriFeature",
+                        "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseSimple",
+                "name": "Canada Base Map - Simple",
+                "description": "Canada Base Map - Simple",
+                "altText": "Canada base map - Simple",
+                "layers": [
+                    {
+                        "id": "SMR",
+                        "layerType": "esriFeature",
+                        "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBME_CBCE_HS_RO_3978",
+                "name": "Canada Base Map - Elevation (CBME)",
+                "description": "The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.",
+                "altText": "Canada Base Map - Elevation (CBME)",
+                "layers": [
+                    {
+                        "id": "CBME_CBCE_HS_RO_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseCBMT_CBCT_GEOM_3978",
+                "name": "Canada Base Map - Transportation (CBMT)",
+                "description": " The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.",
+                "altText": "Canada Base Map - Transportation (CBMT)",
+                "layers": [
+                    {
+                        "id": "CBMT_CBCT_GEOM_3978",
+                        "layerType": "esriFeature",
+                        "url": "https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978"
+            },
+            {
+                "id": "baseEsriWorld",
+                "name": "World Imagery",
+                "description": "World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.",
+                "altText": "World Imagery",
+                "layers": [
+                    {
+                        "id": "World_Imagery",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriPhysical",
+                "name": "World Physical Map",
+                "description": "This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.",
+                "altText": "World Physical Map",
+                "layers": [
+                    {
+                        "id": "World_Physical_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriRelief",
+                "name": "World Shaded Relief",
+                "description": "This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.",
+                "altText": "World Shaded Relief",
+                "layers": [
+                    {
+                        "id": "World_Shaded_Relief",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriStreet",
+                "name": "World Street Map",
+                "description": "This worldwide street map presents highway-level data for the world.",
+                "altText": "ESWorld Street Map",
+                "layers": [
+                    {
+                        "id": "World_Street_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTerrain",
+                "name": "World Terrain Base",
+                "description": "This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.",
+                "altText": "World Terrain Base",
+                "layers": [
+                    {
+                        "id": "World_Terrain_Base",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            },
+            {
+                "id": "baseEsriTopo",
+                "name": "World Topographic Map",
+                "description": "This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.",
+                "altText": "World Topographic Map",
+                "layers": [
+                    {
+                        "id": "World_Topo_Map",
+                        "layerType": "esriFeature",
+                        "url": "https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer"
+                    }
+                ],
+                "tileSchemaId": "EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857"
+            }
+        ],
+        "legend_id": null
+    },
+    "ui": {
+        "title": "Interactive map",
+        "fullscreen": true,
+        "navBar": {
+            "zoom": "buttons",
+            "extra": ["fullscreen", "geoLocator", "home", "help"]
+        },
+        "appBar": {
+            "basemap": true,
+            "sideMenu": true,
+            "geoSearch": true,
+            "layers": true
+        },
+        "help": {
+            "folderName": "default"
+        },
+        "sideMenu": {
+            "items": [["fullscreen", "export", "touch", "help", "about"]],
+            "logo": false
+        },
+        "legend": {
+            "allowImport": false,
+            "isOpen": {
+                "large": false,
+                "medium": false,
+                "small": false
+            },
+            "reorderable": true
+        },
+        "theme": "default",
+        "logoUrl": "",
+        "failureFeedback": {
+            "failureMessage": "",
+            "failureImageUrl": ""
+        },
+        "restrictNavigation": false,
+        "tableIsOpen": {
+            "id": "",
+            "large": false,
+            "medium": false,
+            "small": false
+        }
+    },
+    "services": {
+        "proxyUrl": "https://maps.canada.ca/wmsproxy/ws/wmsproxy/executeFromProxy",
+        "exportMapUrl": "https://maps-cartes.ec.gc.ca/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+        "export": {
+            "title": {
+                "isSelected": true,
+                "isSelectable": true,
+                "value": ""
+            },
+            "map": {
+                "isSelected": true,
+                "isSelectable": true
+            },
+            "mapElements": {
+                "isSelected": true,
+                "isSelectable": true
+            },
+            "legend": {
+                "isSelected": true,
+                "isSelectable": true,
+                "showInfoSymbology": false,
+                "showControlledSymbology": false,
+                "columnWidth": 350
+            },
+            "footnote": {
+                "isSelected": true,
+                "isSelectable": true,
+                "value": ""
+            },
+            "timestamp": {
+                "isSelected": true,
+                "isSelectable": true
+            },
+            "timeout": 120000,
+            "cleanCanvas": false
+        },
+        "search": {
+            "settings": {
+                "categories": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "sortOrder": [
+                    "CITY",
+                    "HAM",
+                    "IR",
+                    "LTM",
+                    "MUN1",
+                    "MUN2",
+                    "PROV",
+                    "STM",
+                    "TERR",
+                    "TOWN",
+                    "UTM",
+                    "VILG",
+                    "UNP"
+                ],
+                "maxResults": 1000,
+                "officialOnly": true
+            },
+            "serviceUrls": {
+                "geoNames": "https://geogratis.gc.ca/services/geoname/en/geonames.json",
+                "geoLocation": "https://geogratis.gc.ca/services/geolocation/en/locate?q=",
+                "geoSuggest": "https://geogratis.gc.ca/services/geolocation/en/suggest?q=",
+                "provinces": "https://geogratis.gc.ca/services/geoname/en/codes/province.json",
+                "types": "https://geogratis.gc.ca/services/geoname/en/codes/concise.json"
+            }
+        },
+        "corsEverywhere": false,
+        "geometryUrl": "",
+        "googleAPIKey": "",
+        "esriLibUrl": ""
+    },
+    "version": "2.0",
+    "language": "en",
+    "plugins": {
+        "rangeSlider": {
+            "enable": false,
+            "open": true,
+            "autorun": false,
+            "loop": false,
+            "controls": ["lock", "delay"],
+            "params": {
+                "type": "number",
+                "rangeType": "dual",
+                "stepType": "dynamic",
+                "precision": "0",
+                "delay": "3000",
+                "range": {
+                    "min": 0,
+                    "max": 1
+                },
+                "limit": {
+                    "min": 0,
+                    "max": 1,
+                    "staticItems": []
+                },
+                "units": ""
+            }
+        },
+        "coordInfo": {
+            "enable": false
+        },
+        "areasOfInterest": {
+            "enable": false
+        },
+        "chart": {
+            "enable": false,
+            "type": "pie",
+            "title": "",
+            "labelsPie": {
+                "type": "config",
+                "values": "",
+                "split": ";"
+            },
+            "options": {
+                "colors": "",
+                "cutOut": 0
+            },
+            "axis": {
+                "xAxis": {
+                    "title": "",
+                    "type": "config",
+                    "values": "",
+                    "split": ";"
+                },
+                "yAxis": {
+                    "title": "",
+                    "type": "config",
+                    "values": "",
+                    "split": ";"
+                }
+            }
+        },
+        "swiper": {
+            "enable": false,
+            "type": "vertical",
+            "keyboardOffset": 10
+        },
+        "draw": {
+            "enable": false,
+            "open": true,
+            "tools": ["picker", "point", "polyline", "polygon", "edit", "measure", "extent", "write", "read"]
+        },
+        "thematicSlider": {
+            "enable": false,
+            "open": true,
+            "autorun": false,
+            "loop": false,
+            "slider": true,
+            "stack": false,
+            "legendStack": true
+        }
+    }
+}

--- a/packages/ramp-core/src/content/samples/index-samples.tpl
+++ b/packages/ramp-core/src/content/samples/index-samples.tpl
@@ -192,6 +192,7 @@
                 <option value="config/config-sample-92.json">92. Third Basemap Schema using WKT</option>
                 <option value="config/config-sample-93.json">93. Dynamic Layer with 'stateOnly' set to true</option>
                 <option value="config/config-sample-94.json">94. Dynamic Layer with reordered indexes</option>
+                <option value="config/config-sample-95.json">95. Feature Layer Initial Filter</option>
             </select>
         </div>
 


### PR DESCRIPTION
fix for storylines issue where initial filter query was not being respected on visibility change

problem was in the code we have `change all symbology stack to toggled/untoggled if top layer is visible/invisible`, and technically if we disable individual toggling of symbology (which is a config option i set to false in sample 95), then it shouldn't be messing with the individual symbology visibilities at all.

now, since that portion is irrelevant in this case, we want to disable that block of code from executing. 

i also modified some of the table stuff to show only the relevant entries (especially on visibility change if table remains open), but that part is a bit confusing and im not sure if im breaking other edge cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4128)
<!-- Reviewable:end -->
