### PR TITLE
Fix offscreen check targeting wrong shell for multi RAMP instances

### DIFF
--- a/packages/ramp-core/src/app/api-loader.ts
+++ b/packages/ramp-core/src/app/api-loader.ts
@@ -67,7 +67,7 @@ RAMPInstance.mapAdded.subscribe((mapInstance) => {
 (<any>jQuery).expr.filters.offscreen = function (el: any) {
     const elem = <any>jQuery(el);
     const position = elem.position();
-    const rvShell = <any>jQuery('rv-shell').first();
+    const rvShell = elem.closest('rv-shell');
 
     return (
         position.left + <any>elem.width() > rvShell.width() ||


### PR DESCRIPTION
*Issue*: Maps: cannot open Layers panel in full-screen mode

1. Open Boreal Caribou chapter
2. Maximize the map
3. Try and click 'Layers' icon

*Expected behaviour*: I expect Layers to show and I should be able to open the data table

*Changes*: JQuery was targeting `rv-shell` for first map on the page, changed to closest.

[Demo](https://fgpv-vpgf.github.io/fgpv-vpgf/multi-RAMP-offscreen/samples/index-many.html)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgpv-vpgf/fgpv-vpgf/4130)
<!-- Reviewable:end -->
