### PR TITLE
Add tooltips for symbology stack and fix details formatting

### DIFF
--- a/packages/ramp-core/src/app/core/formatters.filter.js
+++ b/packages/ramp-core/src/app/core/formatters.filter.js
@@ -106,6 +106,11 @@ function picture() {
             items = items.map(stringify);
         } else {
             items = stringify(items);
+
+            // for a single item, if it is not a representation of an image file return
+            if (typeof items === 'string' && !isPicture(items)) {
+                return items;
+            }
         }
 
         items = items.toString().split(';');
@@ -135,9 +140,16 @@ function picture() {
          * @return {String} picture element
          */
         function process(item) {
-            // check if it is a picture
-            const isPicture = /(.*?)\.(jpe?g|png|gif|bmp)$/.test(item.trim());
-            return isPicture ? `<a class="rv-picture-lightbox" href="${item}"><img src="${item}"></img></a>` : item;
+            return isPicture(item) ? `<a class="rv-picture-lightbox" href="${item}"><img src="${item}"></img></a>` : item;
+        }
+
+        /**
+         * Checks if item is a picture
+         * @param {String} item string
+         * @return {Boolean} returns whether item is an image file that should be converted into an <img> element.
+         */
+        function isPicture(item) {
+            return typeof item !== 'string' || /(.*?)\.(jpe?g|png|gif|bmp)$/.test(item.trim());
         }
     }
 }

--- a/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
+++ b/packages/ramp-core/src/app/ui/toc/symbology-stack.directive.js
@@ -16,6 +16,7 @@ class ToggleSymbol {
     constructor(symbol) {
         this.isSelected = true;
         this.symbol = symbol;
+        this.isNameTruncated = false;
     }
 
     click() {
@@ -67,7 +68,7 @@ function rvSymbologyStack($rootScope, $rootElement, $q, Geo, configService, anim
             container: '=?',
         },
         link: link,
-        controller: () => {},
+        controller: Controller,
         controllerAs: 'self',
         bindToController: true,
     };
@@ -1057,4 +1058,24 @@ function symbologyStack($q, $rootScope, ConfigObject, gapiService) {
     }
 
     return SymbologyStack;
+}
+
+function Controller() {
+    const self = this;
+
+    self.setTruncated = setTruncated;
+
+    /**
+     * Set the symbol.isNameTruncated to True if name is truncated
+     *
+     * @function setTruncated
+     * @private
+     * @param{event} evt event when being hovered
+     * @param{ToggleSymbol} symbol being hovered
+     */
+    function setTruncated(evt, symbol) {
+        const target = evt.currentTarget.children[0];
+
+        symbol.isNameTruncated = target.scrollWidth > target.clientWidth;
+    }
 }

--- a/packages/ramp-core/src/app/ui/toc/templates/symbology-stack.html
+++ b/packages/ramp-core/src/app/ui/toc/templates/symbology-stack.html
@@ -53,8 +53,9 @@
         ></rv-svg>
         <rv-svg ng-if="!symbol.image" class="rv-symbol-graphic" src="symbol.svgcode"></rv-svg>
 
-        <div class="rv-symbol-label-container">
+        <div class="rv-symbol-label-container" ng-mouseenter="self.setTruncated($event, symbol)">
             <span class="rv-symbol-label">{{ symbol.name }}</span>
+            <md-tooltip ng-show="symbol.isNameTruncated">{{ symbol.name }}</md-tooltip>
         </div>
 
         <md-button


### PR DESCRIPTION
Fixes multiple issues from Storylines testing party last week: 

*Issue*: **Hovering doesn't work**

1. On a map open the Layers menu
2. Hover over a layer text

*Expected behaviour*: Because the layer names are long, I expect to hover over layer text and see full layer name

*Changes*: Added tooltips to truncated names in symbology items, one concern is that we can't trigger these tooltips via keyboard. Could turn the parent div container into a `<md-button role="presentation">` if that is more appealing, but there is nothing clickable. 

*Issue*: **If data in cell of data table is larger than column width, user cannot hover to see all text**

1. Open any map, then the web table
2. Scroll to 'REFERENCE DOCUMENT' column
3. Try and hover text

*Expected behaviour*: I expect when I try to hover the cell, I can read full reference document

This was already built into the grid, but instead of hovering to see truncated cell data you have to click the cell. Seems to be working fine. 

*Issue*: **When multiple Province/Territories in the data table, the details doesn't have separator**

1. Open layers of any map
2. Open datatable
3. Click details icon of any record with multiple Provinces/Territories

*Expected behaviour*: Because the data table view has a semi-colon separator between different Provinces/Territories, I expect the same in the Details tab

*Changes*: Modified the picture formatter injected in Angular that was causing the removal of semicolons. 


**Testing**: Use [sample 95](https://fgpv-vpgf.github.io/fgpv-vpgf/symbol-table-hovertips/samples/index-samples.html?sample=95) which demos the Storylines product from last week. Will remove when ready to merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4129)
<!-- Reviewable:end -->
